### PR TITLE
Tweaks for Image Processing settings copy

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -336,7 +336,7 @@ class ComputerVision extends Provider {
 				'label_for'     => 'enable_image_captions',
 				'input_type'    => 'checkbox',
 				'default_value' => true,
-				'description'   => __( 'Uploaded images will be auto-captioned', 'classifai' ),
+				'description'   => __( 'Images will be captioned with alt text upon upload', 'classifai' ),
 			]
 		);
 		add_settings_field(
@@ -362,7 +362,7 @@ class ComputerVision extends Provider {
 				'label_for'     => 'enable_image_tagging',
 				'input_type'    => 'checkbox',
 				'default_value' => true,
-				'description'   => __( 'Uploaded images will be auto-tagged', 'classifai' ),
+				'description'   => __( 'Images will be tagged upon upload', 'classifai' ),
 			]
 		);
 		add_settings_field(

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -394,7 +394,6 @@ class ComputerVision extends Provider {
 			[
 				'label_for'   => 'image_tag_taxonomy',
 				'options'     => $options,
-				'description' => __( 'Minimum confidence score for automatically applied image tags, numeric value from 0-100. Recommended to be set to at least 75.', 'classifai' ),
 			]
 		);
 	}

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -375,7 +375,7 @@ class ComputerVision extends Provider {
 				'label_for'     => 'tag_threshold',
 				'input_type'    => 'number',
 				'default_value' => 70,
-				'description'   => __( 'Minimum confidence score for automatically applied image tags, numeric value from 0-100. Recommended to be set to at least 75.', 'classifai' ),
+				'description'   => __( 'Minimum confidence score for automatically applied image tags, numeric value from 0-100. Recommended to be set to at least 70.', 'classifai' ),
 			]
 		);
 


### PR DESCRIPTION
### Description of the Change

Removes an extraneously copied field description and make sure that suggested threshold values match the actual default.

Also:

`Uploaded images will be auto-captioned` ➡️ `Images will be captioned with alt text upon upload`

`Uploaded images will be auto-tagged` ➡️ `Images will be tagged upon upload`

### Alternate Designs

n/a

### Benefits

Clarity and accuracy

### Possible Drawbacks

None

### Verification Process

Viewed in the WP admin

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes #145