### PR TITLE
Register _classifai_error meta as single

### DIFF
--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -48,6 +48,7 @@ class Plugin {
 				'_classifai_error',
 				[
 					'show_in_rest' => true,
+					'single'       => true,
 				]
 			);
 		}


### PR DESCRIPTION
### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

This is a one-line change intended to resolve #105. The description of the issue this addresses can be found there. Essentially, JS is expecting a WP meta value returned from the REST API to be a string that can be parsed as JSON, and the REST API is returning an array. To fix this, we update the configuration passed to the WP `register_meta` function to tell to tell WP to expect a single value rather than an array.

See: https://codex.wordpress.org/Function_Reference/register_meta

### Alternate Designs

If there is any likelihood multiple values of `_classifai_error` might be intentionally associated with a given post, then this fix might instead involve additional checks at the JS level to validate whether the error notice should display. Currently, however, `_classifai_error` is assumed to be a single value elsewhere in the plugin, including in `SavePostHandler.php` where the value is updated, retrieved, and deleted.

### Benefits

<!-- What benefits will be realized by the code change? -->

"Post updated" notices display as expected. Elimination of JS error reduces risk of other unknown side effects.


### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

With all features of the plugin correctly configured, edit a post with the JS console open. When saving the post, confirm the JS error screenshotted in #105 doesn't show, and that the relevant "Post updated" notice shows.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

The file I touched is not currently covered by tests (beyond testing the class works as a singleton) so I didn't add any tests, but I'd be happy to add an integration test confirming the meta value in REST responses if that would be considered beneficial.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#105
