### PR TITLE
Fix: Smart cropping for existing images

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -177,6 +177,10 @@ class ComputerVision extends Provider {
 		}
 
 		// Direct file system access is required for the current implementation of this feature.
+		if ( ! function_exists( 'get_filesystem_method' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/file.php' );
+		}
+
 		$access_type = get_filesystem_method();
 		if ( 'direct' !== $access_type || ! WP_Filesystem() ) {
 			return $metadata;
@@ -741,6 +745,12 @@ class ComputerVision extends Provider {
 				if ( isset( $image_scan_results->tags ) ) {
 					// Process the tags.
 					return $this->generate_image_tags( $image_scan_results->tags, $post_id );
+				}
+				break;
+			case 'smart-crop':
+				if ( ! empty( $metadata ) ) {
+					// Process the smart crop.
+					return $this->smart_crop_image( $metadata, $post_id );
 				}
 				break;
 		}

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -88,8 +88,10 @@ class ComputerVision extends Provider {
 	 * @param \WP_Post $post The post object.
 	 */
 	public function attachment_data_meta_box( $post ) {
-		$captions = get_post_meta( $post->ID, '_wp_attachment_image_alt', true ) ? __( 'Rescan Alt Text', 'classifai' ) : __( 'Scan Alt Text', 'classifai' );
-		$tags     = ! empty( wp_get_object_terms( $post->ID, 'classifai-image-tags' ) ) ? __( 'Rescan Tags', 'classifai' ) : __( 'Generate Tags', 'classifai' );
+		$settings   = get_option( 'classifai_computer_vision' );
+		$captions   = get_post_meta( $post->ID, '_wp_attachment_image_alt', true ) ? __( 'Rescan Alt Text', 'classifai' ) : __( 'Scan Alt Text', 'classifai' );
+		$tags       = ! empty( wp_get_object_terms( $post->ID, 'classifai-image-tags' ) ) ? __( 'Rescan Tags', 'classifai' ) : __( 'Generate Tags', 'classifai' );
+		$smart_crop = get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ? __( 'Regenerate Smart Crop', 'classifai' ) : __( 'Generate Smart Crop', 'classifai' );
 		?>
 		<div class="misc-publishing-actions">
 			<div class="misc-pub-section">
@@ -104,6 +106,14 @@ class ComputerVision extends Provider {
 					<?php echo esc_html( $tags ); ?>
 				</label>
 			</div>
+			<?php if ( $settings && isset( $settings['enable_smart_cropping'] ) && '1' === $settings['enable_smart_cropping'] ) : ?>
+				<div class="misc-pub-section">
+					<label for="rescan-smart-crop">
+						<input type="checkbox" value="yes" id="rescan-smart-crop" name="rescan-smart-crop"/>
+						<?php echo esc_html( $smart_crop ); ?>
+					</label>
+				</div>
+			<?php endif; ?>
 		</div>
 		<?php
 	}
@@ -125,18 +135,27 @@ class ComputerVision extends Provider {
 			$routes[] = 'alt-tags';
 		} else if ( filter_input( INPUT_POST, 'rescan-tags' ) ) {
 			$routes[] = 'image-tags';
+		} else if ( filter_input( INPUT_POST, 'rescan-smart-crop' ) ) {
+			$routes[] = 'smart-crop';
 		}
 
-		$image_scan = $this->scan_image( $image_url, $routes );
-
-		if ( ! is_wp_error( $image_scan ) ) {
-			// Are we updating the captions?
-			if ( filter_input( INPUT_POST, 'rescan-captions' ) && isset( $image_scan->description->captions ) ) {
-				$this->generate_alt_tags( $image_scan->description->captions, $attachment_id );
+		if ( in_array( 'smart-crop', $routes, true ) ) {
+			// Are we smart cropping the image?
+			if ( filter_input( INPUT_POST, 'rescan-smart-crop' ) && ! empty( $metadata ) ) {
+				$this->smart_crop_image( $metadata, $attachment_id );
 			}
-			// Are we updating the tags?
-			if ( filter_input( INPUT_POST, 'rescan-tags' ) && isset( $image_scan->tags ) ) {
-				$this->generate_image_tags( $image_scan->tags, $attachment_id );
+		} else {
+			$image_scan = $this->scan_image( $image_url, $routes );
+
+			if ( ! is_wp_error( $image_scan ) ) {
+				// Are we updating the captions?
+				if ( filter_input( INPUT_POST, 'rescan-captions' ) && isset( $image_scan->description->captions ) ) {
+					$this->generate_alt_tags( $image_scan->description->captions, $attachment_id );
+				}
+				// Are we updating the tags?
+				if ( filter_input( INPUT_POST, 'rescan-tags' ) && isset( $image_scan->tags ) ) {
+					$this->generate_image_tags( $image_scan->tags, $attachment_id );
+				}
 			}
 		}
 	}

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -91,7 +91,7 @@ class ComputerVision extends Provider {
 		$settings   = get_option( 'classifai_computer_vision' );
 		$captions   = get_post_meta( $post->ID, '_wp_attachment_image_alt', true ) ? __( 'Rescan Alt Text', 'classifai' ) : __( 'Scan Alt Text', 'classifai' );
 		$tags       = ! empty( wp_get_object_terms( $post->ID, 'classifai-image-tags' ) ) ? __( 'Rescan Tags', 'classifai' ) : __( 'Generate Tags', 'classifai' );
-		$smart_crop = get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ? __( 'Regenerate Smart Crop', 'classifai' ) : __( 'Generate Smart Crop', 'classifai' );
+		$smart_crop = get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ? __( 'Regenerate Smart Thumbnail', 'classifai' ) : __( 'Generate Smart Thumbnail', 'classifai' );
 		?>
 		<div class="misc-publishing-actions">
 			<div class="misc-pub-section">

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -54,7 +54,7 @@ class ImageProcessing extends Service {
 		if ( ! $screen ) {
 			$alt_tags_text   = empty( get_post_meta( $post->ID, '_wp_attachment_image_alt', true ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
 			$image_tags_text = empty( wp_get_object_terms( $post->ID, 'classifai-image-tags' ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
-			$smart_crop_text = empty( get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
+			$smart_crop_text = empty( get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ) ? __( 'Generate', 'classifai' ) : __( 'Regenerate', 'classifai' );
 			$form_fields['rescan_alt_tags'] = [
 				'label' => __( 'Classifai Alt Tags', 'classifai' ),
 				'input' => 'html',

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -48,11 +48,13 @@ class ImageProcessing extends Service {
 	 * @param \WP_post $post        Post object for the attachment being viewed.
 	 */
 	public function add_rescan_button_to_media_modal( $form_fields, $post ) {
-		$screen = get_current_screen();
+		$screen   = get_current_screen();
+		$settings = get_option( 'classifai_computer_vision' );
 		// Screen returns null on the Media library page.
 		if ( ! $screen ) {
 			$alt_tags_text   = empty( get_post_meta( $post->ID, '_wp_attachment_image_alt', true ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
 			$image_tags_text = empty( wp_get_object_terms( $post->ID, 'classifai-image-tags' ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
+			$smart_crop_text = empty( get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
 			$form_fields['rescan_alt_tags'] = [
 				'label' => __( 'Classifai Alt Tags', 'classifai' ),
 				'input' => 'html',
@@ -63,6 +65,13 @@ class ImageProcessing extends Service {
 				'input' => 'html',
 				'html'  => '<button class="button secondary" id="classifai-rescan-image-tags" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $image_tags_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
 			];
+			if ( $settings && isset( $settings['enable_smart_cropping'] ) && '1' === $settings['enable_smart_cropping'] ) {
+				$form_fields['rescan_smart_crop'] = [
+					'label' => __( 'Classifai Smart Crop', 'classifai' ),
+					'input' => 'html',
+					'html'  => '<button class="button secondary" id="classifai-rescan-smart-crop" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $smart_crop_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
+				];
+			}
 		}
 		return $form_fields;
 	}
@@ -88,6 +97,16 @@ class ImageProcessing extends Service {
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'provider_endpoint_callback' ],
 				'args'                => [ 'route' => 'image-tags' ],
+				'permission_callback' => '__return_true',
+			]
+		);
+		register_rest_route(
+			'classifai/v1',
+			'smart-crop/(?P<id>\d+)',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'provider_endpoint_callback' ],
+				'args'                => [ 'route' => 'smart-crop' ],
 				'permission_callback' => '__return_true',
 			]
 		);

--- a/src/js/media.js
+++ b/src/js/media.js
@@ -50,6 +50,7 @@
 
 				const altTagsButton = document.getElementById( 'classifai-rescan-alt-tags' );
 				const imageTagsButton = document.getElementById( 'classifai-rescan-image-tags' );
+				const smartCropButton = document.getElementById( 'classifai-rescan-smart-crop' );
 				altTagsButton.addEventListener( 'click', e => handleClick(
 					{
 						button: e.target,
@@ -64,6 +65,7 @@
 				) );
 
 				imageTagsButton.addEventListener( 'click', e => handleClick( { button: e.target, endpoint: '/classifai/v1/image-tags/' } ) );
+				smartCropButton.addEventListener( 'click', e => handleClick( { button: e.target, endpoint: '/classifai/v1/smart-crop/' } ) );
 			} );
 		}
 	} );


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

This PR adds the ability to Smart Crop existing images in WP Admin. It relates to https://github.com/10up/classifai/issues/213.

### Scope/Approach
- [x] Adds a button to the attachment page that will initiate the regeneration of thumbnails.

### Benefits

<!-- What benefits will be realized by the code change? -->
Allows Smart cropping of pre-existing images from the media attachments screen.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

- Under _ClassifAI -> Image Processing_ make sure _enable smart cropping_ is unchecked.
- Add an image to the media gallery
- Go back to _ClassifAI -> Image Processing_ and set _enable smart cropping_ to checked.
- Open the existing image in the media attachments screen
- Press the button to **ClassifAI Smart Crop**
- New smart cropped image attachment should be generated

**NOTE: I could not check the last step as this needs to be done on a remote server. I was able to track the functionality through the code.**

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
https://github.com/10up/classifai/issues/213
