### PR TITLE
Show admin menu notice (!) for lack of registration instead of specific service setup

### DIFF
--- a/includes/Classifai/Services/ServicesManager.php
+++ b/includes/Classifai/Services/ServicesManager.php
@@ -216,11 +216,11 @@ class ServicesManager {
 	 * Helper to return the $menu title
 	 */
 	protected function get_menu_title() {
-		$is_setup         = get_option( 'classifai_configured' );
-		$this->title      = esc_html__( 'ClassifAI', 'classifai' );
-		$this->menu_title = $this->title;
+		$registration_settings = get_option( 'classifai_settings' );
+		$this->title           = esc_html__( 'ClassifAI', 'classifai' );
+		$this->menu_title      = $this->title;
 
-		if ( ! $is_setup ) {
+		if ( ! isset( $registration_settings['valid_license'] ) || ! $registration_settings['valid_license'] ) {
 			/*
 			 * Translators: Main title.
 			 */

--- a/includes/Classifai/Services/ServicesManager.php
+++ b/includes/Classifai/Services/ServicesManager.php
@@ -126,22 +126,22 @@ class ServicesManager {
 	 */
 	public function sanitize_settings( $settings ) {
 		$new_settings = [];
-		if ( isset( $settings['email'] ) && isset( $settings['license_key'] ) ) {
-			if ( $this->check_license_key( $settings['email'], $settings['license_key'] ) ) {
-				$new_settings['valid_license'] = true;
-				$new_settings['email']         = sanitize_text_field( $settings['email'] );
-				$new_settings['license_key']   = sanitize_text_field( $settings['license_key'] );
-			} else {
-				$new_settings['valid_license'] = false;
-				$new_settings['email']         = '';
-				$new_settings['license_key']   = '';
-				add_settings_error(
-					'registration',
-					'classifai-registration',
-					esc_html__( 'Invalid ClassifAI registration info. Please check and try again.', 'classifai' ),
-					'error'
-				);
-			}
+		if ( isset( $settings['email'] )
+			&& isset( $settings['license_key'] )
+			&& $this->check_license_key( $settings['email'], $settings['license_key'] ) ) {
+			$new_settings['valid_license'] = true;
+			$new_settings['email']         = sanitize_text_field( $settings['email'] );
+			$new_settings['license_key']   = sanitize_text_field( $settings['license_key'] );
+		} else {
+			$new_settings['valid_license'] = false;
+			$new_settings['email']         = isset( $settings['email'] ) ? sanitize_text_field( $settings['email'] ) : '';
+			$new_settings['license_key']   = isset( $settings['license_key'] ) ? sanitize_text_field( $settings['license_key'] ) : '';
+			add_settings_error(
+				'registration',
+				'classifai-registration',
+				esc_html__( 'Invalid ClassifAI registration info. Please check and try again.', 'classifai' ),
+				'error'
+			);
 		}
 
 		return $new_settings;


### PR DESCRIPTION
### Description of the Change

Show admin menu notice (!) for lack of registration instead of specific service setup. 

### Alternate Designs

Removing the (!) entirely.

### Benefits

Will not show an error-ish state just because NLU is not configured (i.e. you may just want to set up image processing).

### Possible Drawbacks

None?

### Verification Process

Changing values in the UI. Noticed a bug in the reg key checker endpoint 😬

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Fixes #100 
