### PR TITLE
Don't process items if no Language Processing features are enabled

### DIFF
--- a/includes/Classifai/Admin/SavePostHandler.php
+++ b/includes/Classifai/Admin/SavePostHandler.php
@@ -62,7 +62,8 @@ class SavePostHandler {
 		$post_type   = get_post_type( $post_id );
 		$post_status = get_post_status( $post_id );
 
-		if ( 'publish' === $post_status && in_array( $post_type, $supported, true ) ) {
+		// Only process published, supported items and only if features are enabled
+		if ( 'publish' === $post_status && in_array( $post_type, $supported, true ) && \Classifai\language_processing_features_enabled() ) {
 			$this->classify( $post_id );
 		}
 	}

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -232,6 +232,30 @@ function get_feature_enabled( $feature ) {
 }
 
 /**
+ * Check if any language processing features are enabled
+ *
+ * @since 1.6.0
+ *
+ * @return true
+ */
+function language_processing_features_enabled() {
+	$features = [
+		'category',
+		'concept',
+		'entity',
+		'keyword',
+	];
+
+	foreach ( $features as $feature ) {
+		if ( get_feature_enabled( $feature ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Returns the feature threshold based on current configuration. Lookup
  * order is.
  *


### PR DESCRIPTION
### Description of the Change

This PR adds a new helper function that will check to see if any Language Processing features are enabled. This function is then used as one more check to determine if we should run Language Processing on items.

If we are saving a post type that is supported and is published (which are the existing checks), we now also check to make sure we have at least on Language Processing feature enabled. This ensures we don't make an API request that isn't needed.

### Alternate Designs

None

### Benefits

Saving items is now faster, as we're not making unnecessary API requests.

### Possible Drawbacks

None

### Verification Process

1. Go to the Language Processing settings
2. Enable processing on Posts
3. Disable all features below that
4. Go save a new post and see that the save process completes quickly

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues
#248 