### PR TITLE
Fix NLU Settings and Wp-CLI 

### DIFF
--- a/classifai.php
+++ b/classifai.php
@@ -140,7 +140,8 @@ if ( class_exists( 'Puc_v4_Factory' ) ) {
 	/*
 	 * Enable updates if we have a valid license
 	 */
-	$settings = \Classifai\get_plugin_settings();
+	$service_manager = new \Classifai\Services\ServicesManager();
+	$settings        = $service_manager->get_settings();
 
 	if ( isset( $settings['valid_license'] ) && $settings['valid_license'] ) {
 		// @codingStandardsIgnoreStart

--- a/classifai.php
+++ b/classifai.php
@@ -142,7 +142,7 @@ function classifai_autorun() {
  * Generate a notice if autoload fails.
  */
 function classifai_autoload_notice() {
-	printf( '<div class="%1$s"><p>%2$s</p></div>', 'notice notice-error', get_error_install_message() );
+	printf( '<div class="%1$s"><p>%2$s</p></div>', 'notice notice-error', get_error_install_message() ); // @codingStandardsIgnoreLine Text is escaped in calling function already.
 	error_log( get_error_install_message() );
 }
 

--- a/classifai.php
+++ b/classifai.php
@@ -98,6 +98,18 @@ function classifai_autoloader() {
 }
 
 /**
+ * Gets the installation message error.
+ *
+ * This was put in a function specifically because it's used both in WP-CLI and within an admin notice if not using
+ * WP-CLI.
+ *
+ * @return string
+ */
+function get_error_install_message() {
+	return esc_html__( 'Error: Please run $ composer install in the classifai plugin directory.', 'classifai' );
+}
+
+/**
  * Plugin code entry point. Singleton instance is used to maintain a common single
  * instance of the plugin throughout the current request's lifecycle.
  *
@@ -108,7 +120,19 @@ function classifai_autorun() {
 	if ( classifai_autoload() ) {
 		$plugin = \Classifai\Plugin::get_instance();
 		$plugin->enable();
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			require_once CLASSIFAI_PLUGIN_DIR . '/includes/Classifai/Command/ClassifaiCommand.php';
+		}
 	} else {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			try {
+				\WP_CLI::error( get_error_install_message() );
+			} catch ( \WP_CLI\ExitException $e ) {
+				error_log( $e->getMessage() );
+			}
+		}
+
 		add_action( 'admin_notices', 'classifai_autoload_notice' );
 	}
 }
@@ -118,8 +142,8 @@ function classifai_autorun() {
  * Generate a notice if autoload fails.
  */
 function classifai_autoload_notice() {
-	printf( '<div class="%1$s"><p>%2$s</p></div>', 'notice notice-error', esc_html__( 'Error: Please run $ composer install in the classifai plugin directory.', 'classifai' ) );
-	error_log( esc_html__( 'Error: Please run $ composer install in the classifai plugin directory.', 'classifai' ) );
+	printf( '<div class="%1$s"><p>%2$s</p></div>', 'notice notice-error', get_error_install_message() );
+	error_log( get_error_install_message() );
 }
 
 

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -234,8 +234,8 @@ class ClassifaiCommand extends \WP_CLI_Command {
 	}
 
 	/**
-	 * Restores the plugin configuration to factory defaults. IBM Watson
-	 * credentials must be reentered after this command.
+	 * Restores the plugin configuration to factory defaults. Any API credentials will
+	 * need to be re-entered after this is ran.
 	 *
 	 * @param array $args Arguments.
 	 * @param array $opts Options.

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -234,8 +234,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 	}
 
 	/**
-	 * Restores the plugin configuration to factory defaults. Any API credentials will
-	 * need to be re-entered after this is ran.
+	 * Restores the plugin configuration to factory defaults. Any API credentials will need to be re-entered after this is ran.
 	 *
 	 * @param array $args Arguments.
 	 * @param array $opts Options.

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -249,7 +249,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 		\Classifai\reset_plugin_settings();
 
 		\WP_CLI::success(
-			'Defaults restored successfully. Please update the IBM Watson credentials.'
+			'Defaults restored successfully. Please update all your API credentials.'
 		);
 	}
 

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -309,3 +309,9 @@ class ClassifaiCommand extends \WP_CLI_Command {
 	}
 
 }
+
+try {
+	\WP_CLI::add_command( 'classifai', __NAMESPACE__ . '\\ClassifaiCommand' );
+} catch ( \Exception $e ) {
+	error_log( $e->getMessage() );
+}

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -29,7 +29,7 @@ function get_plugin() {
  */
 function get_plugin_settings( $service = '' ) {
 	$services = Plugin::$instance->services;
-	if ( empty( $services ) ||  empty( $services['service_manager'] ) || ! $services['service_manager'] instanceof ServicesManager ) {
+	if ( empty( $services ) || empty( $services['service_manager'] ) || ! $services['service_manager'] instanceof ServicesManager ) {
 		return [];
 	}
 
@@ -77,11 +77,12 @@ function reset_plugin_settings() {
 	$options = get_option( 'classifai_settings' );
 	if ( $options && isset( $options['registration'] ) ) {
 		// This is a legacy option set, so let's update it to the new format.
-		update_option( 'classifai_settings', [
+		$new_settings = [
 			'valid_license' => $options['valid_license'],
 			'email'         => isset( $options['registration']['email'] ) ? $options['registration']['email'] : '',
 			'license_key'   => isset( $options['registration']['license_key'] ) ? $options['registration']['license_key'] : '',
-		] );
+		];
+		update_option( 'classifai_settings', $new_settings );
 	}
 
 	$services = get_plugin()->services;

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -2,6 +2,7 @@
 
 namespace Classifai;
 
+use Classifai\Providers\Provider;
 use Classifai\Services\ServicesManager;
 
 /**
@@ -21,15 +22,28 @@ function get_plugin() {
 /**
  * Returns the ClassifAI plugin's stored settings in the WP options.
  *
+ * @param string $service The service to get settings from.
+ *
  * @return array The array of ClassifAI settings.
  */
-function get_plugin_settings() {
+function get_plugin_settings( $service = '' ) {
 	$service_manager = Plugin::$instance->services[ 'service_manager' ];
-	if ( $service_manager instanceof ServicesManager ) {
+	if ( ! $service_manager instanceof ServicesManager ) {
+		return [];
+	}
+
+	if ( empty( $service ) ) {
 		return $service_manager->get_settings();
 	}
 
-	return [];
+	if ( ! isset( $service_manager->services[ $service ] ) || ! $service_manager->services[ $service ] instanceof Provider ) {
+		return [];
+	}
+
+	/** @var Provider $provider An instance or extension of the provider abstract class. */
+	$provider = $service_manager->services[ $service ];
+	return $provider->get_settings();
+
 }
 
 /**

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -109,7 +109,7 @@ function reset_plugin_settings() {
 		}
 
 		foreach ( $service_class->provider_classes as $provider_class ) {
-			if ( ! $provider_class instanceof Provider || method_exists( $provider_class, 'reset_settings' ) ) {
+			if ( ! $provider_class instanceof Provider || ! method_exists( $provider_class, 'reset_settings' ) ) {
 				continue;
 			}
 

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -2,6 +2,8 @@
 
 namespace Classifai;
 
+use Classifai\Services\ServicesManager;
+
 /**
  * Miscellaneous Helper functions to access different parts of the
  * ClassifAI plugin.
@@ -17,10 +19,17 @@ function get_plugin() {
 }
 
 /**
- * Returns the ClassifAI plugin's stored settings in the WP options
+ * Returns the ClassifAI plugin's stored settings in the WP options.
+ *
+ * @return array The array of ClassifAI settings.
  */
 function get_plugin_settings() {
-	return get_option( 'classifai_watson_nlu' );
+	$service_manager = Plugin::$instance->services[ 'service_manager' ];
+	if ( $service_manager instanceof ServicesManager ) {
+		return $service_manager->get_settings();
+	}
+
+	return [];
 }
 
 /**

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -112,6 +112,8 @@ function reset_plugin_settings() {
 			if ( ! $provider_class instanceof Provider || method_exists( $provider_class, 'reset_settings' ) ) {
 				continue;
 			}
+
+			$provider_class->register_settings();
 		}
 	}
 }

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -113,7 +113,7 @@ function reset_plugin_settings() {
 				continue;
 			}
 
-			$provider_class->register_settings();
+			$provider_class->reset_settings();
 		}
 	}
 }

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -97,7 +97,23 @@ function reset_plugin_settings() {
 		],
 	];
 
-	update_option( 'classifai_settings', $settings );
+	$services = get_plugin()->services;
+	if ( ! isset( $services['service_manager'] ) || ! $services['service_manager']->service_classes ) {
+		return;
+	}
+
+	$service_classes = $services['service_manager']->service_classes;
+	foreach ( $service_classes as $service_class ) {
+		if ( ! $service_class instanceof Service || empty( $service_class->provider_classes ) ) {
+			continue;
+		}
+
+		foreach ( $service_class->provider_classes as $provider_class ) {
+			if ( ! $provider_class instanceof Provider || method_exists( $provider_class, 'reset_settings' ) ) {
+				continue;
+			}
+		}
+	}
 }
 
 

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -70,32 +70,19 @@ function set_plugin_settings( $settings ) {
 }
 
 /**
- * Resets the plugin to factory defaults.
+ * Resets the plugin to factory defaults, keeping licensing information only.
  */
 function reset_plugin_settings() {
-	$settings = [
-		'post_types' => [
-			'post',
-			'page',
-		],
-		'features'   => [
-			'category'           => true,
-			'category_threshold' => WATSON_CATEGORY_THRESHOLD,
-			'category_taxonomy'  => WATSON_CATEGORY_TAXONOMY,
 
-			'keyword'            => true,
-			'keyword_threshold'  => WATSON_KEYWORD_THRESHOLD,
-			'keyword_taxonomy'   => WATSON_KEYWORD_TAXONOMY,
-
-			'concept'            => false,
-			'concept_threshold'  => WATSON_CONCEPT_THRESHOLD,
-			'concept_taxonomy'   => WATSON_CONCEPT_TAXONOMY,
-
-			'entity'             => false,
-			'entity_threshold'   => WATSON_ENTITY_THRESHOLD,
-			'entity_taxonomy'    => WATSON_ENTITY_TAXONOMY,
-		],
-	];
+	$options = get_option( 'classifai_settings' );
+	if ( $options && isset( $options['registration'] ) ) {
+		// This is a legacy option set, so let's update it to the new format.
+		update_option( 'classifai_settings', [
+			'valid_license' => $options['valid_license'],
+			'email'         => isset( $options['registration']['email'] ) ? $options['registration']['email'] : '',
+			'license_key'   => isset( $options['registration']['license_key'] ) ? $options['registration']['license_key'] : '',
+		] );
+	}
 
 	$services = get_plugin()->services;
 	if ( ! isset( $services['service_manager'] ) || ! $services['service_manager']->service_classes ) {

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -11,7 +11,7 @@ class Plugin {
 	/**
 	 * @var array $services The known list of services.
 	 */
-	protected $services = [];
+	public $services = [];
 
 	/**
 	 * Lazy initialize the plugin
@@ -66,14 +66,17 @@ class Plugin {
 	 * Initialize the Services.
 	 */
 	public function init_services() {
+		$classifai_services = apply_filters(
+			'classifai_services',
+			[
+				'language_processing' => 'Classifai\Services\LanguageProcessing',
+				'image_processing'    => 'Classifai\Services\ImageProcessing'
+			]
+		);
+
 		$this->services = [
-			new Services\ServicesManager(
-				apply_filters(
-					'classifai_services',
-					[ 'Classifai\Services\LanguageProcessing', 'Classifai\Services\ImageProcessing' ]
-				)
-			),
-			new Admin\Notifications(),
+			'service_manager'     => new Services\ServicesManager( $classifai_services ),
+			'admin_notifications' => new Admin\Notifications(),
 		];
 
 		foreach ( $this->services as $service ) {

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -70,7 +70,7 @@ class Plugin {
 			'classifai_services',
 			[
 				'language_processing' => 'Classifai\Services\LanguageProcessing',
-				'image_processing'    => 'Classifai\Services\ImageProcessing'
+				'image_processing'    => 'Classifai\Services\ImageProcessing',
 			]
 		);
 

--- a/includes/Classifai/Providers/AWS/Comprehend.php
+++ b/includes/Classifai/Providers/AWS/Comprehend.php
@@ -24,6 +24,13 @@ class Comprehend extends Provider {
 	}
 
 	/**
+	 * Resets the settings for the Comprehend provider.
+	 */
+	public function reset_settings() {
+		// TODO: Implement reset_settings() method.
+	}
+
+	/**
 	 * Can the functionality be initialized?
 	 *
 	 * @return bool

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -28,6 +28,13 @@ class ComputerVision extends Provider {
 	}
 
 	/**
+	 * Resets settings for the ComputerVision provider.
+	 */
+	public function reset_settings() {
+		// TODO: Implement reset_settings() method.
+	}
+
+	/**
 	 * Can the functionality be initialized?
 	 *
 	 * @return bool

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -97,7 +97,7 @@ abstract class Provider {
 	 *
 	 * @return array
 	 */
-	protected function get_settings( $index = false ) {
+	public function get_settings( $index = false ) {
 		$defaults = [];
 		$settings = get_option( $this->get_option_name(), [] );
 		$settings = wp_parse_args( $settings, $defaults );

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -74,6 +74,11 @@ abstract class Provider {
 	abstract public function register();
 
 	/**
+	 * Resets the settings for this provider.
+	 */
+	abstract public function reset_settings();
+
+	/**
 	 * Initialization routine
 	 */
 	public function register_admin() {

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -70,7 +70,31 @@ class NLU extends Provider {
 	 * Resets the settings for the NLU provider.
 	 */
 	public function reset_settings() {
-		// TODO: Implement reset_settings() method.
+		$settings = [
+			'post_types' => [
+				'post',
+				'page',
+			],
+			'features'   => [
+				'category'           => true,
+				'category_threshold' => WATSON_CATEGORY_THRESHOLD,
+				'category_taxonomy'  => WATSON_CATEGORY_TAXONOMY,
+
+				'keyword'            => true,
+				'keyword_threshold'  => WATSON_KEYWORD_THRESHOLD,
+				'keyword_taxonomy'   => WATSON_KEYWORD_TAXONOMY,
+
+				'concept'            => false,
+				'concept_threshold'  => WATSON_CONCEPT_THRESHOLD,
+				'concept_taxonomy'   => WATSON_CONCEPT_TAXONOMY,
+
+				'entity'             => false,
+				'entity_threshold'   => WATSON_ENTITY_THRESHOLD,
+				'entity_taxonomy'    => WATSON_ENTITY_TAXONOMY,
+			],
+		];
+
+		update_option( $this->get_option_name(), $settings );
 	}
 
 	/**

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -100,7 +100,7 @@ class NLU extends Provider {
 	 *
 	 * @return array
 	 */
-	protected function get_settings( $index = false ) {
+	public function get_settings( $index = false ) {
 		$defaults = [];
 		$settings = get_option( $this->get_option_name(), [] );
 

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -67,6 +67,13 @@ class NLU extends Provider {
 	}
 
 	/**
+	 * Resets the settings for the NLU provider.
+	 */
+	public function reset_settings() {
+		// TODO: Implement reset_settings() method.
+	}
+
+	/**
 	 * Can the functionality be initialized?
 	 *
 	 * @return bool

--- a/includes/Classifai/Services/Service.php
+++ b/includes/Classifai/Services/Service.php
@@ -25,7 +25,7 @@ abstract class Service {
 	/**
 	 * @var array Array of class instances.
 	 */
-	protected $provider_classes;
+	public $provider_classes;
 
 	/**
 	 * Service constructor.

--- a/includes/Classifai/Services/ServicesManager.php
+++ b/includes/Classifai/Services/ServicesManager.php
@@ -71,7 +71,7 @@ class ServicesManager {
 	 *
 	 * @param string $index Optional specific setting to be retrieved.
 	 */
-	protected function get_settings( $index = false ) {
+	public function get_settings( $index = false ) {
 		$settings = get_option( 'classifai_settings' );
 
 		// Special handling polyfill for pre-1.3 settings which were nested

--- a/includes/Classifai/Services/ServicesManager.php
+++ b/includes/Classifai/Services/ServicesManager.php
@@ -10,8 +10,7 @@ class ServicesManager {
 	/**
 	 * @var array List of registered services
 	 */
-	protected $services = [];
-
+	public $services = [];
 
 	/**
 	 * @var array List of class instances being managed.

--- a/includes/Classifai/Services/ServicesManager.php
+++ b/includes/Classifai/Services/ServicesManager.php
@@ -15,7 +15,7 @@ class ServicesManager {
 	/**
 	 * @var array List of class instances being managed.
 	 */
-	protected $service_classes;
+	public $service_classes;
 
 	/**
 	 * @var string Page title for the admin page
@@ -52,9 +52,9 @@ class ServicesManager {
 	 * Register the actions required for the settings page.
 	 */
 	public function register() {
-		foreach ( $this->services as $service ) {
+		foreach ( $this->services as $key => $service ) {
 			if ( class_exists( $service ) ) {
-				$this->service_classes[] = new $service();
+				$this->service_classes[ $key ] = new $service();
 			}
 		}
 


### PR DESCRIPTION
### Fixes NLU Settings backwards compatibility and WP-CLI command registration.

### Benefits
* Fixes #91 
* Fixes #76
* Relates to #86 

### Possible Drawbacks
New Provider classes will be required to implement the `reset_settings()` method.

### Verification Process
#### Settings
1. Installed 1.2.1 - via `git checkout 1.2.1`
1. Set up Watson settings
1. Checked out my branch `git checkout bug/nlu-credentials`
1. Traced settings with xDebug to ensure they're set still.

xDebug Screenshot of endpoint results: https://i.gyazo.com/d01608a12c69244cb655bfe67a361781.png

#### WP-CLI
1. Checked out my branch `git checkout bug/nlu-credentials`
1. Ran `wp classifai --help`
1. Verified commands existed
1. Ran `wp classifai reset`
1. Verified settings were reset, leaving licensing intact.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.


