### PR TITLE
Integration test - change image URL to post-5.3-generated size

### DIFF
--- a/tests/Classifai/Providers/Azure/ComputerVisionTest.php
+++ b/tests/Classifai/Providers/Azure/ComputerVisionTest.php
@@ -48,7 +48,7 @@ class ComputerVisionTest extends WP_UnitTestCase {
 			wp_get_attachment_url( $attachment, 'full' ),
 			wp_get_attachment_metadata( $attachment )['sizes']
 		);
-		$this->assertEquals( sprintf( 'http://example.org/wp-content/uploads/%s/%s/33772-1024x576.jpg', date( 'Y' ), date( 'm' ) ), $url );
+		$this->assertEquals( sprintf( 'http://example.org/wp-content/uploads/%s/%s/33772-1536x864.jpg', date( 'Y' ), date( 'm' ) ), $url );
 
 		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA .'/images/2004-07-22-DSC_0008.jpg' ); // ~109kb image.
 		$url = $this->computer_vision->get_largest_acceptable_image_url(


### PR DESCRIPTION
### Description of the Change

Before WP 5.3, one of the integration tests for the `get_largest_acceptable_image_url` method returned a `large`-size version of a test image. Since 5.3 introduced the new `1536x1536` size to core, the method now returns the image at that size. 

This one-line change simply updates the file name to make the test pass.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Benefits

<!-- What benefits will be realized by the code change? -->

Passing tests.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

If the Travis build passes, this update is successful.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

Is applicable to #157  but does not come close to resolving it.