### PR TITLE
Fix: Wrong setting link in the notice after activation

### DIFF
--- a/includes/Classifai/Admin/Notifications.php
+++ b/includes/Classifai/Admin/Notifications.php
@@ -50,7 +50,7 @@ class Notifications {
 		if ( $needs_setup ) {
 			printf(
 				'<div class="notice notice-warning"><p><a href="%s">' . esc_html__( 'ClassifAI requires setup', 'classifai' ) . '</a></p></div>',
-				esc_url( admin_url( 'options-general.php?page=classifai_settings' ) )
+				esc_url( admin_url( 'admin.php?page=classifai_settings' ) )
 			);
 			delete_transient( 'classifai_activation_notice' );
 		}


### PR DESCRIPTION
### Description of the Change
Change setting link after activation to the correct one.

### Verification Process
The setting link after activation should be: `/wp-admin/admin.php?page=classifai_settings`

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues
Closes #166, closes #99