### PR TITLE
Remove media from language processing settings

### DIFF
--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -172,6 +172,34 @@ function get_watson_password() {
 }
 
 /**
+ * Get post types we want to show in the language processing settings
+ *
+ * @since 1.6.0
+ *
+ * @return array
+ */
+function get_post_types_for_language_settings() {
+	$post_types = get_post_types( [ 'public' => true ], 'objects' );
+
+	// Remove the attachment post type
+	unset( $post_types['attachment'] );
+
+	/**
+	 * Filter post types shown in language processing settings.
+	 *
+	 * @since 1.6.0
+	 * @hook classifai_language_settings_post_types
+	 *
+	 * @param {array} $post_types Array of post types to show in language processing settings.
+	 *
+	 * @return {array} Array of post types.
+	 */
+	$post_types = apply_filters( 'classifai_language_settings_post_types', $post_types );
+
+	return $post_types;
+}
+
+/**
  * The list of post types that get the ClassifAI taxonomies. Defaults
  * to 'post'.
  *

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -194,9 +194,7 @@ function get_post_types_for_language_settings() {
 	 *
 	 * @return {array} Array of post types.
 	 */
-	$post_types = apply_filters( 'classifai_language_settings_post_types', $post_types );
-
-	return $post_types;
+	return apply_filters( 'classifai_language_settings_post_types', $post_types );
 }
 
 /**

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -8,6 +8,7 @@ namespace Classifai\Providers\Watson;
 use Classifai\Admin\SavePostHandler;
 use Classifai\Providers\Provider;
 use Classifai\Taxonomy\TaxonomyFactory;
+use function Classifai\get_post_types_for_language_settings;
 
 class NLU extends Provider {
 
@@ -390,7 +391,7 @@ class NLU extends Provider {
 	 */
 	public function render_post_types_checkboxes( $args ) {
 		echo '<ul>';
-		$post_types = get_post_types( [ 'public' => true ], 'objects' );
+		$post_types = get_post_types_for_language_settings();
 		foreach ( $post_types as $post_type ) {
 			$args = [
 				'label_for'    => $post_type->name,

--- a/tests/e2e/wpacceptance/NaturalLanguageProcessing.php
+++ b/tests/e2e/wpacceptance/NaturalLanguageProcessing.php
@@ -187,44 +187,6 @@ class NaturalLanguageProcessing extends \TestCaseBase {
 
 	}
 
-	/**
-	 * @testdox When the user enables/disables Media under Post Types to Classify, it shows/hides Watson Keywords and other submenus under Media menu.
-	 */
-	public function testToggleMedia() {
-
-		$I = $this->openBrowserPage();
-
-		$I->login();
-
-		$I->moveTo( 'wp-admin/upload.php' );
-
-		$I->dontSeeLink( 'Watson Categories', 'edit-tags.php?taxonomy=watson-category&post_type=attachment' );
-
-		$I->dontSeeLink( 'Watson Keywords', 'edit-tags.php?taxonomy=watson-keyword&post_type=attachment' );
-
-		$I->dontSeeLink( 'Watson Concepts', 'edit-tags.php?taxonomy=watson-concept&post_type=attachment' );
-
-		$I->dontSeeLink( 'Watson Entities', 'edit-tags.php?taxonomy=watson-entity&post_type=attachment' );
-
-		$I->moveTo( 'wp-admin/admin.php?page=language_processing' );
-
-		$I->checkOptions( '#classifai-settings-attachment' );
-
-		$I->click( '#submit' );
-
-		$I->waitUntilNavigation();
-
-		$I->moveTo( 'wp-admin/upload.php' );
-
-		$I->seeLink( 'Watson Categories', 'edit-tags.php?taxonomy=watson-category&post_type=attachment' );
-
-		$I->seeLink( 'Watson Keywords', 'edit-tags.php?taxonomy=watson-keyword&post_type=attachment' );
-
-		$I->seeLink( 'Watson Concepts', 'edit-tags.php?taxonomy=watson-concept&post_type=attachment' );
-
-		$I->seeLink( 'Watson Entities', 'edit-tags.php?taxonomy=watson-entity&post_type=attachment' );
-	}
-
 	public function testWatsonWorks() {
 		$I = $this->openBrowserPage();
 


### PR DESCRIPTION
### Description of the Change

In the Language Processing settings, we have a section to select what post types you want processed. This pulls all public post types, which will include the Attachment post type. While in theory you could run language processing on attachments (processing takes into account the `post_title` and `post_content`, which attachments should have a `post_title` and some may have `post_content`) attachments fire different hooks than other post types, which we aren't currently accounting for. So if you select the Media option in settings, it won't actually do anything.

This PR adds a new helper function to build up the list of post types we want in our Language Processing settings. This helper function runs the results through a new filter, so these results can be filtered if needed. This new function also removes attachments from that list, so we no longer show that as an option in our settings list.

### Alternate Designs

None

### Benefits

This removes a setting that currently won't actually do anything, potentially causing user confusion. Also introduces a new filter, allowing more granular control over the options shown.

### Possible Drawbacks

None

### Verification Process

Go to the Language Processing settings and ensure there are still post type options shown and Media isn't shown anymore.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

#242 