### PR TITLE
Update: cli crop command

### DIFF
--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -303,12 +303,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 		$classifier     = new ComputerVision( false );
 		$settings       = $classifier->get_settings();
 		$smart_cropping = new SmartCropping( $settings );
-
-		if ( ! isset( $settings['enable_smart_cropping'] ) || '1' !== $settings['enable_smart_cropping'] ) {
-			\WP_CLI::error( 'Smart Cropping is disabled. Enable it in Image settings to use this command.' );
-		}
-
-		$default_opts = [
+		$default_opts   = [
 			'limit' => false,
 		];
 

--- a/includes/Classifai/Providers/Azure/SmartCropping.php
+++ b/includes/Classifai/Providers/Azure/SmartCropping.php
@@ -183,7 +183,7 @@ class SmartCropping {
 
 			$better_thumb_filename = $this->get_cropped_thumbnail( $attachment_id, $data );
 
-			if ( ! empty( $better_thumb_filename ) && ! is_wp_error( $better_thumb_filename ) ) {
+			if ( ! is_wp_error( $better_thumb_filename ) ) {
 				$metadata['sizes'][ $size ]['file'] = basename( $better_thumb_filename );
 			}
 		}
@@ -198,7 +198,7 @@ class SmartCropping {
 	 *
 	 * @param int   $attachment_id Attachment ID.
 	 * @param array $size_data Attachment metadata size data.
-	 * @return bool|mixed The thumbnail file name or false on failure.
+	 * @return string|\WP_Error The thumbnail file name or WP_Error on failure.
 	 */
 	public function get_cropped_thumbnail( $attachment_id, $size_data ) {
 		/**
@@ -242,7 +242,7 @@ class SmartCropping {
 		}
 
 		if ( empty( $new_thumb_image ) ) {
-			return false;
+			return new \WP_Error( 'classifai_smart_cropping_empty_image', 'Empty cropped image.' );
 		}
 
 		$attached_file       = get_attached_file( $attachment_id );
@@ -281,7 +281,7 @@ class SmartCropping {
 			return $new_thumb_file_name;
 		}
 
-		return false;
+		return new \WP_Error( 'classifai_smart_cropping_filesystem_error', 'Filesystem error. Can not write cropped thumbnail file.' );
 	}
 
 	/**
@@ -301,7 +301,7 @@ class SmartCropping {
 	 * @since 1.5.0
 	 *
 	 * @param array $data Data for an attachment image size.
-	 * @return bool|string
+	 * @return string|\WP_Error
 	 */
 	public function request_cropped_thumbnail( $data ) {
 		$url = add_query_arg(
@@ -376,7 +376,7 @@ class SmartCropping {
 			return new \WP_Error( 'classifai_smart_cropping_api_validation_errors', implode( ' ', $response_json->errors->smartCropping ) );
 		}
 
-		return false;
+		return new \WP_Error( 'classifai_smart_cropping_failed', 'A Smart Cropping error occurred.' );
 	}
 }
 

--- a/includes/Classifai/Providers/Azure/SmartCropping.php
+++ b/includes/Classifai/Providers/Azure/SmartCropping.php
@@ -340,6 +340,10 @@ class SmartCropping {
 		 */
 		do_action( 'classifai_smart_cropping_after_request', $response, $url, $data );
 
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
 		$response_body = wp_remote_retrieve_body( $response );
 
 		if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
@@ -364,6 +368,10 @@ class SmartCropping {
 			return new \WP_Error( $response_json->code, $response_json->message );
 		}
 
+		if ( ! empty( $response_json->error ) ) {
+			return new \WP_Error( $response_json->error->code, $response_json->error->message );
+		}
+
 		if ( ! empty( $response_json->errors ) ) {
 			return new \WP_Error( 'classifai_smart_cropping_api_validation_errors', implode( ' ', $response_json->errors->smartCropping ) );
 		}
@@ -371,3 +379,4 @@ class SmartCropping {
 		return false;
 	}
 }
+

--- a/includes/Classifai/Providers/Azure/SmartCropping.php
+++ b/includes/Classifai/Providers/Azure/SmartCropping.php
@@ -225,7 +225,7 @@ class SmartCropping {
 		}
 
 		if ( empty( $url ) || empty( $size_data ) || ! is_array( $size_data ) ) {
-			return false;
+			return new \WP_Error( 'classifai_smart_cropping_invalid_args', 'Invalid arguments for API request.' );
 		}
 
 		$data = [

--- a/tests/Classifai/Providers/Azure/SmartCroppingTest.php
+++ b/tests/Classifai/Providers/Azure/SmartCroppingTest.php
@@ -211,7 +211,7 @@ class SmartCroppingTest extends WP_UnitTestCase {
 			);
 
 			// Test failed request.
-			$this->assertFalse(
+			$this->assertWPError(
 				$this->get_smart_cropping(
 					[
 						'url'     => 'my-bad-url.com',

--- a/tests/Classifai/Providers/Azure/SmartCroppingTest.php
+++ b/tests/Classifai/Providers/Azure/SmartCroppingTest.php
@@ -136,12 +136,12 @@ class SmartCroppingTest extends WP_UnitTestCase {
 	 */
 	public function test_get_cropped_thumbnail() {
 		// Test invalid data returns false.
-		$this->assertFalse( $this->get_smart_cropping()->get_cropped_thumbnail( 999999999, [] ) );
+		$this->assertWPError( $this->get_smart_cropping()->get_cropped_thumbnail( 999999999, [] ) );
 
 		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA .'/images/33772.jpg' );
 
 		// Test bad request returns false.
-		$this->assertFalse(
+		$this->assertWPError(
 			$this->get_smart_cropping(
 				[
 					'url'     => 'my-bad-url.com',
@@ -171,7 +171,7 @@ class SmartCroppingTest extends WP_UnitTestCase {
 
 			// Test when file operations fail.
 			add_filter( 'classifai_smart_crop_wp_filesystem', '__return_false' );
-			$this->assertFalse(
+			$this->assertWPError(
 				$this->get_smart_cropping()->get_cropped_thumbnail(
 					$attachment,
 					wp_get_attachment_metadata( $attachment )['sizes']['thumbnail']


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR catches more API errors and bypasses the Smart Cropping seting (as suggested by @dkotter) which allows users to use `crop` command without enabling it in the admin area.