### PR TITLE
Ensure manual image scanning still works if the automatic scanning is turned off

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -15,7 +15,7 @@ class ComputerVision extends Provider {
 	/**
 	 * @var string URL fragment to the analyze API endpoint
 	 */
-	protected $analyze_url = '/vision/v1.0/analyze';
+	protected $analyze_url = 'vision/v1.0/analyze';
 
 	/**
 	 * ComputerVision constructor.
@@ -112,8 +112,17 @@ class ComputerVision extends Provider {
 	 * @param int $attachment_id Post id for the attachment
 	 */
 	public function maybe_rescan_image( $attachment_id ) {
-		$image_url  = wp_get_attachment_image_url( $attachment_id );
-		$image_scan = $this->scan_image( $image_url );
+		$routes    = [];
+		$image_url = wp_get_attachment_image_url( $attachment_id );
+
+		if ( filter_input( INPUT_POST, 'rescan-captions' ) ) {
+			$routes[] = 'alt-tags';
+		} else if ( filter_input( INPUT_POST, 'rescan-tags' ) ) {
+			$routes[] = 'image-tags';
+		}
+
+		$image_scan = $this->scan_image( $image_url, $routes );
+
 		if ( ! is_wp_error( $image_scan ) ) {
 			// Are we updating the captions?
 			if ( filter_input( INPUT_POST, 'rescan-captions' ) && isset( $image_scan->description->captions ) ) {
@@ -228,12 +237,12 @@ class ComputerVision extends Provider {
 	 * Scan the image and return the captions.
 	 *
 	 * @param string $image_url Path to the uploaded image.
-	 *
+	 * @param array  $routes Routes we are calling.
 	 * @return bool|object|\WP_Error
 	 */
-	protected function scan_image( $image_url ) {
+	protected function scan_image( $image_url, array $routes = [] ) {
 		$settings = $this->get_settings();
-		$url      = $this->prep_api_url();
+		$url      = $this->prep_api_url( $routes );
 
 		$request = wp_remote_post(
 			$url,
@@ -263,15 +272,17 @@ class ComputerVision extends Provider {
 	/**
 	 * Build and return the API endpoint based on settings.
 	 *
+	 * @param array $routes The routes we are calling.
+	 *
 	 * @return string
 	 */
-	protected function prep_api_url() {
+	protected function prep_api_url( array $routes = [] ) {
 		$settings     = $this->get_settings();
 		$api_features = [];
-		if ( 'no' !== $settings['enable_image_captions'] ) {
+		if ( in_array( 'alt-tags', $routes, true ) || 'no' !== $settings['enable_image_captions'] ) {
 			$api_features[] = 'Description';
 		}
-		if ( 'no' !== $settings['enable_image_tagging'] ) {
+		if ( in_array( 'image-tags', $routes, true ) || 'no' !== $settings['enable_image_tagging'] ) {
 			$api_features[] = 'Tags';
 		}
 		$endpoint = add_query_arg( 'visualFeatures', implode( ',', $api_features ), trailingslashit( $settings['url'] ) . $this->analyze_url );
@@ -690,7 +701,7 @@ class ComputerVision extends Provider {
 			wp_get_attachment_url( $post_id ),
 			$metadata['sizes']
 		);
-		$image_scan_results = $this->scan_image( $image_url );
+		$image_scan_results = $this->scan_image( $image_url, [ $route_to_call ] );
 
 		if ( is_wp_error( $image_scan_results ) ) {
 			return $image_scan_results;


### PR DESCRIPTION
### Description of the Change

If either the Automatically Caption Images or Automatically Tag Images settings are turned off, we still output the manual scan/rescan buttons when editing an individual image. But those buttons don't work, as we check the aforementioned settings when making a request to get image details and if those settings are disabled, we don't request the proper image details.

This PR fixes that, so if manual scanning is triggered, this overrides the automatic setting, so even if that setting is turned off, the manual scan will still work. Automatic scanning for newly uploaded images still respect that setting though, this only applies to manual scans.

### Alternate Designs

We could remove the manual scan buttons all together if the automatic scanning is turned off

### Benefits

Manual scanning works properly even if the automatic scanning is turned off. At the moment, those buttons show but won't work properly

### Possible Drawbacks

None

### Verification Process

1. Setup the plugin
2. Turn off the settings for either Automatically Caption Images or Automatically Tag Images (or both)
3. Edit an existing image or upload a new one
4. Select that image and in the image modal that pops up, click the button that corresponds to the setting turned off above
5. Processing should work correctly and the spinner should disappear and either alt text is added or tags are added (if either can be found)

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#232