### PR TITLE
Switch to the v3.0 version of the Computer Vision analyze endpoint

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -16,7 +16,7 @@ class ComputerVision extends Provider {
 	/**
 	 * @var string URL fragment to the analyze API endpoint
 	 */
-	protected $analyze_url = 'vision/v3.1/analyze';
+	protected $analyze_url = 'vision/v3.0/analyze';
 
 	/**
 	 * ComputerVision constructor.


### PR DESCRIPTION
### Description of the Change

We [recently updated](https://github.com/10up/classifai/pull/244) from the v1.0 Computer Vision analyze endpoint to the v3.1 version. After further testing, I'm noticing less accurate image captions (which we store as alt text) are being returned, resulting in either lowering the confidence score fairly low (like ~30%) or you end up with no alt text ever being saved.

It seems the v3.0 endpoint is much more accurate, with most captions being in the >75% range. This results in more accurate alt text and more images that have alt text generated.

### Alternate Designs

None

### Benefits

More accurate image scanning results

### Possible Drawbacks

None

### Verification Process

I scanned multiple images with the v3.1 endpoint and then again with the v3.0 endpoint. Results across the board were much better with the v3.0 one.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.