### PR TITLE
Don't try to run Watson NLU when it's not fully configured

### DIFF
--- a/includes/Classifai/Admin/SavePostHandler.php
+++ b/includes/Classifai/Admin/SavePostHandler.php
@@ -24,7 +24,9 @@ class SavePostHandler {
 	 * Save Post handler only runs on admin or REST requests
 	 */
 	public function can_register() {
-		if ( is_admin() ) {
+		if ( empty( get_option( 'classifai_watson_nlu' )['credentials']['watson_url'] ) ) {
+			return false;
+		} elseif ( is_admin() ) {
 			return true;
 		} elseif ( $this->is_rest_route() ) {
 			return true;

--- a/includes/Classifai/Admin/SavePostHandler.php
+++ b/includes/Classifai/Admin/SavePostHandler.php
@@ -26,6 +26,8 @@ class SavePostHandler {
 	public function can_register() {
 		if ( ! get_option( 'classifai_configured', false ) ) {
 			return false;
+		} elseif ( empty( get_option( 'classifai_watson_nlu' ) ) ) {
+			return false;
 		} elseif ( empty( get_option( 'classifai_watson_nlu' )['credentials']['watson_url'] ) ) {
 			return false;
 		} elseif ( is_admin() ) {

--- a/includes/Classifai/Admin/SavePostHandler.php
+++ b/includes/Classifai/Admin/SavePostHandler.php
@@ -24,7 +24,9 @@ class SavePostHandler {
 	 * Save Post handler only runs on admin or REST requests
 	 */
 	public function can_register() {
-		if ( empty( get_option( 'classifai_watson_nlu' )['credentials']['watson_url'] ) ) {
+		if ( ! get_option( 'classifai_configured', false ) ) {
+			return false;
+		} elseif ( empty( get_option( 'classifai_watson_nlu' )['credentials']['watson_url'] ) ) {
 			return false;
 		} elseif ( is_admin() ) {
 			return true;
@@ -33,8 +35,6 @@ class SavePostHandler {
 		} elseif ( defined( 'PHPUNIT_RUNNER' ) && PHPUNIT_RUNNER ) {
 			return false;
 		} elseif ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return false;
-		} elseif ( ! get_option( 'classifai_configured', false ) ) {
 			return false;
 		} else {
 			return false;


### PR DESCRIPTION
### Description of the Change

Return `false` in more cases in `SavePostHandler::can_register()` - if  `watson_url` or the entire `classifai_watson_nlu` setting is empty.

### Alternate Designs

IMO `SavePostHandler` could benefit from a rethink, especially as we approach adding multiple providers for a given piece of functionality.

### Benefits

No more unnecessary requests resulting in confusing errors.

### Possible Drawbacks

n/a

### Verification Process

**Using classic editor*** Added and updated posts with Watson configured, half-configured, and unconfigured.

* I was unable to trigger any notices in Gutenberg, this needs further investigating and likely an issue.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes #102 
