### PR TITLE
Add a dev version notice

### DIFF
--- a/.github/action-release/entrypoint.sh
+++ b/.github/action-release/entrypoint.sh
@@ -10,6 +10,11 @@ if [[ -z "$GITHUB_TOKEN" ]]; then
 	exit 1
 fi
 
+if [[ -z "$VERSION_FILE" ]]; then
+	echo "Set the VERSION_FILE env variable"
+	exit 1
+fi
+
 TMP="/github/tmp"
 mkdir $TMP
 
@@ -38,14 +43,15 @@ rsync -r "$GITHUB_WORKSPACE/" release/ --exclude-from=".github/action-release/rs
 # Put .git folder back
 cp -a "$TMP/.git" release/
 
-echo "ℹ︎ Committing files"
-# Commit everything
+echo "ℹ︎ Modifying version string"
 cd release
 
+# replace -dev' with ' in the specified file that contains the version number
+sed -i "s/-dev'/'/g" "$VERSION_FILE"
+
+echo "ℹ︎ Committing files"
 # Explicit add command because -a doesn't pick up new files
 git add .
-
-git status
 
 # Skipping pre-commit hook because it's not installed in stable
 git commit -m "Committing built version of $GITHUB_SHA" --no-verify

--- a/.github/action-release/entrypoint.sh
+++ b/.github/action-release/entrypoint.sh
@@ -38,6 +38,7 @@ rsync -r "$GITHUB_WORKSPACE/" release/ --exclude-from=".github/action-release/rs
 # Put .git folder back
 cp -a "$TMP/.git" release/
 
+echo "ℹ︎ Committing files"
 cd release
 
 # Explicit add command because -a doesn't pick up new files

--- a/.github/action-release/entrypoint.sh
+++ b/.github/action-release/entrypoint.sh
@@ -10,11 +10,6 @@ if [[ -z "$GITHUB_TOKEN" ]]; then
 	exit 1
 fi
 
-if [[ -z "$VERSION_FILE" ]]; then
-	echo "Set the VERSION_FILE env variable"
-	exit 1
-fi
-
 TMP="/github/tmp"
 mkdir $TMP
 
@@ -43,13 +38,8 @@ rsync -r "$GITHUB_WORKSPACE/" release/ --exclude-from=".github/action-release/rs
 # Put .git folder back
 cp -a "$TMP/.git" release/
 
-echo "ℹ︎ Modifying version string"
 cd release
 
-# replace -dev' with ' in the specified file that contains the version number
-sed -i "s/-dev'/'/g" "$VERSION_FILE"
-
-echo "ℹ︎ Committing files"
 # Explicit add command because -a doesn't pick up new files
 git add .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,4 @@ jobs:
       uses: ./.github/action-release/
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION_FILE: config.php

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,3 @@ jobs:
       uses: ./.github/action-release/
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        VERSION_FILE: config.php

--- a/classifai.php
+++ b/classifai.php
@@ -158,7 +158,12 @@ register_activation_hook( __FILE__, 'classifai_activation' );
 classifai_autorun();
 
 // Include in case we have composer issues.
-require_once __DIR__ . '/vendor/yahnis-elsts/plugin-update-checker/plugin-update-checker.php';
+if ( file_exists( __DIR__ . '/vendor/yahnis-elsts/plugin-update-checker/plugin-update-checker.php' ) ) {
+	require_once __DIR__ . '/vendor/yahnis-elsts/plugin-update-checker/plugin-update-checker.php';
+} else {
+	add_action( 'admin_notices', 'classifai_dev_notice' );
+	add_action( 'network_admin_notices', 'classifai_dev_notice' );
+}
 
 if ( class_exists( 'Puc_v4_Factory' ) ) {
 	/*
@@ -184,5 +189,19 @@ if ( class_exists( 'Puc_v4_Factory' ) ) {
 			}
 		);
 		// @codingStandardsIgnoreEnd
+	}
+}
+
+/**
+ * Show dev version notice on ClassifAI pages if necessary.
+ */
+function classifai_dev_notice() {
+	if ( 0 === strpos( get_current_screen()->parent_base, 'classifai' ) ) {
+		?>
+		<div class="notice notice-warning">
+		<?php /* translators: %1$s: CLI install commands, %2$s: classifai url */ ?>
+		<p><?php echo wp_kses_post( sprintf( __( 'You appear to be running a development version of ClassifAI. Certain features may not work correctly without regularly running %1$s. If you&rsquo;re not sure what this means, you may want to <a href="%2$s">download and install</a> the stable version of ClassifAI instead.', 'distributor' ), '<code>composer install && npm install && npm run build</code>', 'https://classifaiplugin.com/' ) ); ?></p>
+		</div>
+		<?php
 	}
 }

--- a/classifai.php
+++ b/classifai.php
@@ -200,7 +200,7 @@ function classifai_dev_notice() {
 		?>
 		<div class="notice notice-warning">
 		<?php /* translators: %1$s: CLI install commands, %2$s: classifai url */ ?>
-		<p><?php echo wp_kses_post( sprintf( __( 'You appear to be running a development version of ClassifAI. Certain features may not work correctly without running %1$s. If you&rsquo;re not sure what this means, you may want to <a href="%2$s">download and install</a> the stable version of ClassifAI instead.', 'distributor' ), '<code>composer install && npm install && npm run build</code>', 'https://classifaiplugin.com/' ) ); ?></p>
+		<p><?php echo wp_kses_post( sprintf( __( 'You appear to be running a development version of ClassifAI. Certain features may not work correctly without running %1$s. If you&rsquo;re not sure what this means, you may want to <a href="%2$s">download and install</a> the stable version of ClassifAI instead.', 'classifai' ), '<code>composer install && npm install && npm run build</code>', 'https://classifaiplugin.com/' ) ); ?></p>
 		</div>
 		<?php
 	}

--- a/classifai.php
+++ b/classifai.php
@@ -200,7 +200,7 @@ function classifai_dev_notice() {
 		?>
 		<div class="notice notice-warning">
 		<?php /* translators: %1$s: CLI install commands, %2$s: classifai url */ ?>
-		<p><?php echo wp_kses_post( sprintf( __( 'You appear to be running a development version of ClassifAI. Certain features may not work correctly without regularly running %1$s. If you&rsquo;re not sure what this means, you may want to <a href="%2$s">download and install</a> the stable version of ClassifAI instead.', 'distributor' ), '<code>composer install && npm install && npm run build</code>', 'https://classifaiplugin.com/' ) ); ?></p>
+		<p><?php echo wp_kses_post( sprintf( __( 'You appear to be running a development version of ClassifAI. Certain features may not work correctly without running %1$s. If you&rsquo;re not sure what this means, you may want to <a href="%2$s">download and install</a> the stable version of ClassifAI instead.', 'distributor' ), '<code>composer install && npm install && npm run build</code>', 'https://classifaiplugin.com/' ) ); ?></p>
 		</div>
 		<?php
 	}


### PR DESCRIPTION
### Description of the Change

Adds a dev version notice saying "You appear to be running a development version of ClassifAI. Certain features may not work correctly without regularly running `composer install && npm install && npm run build`. If you're not sure what this means, you may want to download and install the stable version of ClassifAI instead." This happens if the plugin update checker library is not present as expected in the vendor directory and only shows on ClassifAI pages (settings).

### Alternate Designs

Considered adding the `-dev` suffix to the version number and the whole nine yards with the build process like in Distributor but decided against it for 1.4. Let's do it for 1.5 though.

### Benefits

More immediate understanding of why the plugin might not be working the way you expect if you just clone from GitHub instead of downloading the built package as intended for end users.

### Possible Drawbacks

It will stop showing once you've run `composer install`, even though you are still on a dev version and need to be building with changes.

### Verification Process

Tested in the admin UI by renaming the `vendor` directory and navigating around.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes #66 