### PR TITLE
Fix/hookdoc generation

### DIFF
--- a/.github/action-release/rsync-filter.txt
+++ b/.github/action-release/rsync-filter.txt
@@ -10,6 +10,7 @@
 - CODE_OF_CONDUCT.md
 - CONTRIBUTING.md
 - CREDITS.md
+- hookdoc-conf.json
 - /ISSUE_TEMPLATE/
 - LICENSE.md
 - PULL_REQUEST_TEMPLATE.md

--- a/.github/action-release/rsync-filter.txt
+++ b/.github/action-release/rsync-filter.txt
@@ -16,6 +16,7 @@
 - PULL_REQUEST_TEMPLATE.md
 - /bin/
 - composer.lock
+- /docs/
 - /node_modules/
 - package-lock.json
 - package.json

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,7 +3,7 @@ name: Build Hook Docs
 on:
  push:
    branches:
-    - master
+    - develop
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ release
 phpunit.xml
 /dist
 coverage
+/docs
 
 debug.log
 

--- a/includes/Classifai/Admin/DebugInfo.php
+++ b/includes/Classifai/Admin/DebugInfo.php
@@ -51,9 +51,14 @@ class DebugInfo {
 		/**
 		 * Filters debug information displayed on the Site Health screen for the ClassifAI plugin.
 		 *
-		 * @param array Array of associative arrays corresponding to lines shown on the Site Health screen. Each array
-		 *              requires a `label` and a `value` field. Other accepted fields are `debug` and `private`.
 		 * @since 1.4.0
+		 * @hook classifai_debug_information
+		 * @see {@link https://developer.wordpress.org/reference/hooks/debug_information/|debug_information}
+		 *
+		 * @param {array} 'debug_info' Array of associative arrays corresponding to lines shown on the Site Health screen. Each array
+		 *              requires a `label` and a `value` field. Other accepted fields are `debug` and `private`.
+		 *
+		 * @return {array} Filtered array of debug information.
 		 */
 		$fields = apply_filters(
 			'classifai_debug_information',

--- a/includes/Classifai/Admin/SavePostHandler.php
+++ b/includes/Classifai/Admin/SavePostHandler.php
@@ -81,11 +81,14 @@ class SavePostHandler {
 		 *
 		 * Default is true, return false to skip classifying a post.
 		 *
-		 * @param bool $should_classify Whether the post should be classified. Default true, return false to skip
-		 *                              classification for this post.
-		 * @param int  $post_id         The id of the post to be considered for classification.
+		 * @since 1.2.0
+		 * @hook classifai_should_classify_post
 		 *
-		 * @return bool $should_classify Whether the post should be classified.
+		 * @param {bool} $should_classify Whether the post should be classified. Default `true`, return `false` to skip
+		 *                              classification for this post.
+		 * @param {int}  $post_id         The ID of the post to be considered for classification.
+		 *
+		 * @return {bool} Whether the post should be classified.
 		 */
 		$classifai_should_classify_post = apply_filters( 'classifai_should_classify_post', true, $post_id );
 		if ( ! $classifai_should_classify_post ) {
@@ -193,7 +196,16 @@ class SavePostHandler {
 			return false;
 		}
 
-		// Support custom post types with custom rest base.
+		/**
+		 * Filter the REST bases. Supports custom post types with a custom REST base.
+		 *
+		 * @since 1.5.0
+		 * @hook classifai_rest_bases
+		 *
+		 * @param {array} rest_bases Array of REST bases.
+		 *
+		 * @return {array} The filtered array of REST bases.
+		 */
 		$rest_bases = apply_filters( 'classifai_rest_bases', array( 'posts', 'pages' ) );
 
 		foreach ( $rest_bases as $rest_base ) {

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -195,6 +195,16 @@ function get_supported_post_types() {
 		$post_types = [ 'post' ];
 	}
 
+	/**
+	 * Filter post types supported for language processing.
+	 *
+	 * @since 1.0.0
+	 * @hook classifai_post_types
+	 *
+	 * @param {array} $post_types Array of post types to be classified with language processing.
+	 *
+	 * @return {array} Array of post types.
+	 */
 	$post_types = apply_filters( 'classifai_post_types', $post_types );
 
 	return $post_types;
@@ -259,10 +269,13 @@ function get_feature_threshold( $feature ) {
 	 * Filter the threshold for a specific feature. Any results below the
 	 * threshold will be ignored.
 	 *
-	 * @param string $threshold The threshold to use.
-	 * @param string $feature   The feature whose threshold to lookup.
+	 * @since 1.0.0
+	 * @hook classifai_feature_threshold
 	 *
-	 * @ return string $threshold The filtered threshold.
+	 * @param {string} $threshold The threshold to use, expressed as a decimal between 0 and 1 inclusive.
+	 * @param {string} $feature   The feature in question.
+	 *
+	 * @return {string} The filtered threshold.
 	 */
 	return apply_filters( 'classifai_feature_threshold', $threshold, $feature );
 }
@@ -295,10 +308,13 @@ function get_feature_taxonomy( $feature ) {
 	/**
 	 * Filter the Taxonomy for the specified NLU feature.
 	 *
-	 * @param string $taxonomy The taxonomy to use.
-	 * @param string $feature  The NLU feature this taxonomy is for.
+	 * @since 1.1.0
+	 * @hook classifai_taxonomy_for_feature
 	 *
-	 * @return string $taxonomy The filtered taxonomy.
+	 * @param {string} $taxonomy The slug of the taxonomy to use.
+	 * @param {string} $feature  The NLU feature this taxonomy is for.
+	 *
+	 * @return {string} The filtered taxonomy slug.
 	 */
 	return apply_filters( 'classifai_taxonomy_for_feature', $taxonomy, $feature );
 }
@@ -314,7 +330,12 @@ function computer_vision_max_filesize() {
 	/**
 	 * Filters the Computer Vision maximum allowed filesize.
 	 *
-	 * @param int Default 4MB.
+	 * @since 1.5.0
+	 * @hook classifai_computer_vision_max_filesize
+	 *
+	 * @param {int} file_size The maximum allowed filesize for Computer Vision in bytes. Default `4 * MB_IN_BYTES`.
+	 *
+	 * @return {int} Filtered filesize in bytes.
 	 */
 	return apply_filters( 'classifai_computer_vision_max_filesize', 4 * MB_IN_BYTES ); // 4MB default.
 }

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -42,6 +42,12 @@ class Plugin {
 	 * Initializes the ClassifAI plugin modules and support objects.
 	 */
 	public function init() {
+		/**
+		 * Fires before ClassifAI services are loaded.
+		 *
+		 * @since 1.2.0
+		 * @hook before_classifai_init
+		 */
 		do_action( 'before_classifai_init' );
 
 		// Initialize the services, each services handles the providers
@@ -60,6 +66,12 @@ class Plugin {
 			);
 		}
 
+		/**
+		 * Fires after ClassifAI services are loaded.
+		 *
+		 * @since 1.2.0
+		 * @hook after_classifai_init
+		 */
 		do_action( 'after_classifai_init' );
 	}
 

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -86,6 +86,16 @@ class Plugin {
 	 * Initialize the Services.
 	 */
 	public function init_services() {
+		/**
+		 * Filter available Services.
+		 *
+		 * @since 1.3.0
+		 * @hook classifai_services
+		 *
+		 * @param {array} 'services' Associative array of service slugs and PHP class namespace.
+		 *
+		 * @return {array} The filtered list of services.
+		 */
 		$classifai_services = apply_filters(
 			'classifai_services',
 			[

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -150,10 +150,13 @@ class ComputerVision extends Provider {
 		 * Filters whether to apply smart cropping to the current image.
 		 *
 		 * @since 1.5.0
+		 * @hook classifai_should_smart_crop_image
 		 *
-		 * @param boolean Whether to apply smart cropping. The default value is set in ComputerVision settings.
-		 * @param array   Image metadata.
-		 * @param int     The attachment ID.
+		 * @param {bool}  $should_smart_crop Whether to apply smart cropping. The default value is set in ComputerVision settings.
+		 * @param {array} $metadata          Image metadata.
+		 * @param {int}   $attachment_id     The attachment ID.
+		 *
+		 * @return {bool} Whether to apply smart cropping.
 		 */
 		if ( ! apply_filters( 'classifai_should_smart_crop_image', $should_smart_crop, $metadata, $attachment_id ) ) {
 			return $metadata;
@@ -282,9 +285,12 @@ class ComputerVision extends Provider {
 		/**
 		 * Filter the captions returned from the API.
 		 *
-		 * @param array $captions. The caption data.
+		 * @since 1.4.0
+		 * @hook classifai_computer_vision_captions
 		 *
-		 * @return array $captions The filtered caption data.
+		 * @param {array} $captions The returned caption data.
+		 *
+		 * @return {array} The filtered caption data.
 		 */
 		$captions = apply_filters( 'classifai_computer_vision_captions', $captions );
 		// If $captions isn't an array, don't save them.
@@ -325,9 +331,12 @@ class ComputerVision extends Provider {
 		/**
 		 * Filter the tags returned from the API.
 		 *
-		 * @param array $tags. The image tag data.
+		 * @since 1.4.0
+		 * @hook classifai_computer_vision_image_tags
 		 *
-		 * @return array $tags The filtered image tags.
+		 * @param {array} $tags The image tag data.
+		 *
+		 * @return {array} The filtered image tags.
 		 */
 		$tags = apply_filters( 'classifai_computer_vision_image_tags', $tags );
 		// If $tags isn't an array, don't save them.

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -296,10 +296,13 @@ class ComputerVision extends Provider {
 				$rtn = $captions[0]->text;
 			} else {
 				/**
-				 * Fire an action if there were no captions added.
+				 * Fires if there were no captions returned.
 				 *
-				 * @param array $tags.   The caption data.
-				 * @param int $threshold The caption_threshold setting.
+				 * @since 1.5.0
+				 * @hook classifai_computer_vision_caption_failed
+				 *
+				 * @param array $tags      The caption data.
+				 * @param int   $threshold The caption_threshold setting.
 				 */
 				do_action( 'classifai_computer_vision_caption_failed', $captions, $threshold );
 			}
@@ -343,10 +346,13 @@ class ComputerVision extends Provider {
 				wp_update_term_count_now( $custom_tags, $taxonomy );
 			} else {
 				/**
-				 * Fire an action if there were no tags added.
+				 * Fires if there were no tags added.
 				 *
-				 * @param array $tags.   The image tag data.
-				 * @param int $threshold The tag_threshold setting.
+				 * @since 1.5.0
+				 * @hook classifai_computer_vision_image_tag_failed
+				 *
+				 * @param array $tags      The image tag data.
+				 * @param int   $threshold The tag_threshold setting.
 				 */
 				do_action( 'classifai_computer_vision_image_tag_failed', $tags, $threshold );
 			}

--- a/includes/Classifai/Providers/Azure/SmartCropping.php
+++ b/includes/Classifai/Providers/Azure/SmartCropping.php
@@ -79,8 +79,11 @@ class SmartCropping {
 		 * Filters the filesystem class instance used to save image files.
 		 *
 		 * @since 1.5.0
+		 * @hook classifai_smart_crop_wp_filesystem
 		 *
-		 * @param WP_Filesystem_Base
+		 * @param {WP_Filesystem_Base} $this->wp_filesystem Filesystem class for saving images.
+		 *
+		 * @return {WP_Filesystem_Base} Filtered Filesystem class.
 		 */
 		return apply_filters( 'classifai_smart_crop_wp_filesystem', $this->wp_filesystem );
 	}
@@ -97,7 +100,12 @@ class SmartCropping {
 		/**
 		 * Filters the maximum allowable width or height of an image to be cropped. Default 1024.
 		 *
-		 * @param int The width/height in pixels.
+		 * @since 1.5.0
+		 * @hook classifai_smart_crop_max_pixel_dimension
+		 *
+		 * @param {int} max The max width/height in pixels.
+		 *
+		 * @return {int} Filtered max dimension in pixels.
 		 */
 		return apply_filters( 'classifai_smart_crop_max_pixel_dimension', 1024 );
 	}
@@ -139,9 +147,12 @@ class SmartCropping {
 		 * Filters whether to smart crop images of a given size.
 		 *
 		 * @since 1.5.0
+		 * @hook classifai_should_crop_size
 		 *
-		 * @param boolean Whether non-position-based cropping was opted into when registering the image size.
-		 * @param string  The image size.
+		 * @param {bool}   $return Whether non-position-based cropping was opted into when registering the image size.
+		 * @param {string} $size   The image size.
+		 *
+		 * @return {bool} Whether this image size should be smart cropped.
 		 */
 		return apply_filters( 'classifai_should_crop_size', $return, $size );
 	}
@@ -194,9 +205,12 @@ class SmartCropping {
 		 * plugin behavior.
 		 *
 		 * @since 1.5.0
+		 * @hook classifai_smart_cropping_source_url
 		 *
-		 * @param null|string Null to use default plugin behavior; string to override.
-		 * @param int         The attachment image ID.
+		 * @param {null|string} url            `null` to use default plugin behavior; `string` to override.
+		 * @param {int}         $attachment_id The attachment image ID.
+		 *
+		 * @return {null|string} URL to be sent to Computer Vision for smart cropping.
 		 */
 		$url = apply_filters( 'classifai_smart_cropping_source_url', null, $attachment_id );
 

--- a/includes/Classifai/Providers/Azure/SmartCropping.php
+++ b/includes/Classifai/Providers/Azure/SmartCropping.php
@@ -312,6 +312,7 @@ class SmartCropping {
 		 * Fires after the request to the generateThumbnail smart-cropping endpoint has run.
 		 *
 		 * @since 1.5.0
+		 * @hook classifai_smart_cropping_after_request
 		 *
 		 * @param array|WP_Error Response data or a WP_Error if the request failed.
 		 * @param string The request URL with query args added.
@@ -327,6 +328,7 @@ class SmartCropping {
 		 * Fires when the generateThumbnail smart-cropping API response did not have a 200 status code.
 		 *
 		 * @since 1.5.0
+		 * @hook classifai_smart_cropping_unsuccessful_response
 		 *
 		 * @param array|WP_Error Response data or a WP_Error if the request failed.
 		 * @param string The request URL with query args added.

--- a/includes/Classifai/Services/Service.php
+++ b/includes/Classifai/Services/Service.php
@@ -45,7 +45,14 @@ abstract class Service {
 	 */
 	public function init() {
 		/**
-		 * Filter the list of providers
+		 * Filter the list of providers for the service.
+		 *
+		 * @since 1.3.0
+		 * @hook {$this->menu_slug}_providers
+		 *
+		 * @param {array} $this->providers Array of available providers for the service.
+		 *
+		 * @return {array} The filtered available providers.
 		 */
 		$this->providers = apply_filters( "{$this->menu_slug}_providers", $this->providers );
 

--- a/includes/Classifai/Watson/Classifier.php
+++ b/includes/Classifai/Watson/Classifier.php
@@ -69,9 +69,12 @@ class Classifier {
 		/**
 		 * Filter the classified data returned from the API call.
 		 *
-		 * @param array $classified_data The classified data.
+		 * @since 1.0.0
+		 * @hook classifai_classified_data
 		 *
-		 * @return array $classified_data The filtered classified data.
+		 * @param {array} $classified_data The classified data.
+		 *
+		 * @return {array} The filtered classified data.
 		 */
 		return apply_filters( 'classifai_classified_data', $classified_data );
 	}

--- a/includes/Classifai/Watson/Normalizer.php
+++ b/includes/Classifai/Watson/Normalizer.php
@@ -59,13 +59,15 @@ class Normalizer {
 		}
 
 		/**
-		 * Filters the normalized content to allow for additional
-		 * cleanup.
+		 * Filters the normalized content to allow for additional cleanup.
 		 *
 		 * @since 0.1.0
+		 * @hook classifai_normalize
 		 *
-		 * @param string $post_content The normalized post_content
-		 * @param int $post_id The ID of the post whose content is being normalized
+		 * @param {string} $post_content The normalized post content.
+		 * @param {int}    $post_id      The ID of the post whose content is being normalized.
+		 *
+		 * @return {string} The filtered normalized post content.
 		 */
 		$post_content = apply_filters( 'classifai_normalize', $post_content, $post_id );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1954,6 +1954,15 @@
       "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
       "dev": true
     },
+    "catharsis": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
+      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2734,6 +2743,12 @@
         "memory-fs": "^0.4.0",
         "tapable": "^1.0.0"
       }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
     },
     "errno": {
       "version": "0.1.7",
@@ -4628,6 +4643,51 @@
         "esprima": "^4.0.0"
       }
     },
+    "js2xmlparser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
+      "integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
+      "dev": true,
+      "requires": {
+        "xmlcreate": "^2.0.3"
+      }
+    },
+    "jsdoc": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.3.tgz",
+      "integrity": "sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.4.4",
+        "bluebird": "^3.5.4",
+        "catharsis": "^0.8.11",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.0",
+        "klaw": "^3.0.0",
+        "markdown-it": "^8.4.2",
+        "markdown-it-anchor": "^5.0.2",
+        "marked": "^0.7.0",
+        "mkdirp": "^0.5.1",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.0.1",
+        "taffydb": "2.6.2",
+        "underscore": "~1.9.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        }
+      }
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -4667,6 +4727,15 @@
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
+    "klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -4691,6 +4760,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
+    },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
     },
     "lint-staged": {
       "version": "9.2.5",
@@ -5076,6 +5154,31 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-it": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
+    "markdown-it-anchor": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.5.tgz",
+      "integrity": "sha512-xLIjLQmtym3QpoY9llBgApknl7pxAcN3WDRc2d3rwpl+/YvDZHPmKscGs+L6E05xf2KrCXPBvosWt7MZukwSpQ==",
+      "dev": true
+    },
+    "marked": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "dev": true
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -5086,6 +5189,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
     },
     "mem": {
       "version": "4.3.0",
@@ -6150,6 +6259,15 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "requizzle": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -6829,6 +6947,12 @@
         }
       }
     },
+    "taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
+    },
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -7019,6 +7143,18 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -7458,6 +7594,12 @@
         "errno": "~0.1.7"
       }
     },
+    "wp-hookdoc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/wp-hookdoc/-/wp-hookdoc-0.2.0.tgz",
+      "integrity": "sha512-BDVfqSA+L7Ho99McFu0ATwJRddaSVbUH/lgoe4RFP7Ktg3kiRtp7VHGIIdn+QhQN7ZtLmCBMpqtEChDvaGDppw==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
@@ -7492,6 +7634,12 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xmlcreate": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
+      "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "./vendor/bin/phpunit",
     "tests:e2e": "./vendor/bin/wpacceptance run",
     "makepot": "wpi18n makepot && echo '.pot file updated'",
-    "build:docs": "rm -rf hook_docs && jsdoc -c hookdoc-conf.json classifai.php includes"
+    "build:docs": "rm -rf docs && jsdoc -c hookdoc-conf.json classifai.php includes"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
### Description of the Change

Add/flesh out hook docs so they can be picked up by the page generator. **IMPORTANT NOTE**: This PR also changes the action to run on `develop` instead of just `master`; once this is confirmed to be working we should switch it back to `master` so hook docs don't update separately from releases.

### Alternate Designs

n/a

### Benefits

Actual hook docs at https://10up.github.io/classifai/

### Possible Drawbacks

n/a

### Verification Process

Ran `npm run build:docs` locally and checked every single hook doc page.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

See #189 

### Changelog Entry

n/a
