### PR TITLE
Ensure we use the largest image size possible when scanning from the single edit view

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -112,7 +112,12 @@ class ComputerVision extends Provider {
 	 * @param int $attachment_id Post id for the attachment
 	 */
 	public function maybe_rescan_image( $attachment_id ) {
-		$image_url  = wp_get_attachment_image_url( $attachment_id );
+		$metadata   = wp_get_attachment_metadata( $attachment_id );
+		$image_url  = get_largest_acceptable_image_url(
+			get_attached_file( $attachment_id ),
+			wp_get_attachment_url( $attachment_id ),
+			$metadata['sizes']
+		);
 		$image_scan = $this->scan_image( $image_url );
 		if ( ! is_wp_error( $image_scan ) ) {
 			// Are we updating the captions?


### PR DESCRIPTION
### Description of the Change

Currently, when initiating a scan from the single edit screen, we are passing the image thumbnail to be processed. This can lead to unexpected results, results that don't match what we get on initial image processing or when scanning from the media modal view.

This PR fixes that to ensure we are passing the largest image size possible in this situation, to match the same image size we use in other scans.

### Alternate Designs

None

### Benefits

Scan results should now be the same no matter where they are initiated.

### Possible Drawbacks

None

### Verification Process
This will depend heavily on the image you're testing but I tested a text heavy image and got very different results from the media modal view compared to the single image edit view

1. Setup the plugin
2. Edit an existing image or upload a new one
3. Select that image and in the image modal that pops up, click the button to rescan for alt text
4. Take a note of what that text is
5. Now go to the single edit screen for that image
6. Check the box to rescan for alt text and save the image
7. When the page refreshes, the alt text should still be the same

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues
#234