### PR TITLE
Make sure (re)scan buttons show up immediately after uploading an image

### DIFF
--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -48,31 +48,30 @@ class ImageProcessing extends Service {
 	 * @param \WP_post $post        Post object for the attachment being viewed.
 	 */
 	public function add_rescan_button_to_media_modal( $form_fields, $post ) {
-		$screen   = get_current_screen();
-		$settings = get_option( 'classifai_computer_vision' );
-		// Screen returns null on the Media library page.
-		if ( ! $screen ) {
-			$alt_tags_text   = empty( get_post_meta( $post->ID, '_wp_attachment_image_alt', true ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
-			$image_tags_text = empty( wp_get_object_terms( $post->ID, 'classifai-image-tags' ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
-			$smart_crop_text = empty( get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ) ? __( 'Generate', 'classifai' ) : __( 'Regenerate', 'classifai' );
-			$form_fields['rescan_alt_tags'] = [
-				'label' => __( 'Classifai Alt Tags', 'classifai' ),
+		$settings        = get_option( 'classifai_computer_vision' );
+		$alt_tags_text   = empty( get_post_meta( $post->ID, '_wp_attachment_image_alt', true ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
+		$image_tags_text = empty( wp_get_object_terms( $post->ID, 'classifai-image-tags' ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
+		$smart_crop_text = empty( get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ) ? __( 'Generate', 'classifai' ) : __( 'Regenerate', 'classifai' );
+
+		$form_fields['rescan_alt_tags'] = [
+			'label' => __( 'Classifai Alt Tags', 'classifai' ),
+			'input' => 'html',
+			'html'  => '<button class="button secondary" id="classifai-rescan-alt-tags" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $alt_tags_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
+		];
+		$form_fields['rescan_captions'] = [
+			'label' => __( 'Classifai Image Tags', 'classifai' ),
+			'input' => 'html',
+			'html'  => '<button class="button secondary" id="classifai-rescan-image-tags" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $image_tags_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
+		];
+
+		if ( $settings && isset( $settings['enable_smart_cropping'] ) && '1' === $settings['enable_smart_cropping'] ) {
+			$form_fields['rescan_smart_crop'] = [
+				'label' => __( 'Classifai Smart Crop', 'classifai' ),
 				'input' => 'html',
-				'html'  => '<button class="button secondary" id="classifai-rescan-alt-tags" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $alt_tags_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
+				'html'  => '<button class="button secondary" id="classifai-rescan-smart-crop" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $smart_crop_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
 			];
-			$form_fields['rescan_captions'] = [
-				'label' => __( 'Classifai Image Tags', 'classifai' ),
-				'input' => 'html',
-				'html'  => '<button class="button secondary" id="classifai-rescan-image-tags" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $image_tags_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
-			];
-			if ( $settings && isset( $settings['enable_smart_cropping'] ) && '1' === $settings['enable_smart_cropping'] ) {
-				$form_fields['rescan_smart_crop'] = [
-					'label' => __( 'Classifai Smart Crop', 'classifai' ),
-					'input' => 'html',
-					'html'  => '<button class="button secondary" id="classifai-rescan-smart-crop" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $smart_crop_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
-				];
-			}
 		}
+
 		return $form_fields;
 	}
 


### PR DESCRIPTION
### Description of the Change

Right now, if you upload an image directly to the media library and then click on that image to open the modal view, the scan/rescan buttons won't show up. You have to refresh the page before you see those.

The issue here is we have a check for the current screen and only show those buttons if the screen object doesn't exist. Not sure the historical context here but this does force a page refresh to see those settings, which is not ideal.

In testing, I don't see any issues with removing that check and it does fix the problem.

### Alternate Designs

None

### Benefits

Scan buttons show up immediately, without requiring a page refresh

### Possible Drawbacks

Whatever the original reason there was for adding this check (for instance, to solve some sort of error), that could happen again, now that the check is gone. I've not run into any issues testing this though.

### Verification Process

In the media library grid view, upload a new image and then click on that image to open the modal view. Ensure the scan buttons are showing up.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.