### PR TITLE
Don't default to the `post` post type, if no other post types are selected

### DIFF
--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -191,10 +191,6 @@ function get_supported_post_types() {
 		}
 	}
 
-	if ( empty( $post_types ) ) {
-		$post_types = [ 'post' ];
-	}
-
 	/**
 	 * Filter post types supported for language processing.
 	 *

--- a/tests/Classifai/HelpersTest.php
+++ b/tests/Classifai/HelpersTest.php
@@ -29,7 +29,7 @@ class HelpersTest extends \WP_UnitTestCase {
 
 	function test_it_has_default_supported_post_types() {
 		$actual = get_supported_post_types();
-		$this->assertEquals( [ 'post' ], $actual );
+		$this->assertEquals( [], $actual );
 	}
 
 	function test_it_can_lookup_supported_post_types_from_option() {

--- a/tests/Classifai/Taxonomy/TaxonomyFactoryTest.php
+++ b/tests/Classifai/Taxonomy/TaxonomyFactoryTest.php
@@ -52,6 +52,10 @@ class TaxonomyFactoryTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_connects_watson_taxonomies_to_post_type() {
+		add_filter( 'classifai_post_types', function() {
+			return [ 'post' ];
+		} );
+
 		$this->factory->build_all();
 
 		$actual = get_object_taxonomies( 'post' );


### PR DESCRIPTION
### Description of the Change

For Language Processing, if no post types are selected in the settings, we default to still using the `post` post type. If a user has decided to not select any post types, we should respect that decision and not run Language Processing on posts anyway.

### Alternate Designs

None

### Benefits

Settings will be respected and Language Processing won't happen on post types that haven't been selected

### Possible Drawbacks

None

### Verification Process

1. Go to the Language Processing settings
2. Deselect all the options under Post Types to Classify
3. Ensure the options below that are still enabled
4. Go and add a new post and save it
5. Ensure no classification happened and no Classify taxonomies are shown

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#246 