### PR TITLE
Fix: Saving protected meta in Gutenberg

### DIFF
--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -53,8 +53,9 @@ class Plugin {
 				$post_type,
 				'_classifai_error',
 				[
-					'show_in_rest' => true,
-					'single'       => true,
+					'show_in_rest'  => true,
+					'single'        => true,
+					'auth_callback' => '__return_true',
 				]
 			);
 		}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Add `auth_callback` to save our protected meta `_classifai_error` when using block editor/Gutenberg.
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
N/a
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits
Currently, if other plugin update post meta after updating post, the process will be failed because `_classifai_error` can't be updated. This PR fixes that and makes classifai works with other plugin.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
None
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. Install and configure ClassifAI.
2. Install and configure AMP.
3. Edit a post, toggle `Enable AMP
` to disable AMP for the post.
4. Click Update buttons.
5. See the page saved with error related to `_classifai_error`.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
Closes #171
<!-- Enter any applicable Issues here -->