### PR TITLE
Fix 'permission_callback' error on WordPress 5.5

### DIFF
--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -75,18 +75,20 @@ class ImageProcessing extends Service {
 			'classifai/v1',
 			'alt-tags/(?P<id>\d+)',
 			[
-				'methods'  => 'GET',
-				'callback' => [ $this, 'provider_endpoint_callback' ],
-				'args'     => [ 'route' => 'alt-tags' ],
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'provider_endpoint_callback' ],
+				'args'                => [ 'route' => 'alt-tags' ],
+				'permission_callback' => '__return_true',
 			]
 		);
 		register_rest_route(
 			'classifai/v1',
 			'image-tags/(?P<id>\d+)',
 			[
-				'methods'  => 'GET',
-				'callback' => [ $this, 'provider_endpoint_callback' ],
-				'args'     => [ 'route' => 'image-tags' ],
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'provider_endpoint_callback' ],
+				'args'                => [ 'route' => 'image-tags' ],
+				'permission_callback' => '__return_true',
 			]
 		);
 	}


### PR DESCRIPTION

### Description of the Change

Fix `permission_callback` error when using WordPress version 5.5. I've added `__return_true` since it's a public endpoint which is stated here : https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#permissions-callback

### Benefits

Prevent these errors from showing/logging.

<img width="1280" alt="Screen Shot 2020-08-22 at 2 40 40 AM" src="https://user-images.githubusercontent.com/3365507/90923825-f17fea80-e420-11ea-8396-dfe877b60879.png">


### Possible Drawbacks

None.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
