### PR TITLE
Settings: improve handling of empty credentials.

### DIFF
--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -297,7 +297,8 @@ class NLU extends Provider {
 	 * Check if a username/password is using instead of API key.
 	 */
 	protected function use_usename_password() {
-		return 'apikey' === $this->get_settings( 'credentials' )['watson_username'];
+		$credentials = $this->get_settings( 'credentials' );
+		return isset( $credentials['watson_username'] ) && 'apikey' === $credentials['watson_username'];
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Fix a PHP notice when Classifai is activated for the first time. 

### Benefits

Before this change, when activating the plugin for the first time, a PHP notice is thrown:

`Undefined index: watson_username in .../classifai/includes/Classifai/Providers/Watson/NLU.php on line 300`

After the change, no notice is thrown.

### Possible Drawbacks

None.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/classifai/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
