### PR TITLE
Release version 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 ## [1.0.0] - 2018-07-24
 - Initial closed source release
 
-[Unreleased]: https://github.com/10up/classifai/compare/1.3.2...develop
+[Unreleased]: https://github.com/10up/classifai/compare/master...develop
 [1.3.2]: https://github.com/10up/classifai/compare/1.3.1...1.3.2
 [1.3.1]: https://github.com/10up/classifai/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/10up/classifai/compare/1.2.1...1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
+## [1.3.2] - 2019-07-24
+### Fixed
+- Only run Watson NLU when it's fully configured (props @helen, @eflorea via #103)
+- NLU Settings backwards compatibility and WP-CLI command registration (props @JayWood, @aaronjorbin via #96)
+
 ## [1.3.1] - 2019-06-13
 ### Fixed
 - Specify and handle minimum PHP version support (props @helen via #84)
@@ -43,10 +48,11 @@ All notable changes to this project will be documented in this file, per [the Ke
 - Taxonomy mapping support
 - Admin notice on API errors
 
-## [1.0.0]
+## [1.0.0] - 2018-07-24
 - Initial closed source release
 
-[Unreleased]: https://github.com/10up/classifai/compare/1.3.1...develop
+[Unreleased]: https://github.com/10up/classifai/compare/1.3.2...develop
+[1.3.2]: https://github.com/10up/classifai/compare/1.3.1...1.3.2
 [1.3.1]: https://github.com/10up/classifai/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/10up/classifai/compare/1.2.1...1.3.0
 [1.2.1]: https://github.com/10up/classifai/compare/1.2.0...1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file, per [the Ke
 ### Fixed
 - Only run Watson NLU when it's fully configured (props @helen, @eflorea via #103)
 - NLU Settings backwards compatibility and WP-CLI command registration (props @JayWood, @aaronjorbin via #96)
+- Avoid JS errors and inaccurate data representation of `_classifai_error` meta (props @johnwatkins0 via #106)
+- Resolve sudden Travis test failures (props @jeffpaul via #107)
+
+### Changed
+- Documentation updates (props @jeffpaul, @dustinrue via #89, #90, #94, and #97)
 
 ## [1.3.1] - 2019-06-13
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ The `develop` branch is the development branch which means it contains the next 
 ## Release instructions
 
 1. Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
-2. Version bump: Bump the version number in `classifai.php` if it does not already reflect the version being released.
+2. Version bump: Bump the version number in `classifai.php` and `config.php` if it does not already reflect the version being released.
 3. Changelog: Add/update the changelog in `CHANGELOG.md`
 4. Update the `.pot` file by running `npm run makepot`.
 5. Check to be sure any new files/paths that are unnecessary in the production version are included in `.github/action-release/rsync-filter.txt`.

--- a/classifai.php
+++ b/classifai.php
@@ -3,7 +3,7 @@
  * Plugin Name:     ClassifAI
  * Plugin URI:      https://github.com/10up/classifai
  * Description:     Enhance your WordPress content with Artificial Intelligence and Machine Learning services.
- * Version:         1.3.1
+ * Version:         1.3.2
  * Author:          10up
  * Author URI:      https://10up.com
  * License:         MIT

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
  * declared here instead of a Class.
  */
 
-$plugin_version = '1.2.0';
+$plugin_version = '1.3.2';
 
 if ( file_exists( __DIR__ . '/.commit' ) ) {
 	$plugin_version .= '-' . file_get_contents( __DIR__ . '/.commit' );

--- a/languages/classifai.pot
+++ b/languages/classifai.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: ClassifAI 1.3.1\n"
+"Project-Id-Version: ClassifAI 1.3.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/classifai\n"
-"POT-Creation-Date: 2019-06-13 22:54:58+00:00\n"
+"POT-Creation-Date: 2019-07-24 21:17:35+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"


### PR DESCRIPTION
PR for tracking changes for the 1.3.2 release. Target release date: **Wednesday, July 24th.**

### [Release steps](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md#release-instructions)

- [x] Starting from `develop`, cut a release branch named `release/1.3.2` for your changes.
- [x] Version bump: Bump the version number in `classifai.php` if it does not already reflect the version being released.
- [x] Changelog: Add/update the changelog in `CHANGELOG.md`
- [x] Update the `.pot` file by running `npm run makepot`.
- [x] Check to be sure any new files/paths that are unnecessary in the production version are included in `.github/action-release/rsync-filter.txt`.
- [x] Merge: Make a non-fast-forward merge from your release branch to `develop`, then do the same for `develop` into `master`. `master` contains the stable development version.
- [x] Push: Push your master branch to GitHub, e.g. `git push origin master`.
- [x] Wait for build: Head to the [Actions](https://github.com/10up/classifai/actions) tab in the repo and wait for it to finish if it hasn't already. If it doesn't succeed, figure out why and start over.
- [x] Check the build: Check out the `stable` branch and test for functionality locally.
- [x] Git tag: Create the release as `1.3.2` on the `stable` branch in GitHub. It should now appear under [releases](https://github.com/10up/classifai/releases) and in the WordPress admin as an update as well.
- [x] Update the [1.3.2 milestone](https://github.com/10up/classifai/milestone/8) with release date and link to GitHub release, then close 1.3.2 milestone
- [x] If any open PRs which were milestoned for 1.3.2 do not make it into the release, update their milestone.