### PR TITLE
Add image tags and alt text to search

### DIFF
--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -302,33 +302,3 @@ function get_feature_taxonomy( $feature ) {
 	 */
 	return apply_filters( 'classifai_taxonomy_for_feature', $taxonomy, $feature );
 }
-
-/**
- * Filter the SQL clauses of an attachment query to include tags and alt text.
- *
- * @param array $clauses An array including WHERE, GROUP BY, JOIN, ORDER BY,
- *                       DISTINCT, fields (SELECT), and LIMITS clauses.
- * @return array The modified clauses.
- */
-function filter_attachment_query_keywords( array $clauses ) {
-	global $wpdb;
-	remove_filter( 'posts_clauses', __FUNCTION__ );
-
-	if ( ! preg_match( "/\({$wpdb->posts}.post_content (NOT LIKE|LIKE) (\'[^']+\')\)/", $clauses['where'] ) ) {
-		return $clauses;
-	}
-
-	// Add a LEFT JOIN of the postmeta table so we don't trample existing JOINs.
-	$clauses['join'] .= " LEFT JOIN {$wpdb->postmeta} AS classifai_postmeta ON ( {$wpdb->posts}.ID = classifai_postmeta.post_id AND ( classifai_postmeta.meta_key = 'classifai_computer_vision_image_tags' OR classifai_postmeta.meta_key = '_wp_attachment_image_alt' ) )";
-
-	$clauses['groupby'] = "{$wpdb->posts}.ID";
-
-	$clauses['where'] = preg_replace(
-		"/\({$wpdb->posts}.post_content (NOT LIKE|LIKE) (\'[^']+\')\)/",
-		'$0 OR ( classifai_postmeta.meta_value $1 $2 )',
-		$clauses['where']
-	);
-
-	return $clauses;
-}
-\add_filter( 'posts_clauses', __NAMESPACE__ . '\\filter_attachment_query_keywords' );

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -56,6 +56,7 @@ class ComputerVision extends Provider {
 	 */
 	public function register() {
 		add_filter( 'wp_generate_attachment_metadata', [ $this, 'process_image' ], 10, 2 );
+		add_filter( 'posts_clauses', [ $this, 'filter_attachment_query_keywords' ], 10, 1 );
 	}
 
 
@@ -422,5 +423,34 @@ class ComputerVision extends Provider {
 		}
 
 		return $rtn;
+	}
+
+	/**
+	 * Filter the SQL clauses of an attachment query to include tags and alt text.
+	 *
+	 * @param array $clauses An array including WHERE, GROUP BY, JOIN, ORDER BY,
+	 *                       DISTINCT, fields (SELECT), and LIMITS clauses.
+	 * @return array The modified clauses.
+	 */
+	public function filter_attachment_query_keywords( $clauses ) {
+		global $wpdb;
+		remove_filter( 'posts_clauses', __FUNCTION__ );
+
+		if ( ! preg_match( "/\({$wpdb->posts}.post_content (NOT LIKE|LIKE) (\'[^']+\')\)/", $clauses['where'] ) ) {
+			return $clauses;
+		}
+
+		// Add a LEFT JOIN of the postmeta table so we don't trample existing JOINs.
+		$clauses['join'] .= " LEFT JOIN {$wpdb->postmeta} AS classifai_postmeta ON ( {$wpdb->posts}.ID = classifai_postmeta.post_id AND ( classifai_postmeta.meta_key = 'classifai_computer_vision_image_tags' OR classifai_postmeta.meta_key = '_wp_attachment_image_alt' ) )";
+
+		$clauses['groupby'] = "{$wpdb->posts}.ID";
+
+		$clauses['where'] = preg_replace(
+			"/\({$wpdb->posts}.post_content (NOT LIKE|LIKE) (\'[^']+\')\)/",
+			'$0 OR ( classifai_postmeta.meta_value $1 $2 )',
+			$clauses['where']
+		);
+
+		return $clauses;
 	}
 }


### PR DESCRIPTION
### Description of the Change

Allow image searches to search tags and alt text. This is modeled after the core function `_filter_query_attachment_filenames()`

### Alternate Designs

n/a

### Benefits

More intuitive finding of your media.

### Possible Drawbacks

Slow queries. It would be a good place to suggest usage of Elasticsearch/ElasticPress if you find that this is becoming slow.

### Verification Process

Tested searches for unique keywords in alt text and generated tag meta.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

See #75 
