### PR TITLE
remove double slashes in the script url

### DIFF
--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -168,7 +168,7 @@ class NLU extends Provider {
 	public function enqueue_editor_assets() {
 		wp_enqueue_script(
 			'classifai-editor', // Handle.
-			CLASSIFAI_PLUGIN_URL . '/dist/js/editor.min.js',
+			CLASSIFAI_PLUGIN_URL . 'dist/js/editor.min.js',
 			array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor', 'wp-edit-post' ),
 			CLASSIFAI_PLUGIN_VERSION,
 			true


### PR DESCRIPTION
### Description of the Change
Remove double slashes in the script URL.

### Verification Process
The script URL now is: `http://example.com/wp-content/plugins/classifai/dist/js/editor.min.js?ver=1.4.0`

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues
Closes #167