### PR TITLE
Allow filtering of the image URL prior to generating image tags and alternate text

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -187,6 +187,9 @@ class ComputerVision extends Provider {
 			'no' !== $settings['enable_image_tagging'] ||
 			'no' !== $settings['enable_image_captions']
 		) {
+
+			$image_url = null;
+
 			if ( isset( $metadata['sizes'] ) && is_array( $metadata['sizes'] ) ) {
 				$image_url = get_largest_acceptable_image_url(
 					get_attached_file( $attachment_id ),
@@ -197,6 +200,8 @@ class ComputerVision extends Provider {
 			} else {
 				$image_url = wp_get_attachment_url( $attachment_id, 'full' );
 			}
+
+			$image_url = apply_filters( 'classifai_generate_image_alt_tags_source_url', $image_url, $attachment_id );
 
 			if ( ! empty( $image_url ) ) {
 				$image_scan = $this->scan_image( $image_url );

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -188,20 +188,20 @@ class ComputerVision extends Provider {
 			'no' !== $settings['enable_image_captions']
 		) {
 
-			$image_url = null;
+			$image_url = apply_filters( 'classifai_generate_image_alt_tags_source_url', null, $attachment_id );
 
-			if ( isset( $metadata['sizes'] ) && is_array( $metadata['sizes'] ) ) {
-				$image_url = get_largest_acceptable_image_url(
-					get_attached_file( $attachment_id ),
-					wp_get_attachment_url( $attachment_id, 'full' ),
-					$metadata['sizes'],
-					computer_vision_max_filesize()
-				);
-			} else {
-				$image_url = wp_get_attachment_url( $attachment_id, 'full' );
+			if ( ! empty( $image_url ) ) {
+				if ( isset( $metadata['sizes'] ) && is_array( $metadata['sizes'] ) ) {
+					$image_url = get_largest_acceptable_image_url(
+						get_attached_file( $attachment_id ),
+						wp_get_attachment_url( $attachment_id, 'full' ),
+						$metadata['sizes'],
+						computer_vision_max_filesize()
+					);
+				} else {
+					$image_url = wp_get_attachment_url( $attachment_id, 'full' );
+				}
 			}
-
-			$image_url = apply_filters( 'classifai_generate_image_alt_tags_source_url', $image_url, $attachment_id );
 
 			if ( ! empty( $image_url ) ) {
 				$image_scan = $this->scan_image( $image_url );

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -190,7 +190,7 @@ class ComputerVision extends Provider {
 
 			$image_url = apply_filters( 'classifai_generate_image_alt_tags_source_url', null, $attachment_id );
 
-			if ( ! empty( $image_url ) || ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
+			if ( empty( $image_url ) || ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
 				if ( isset( $metadata['sizes'] ) && is_array( $metadata['sizes'] ) ) {
 					$image_url = get_largest_acceptable_image_url(
 						get_attached_file( $attachment_id ),

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -190,7 +190,7 @@ class ComputerVision extends Provider {
 
 			$image_url = apply_filters( 'classifai_generate_image_alt_tags_source_url', null, $attachment_id );
 
-			if ( ! empty( $image_url ) ) {
+			if ( ! empty( $image_url ) || ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
 				if ( isset( $metadata['sizes'] ) && is_array( $metadata['sizes'] ) ) {
 					$image_url = get_largest_acceptable_image_url(
 						get_attached_file( $attachment_id ),


### PR DESCRIPTION
### Description of the Change
In instances where an image has been offloaded to a CDN, running the `image` CLI command is failing. This command calls `generate_image_alt_tags()`, which calls `get_largest_acceptable_image_url()`, which requires an image to be physically present on the server. If the image is not present, the image URL is null and no tags or alternate text can be generated. 

### Alternate Designs

None

### Benefits

This pull request adds a filter to allow overriding of the image URL which can allow the Computer Vision API to pull the image directly from a CDN.

### Possible Drawbacks

None

### Verification Process

No verification was performed.

### Checklist:

- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

* Added `classifai_generate_image_alt_tags_source_url` filter to allow overriding of the image URL within `generate_image_alt_tags()`