### PR TITLE
Addressing TODO from https://github.com/10up/classifai/issues/260 ComputerVision::reset_settings()

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -49,10 +49,10 @@ class ComputerVision extends Provider {
 			'valid' => false,
 			'url' => '',
 			'api_key' => '',
-			'enable_image_captions' => '1',
-			'enable_image_tagging' => '1',
-			'enable_smart_cropping' => 'no',
-			'enable_ocr' => 'no',
+			'enable_image_captions' => true,
+			'enable_image_tagging' => true,
+			'enable_smart_cropping' => false,
+			'enable_ocr' => false,
 			'caption_threshold' => 75,
 			'tag_threshold' => 70,
 			'image_tag_taxonomy' => 'classifai-image-tags',
@@ -622,124 +622,116 @@ class ComputerVision extends Provider {
 	 */
 	public function setup_fields_sections() {
 		add_settings_section( $this->get_option_name(), $this->provider_service_name, '', $this->get_option_name() );
-		
 		$settings = $this->get_default_settings();
-		
 		add_settings_field(
 			'url',
 			esc_html__( 'Endpoint URL', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$settings[ 'url' ],
+			$this->get_option_name(),
 			[
-				'label_for'   => 'url',
-				'input_type'  => 'text',
-				'description' => __( 'e.g. <code>https://REGION.api.cognitive.microsoft.com/</code>', 'classifai' ),
+				'label_for'     => 'url',
+				'input_type'    => 'text',
+				'default_value' => $settings['url'],
+				'description'   => __( 'e.g. <code>https://REGION.api.cognitive.microsoft.com/</code>', 'classifai' ),
 			]
 		);
-		
 		add_settings_field(
 			'api-key',
 			esc_html__( 'API Key', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$settings[ 'api_key' ],
+			$this->get_option_name(),
 			[
-				'label_for'  => 'api_key',
-				'input_type' => 'password',
+				'label_for'     => 'api_key',
+				'input_type'    => 'password',
+				'default_value' => $settings['api_key']
 			]
 		);
-		
 		add_settings_field(
 			'enable-image-captions',
 			esc_html__( 'Automatically Caption Images', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$settings[ 'enable_image_captions' ],
+			$this->get_option_name(),
 			[
 				'label_for'     => 'enable_image_captions',
 				'input_type'    => 'checkbox',
-				'default_value' => true,
+				'default_value' => $settings['enable_image_captions'],
 				'description'   => __( 'Images will be captioned with alt text upon upload', 'classifai' ),
 			]
 		);
-		
 		add_settings_field(
 			'enable-image-tagging',
 			esc_html__( 'Automatically Tag Images', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$settings[ 'enable_image_captions' ],
+			$this->get_option_name(),
 			[
 				'label_for'     => 'enable_image_tagging',
 				'input_type'    => 'checkbox',
-				'default_value' => true,
+				'default_value' => $settings['enable_image_tagging'],
 				'description'   => __( 'Images will be tagged upon upload', 'classifai' ),
 			]
 		);
-		
 		add_settings_field(
 			'enable-smart-cropping',
 			esc_html__( 'Enable smart cropping', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$settings[ 'enable_smart_cropping' ],
+			$this->get_option_name(),
 			[
 				'label_for'     => 'enable_smart_cropping',
 				'input_type'    => 'checkbox',
-				'default_value' => false,
+				'default_value' => $settings['enable_smart_cropping'],
 				'description'   => __(
 					'Crop images around a region of interest identified by ComputerVision',
 					'classifai'
 				),
 			]
 		);
-		
 		add_settings_field(
 			'enable-ocr',
 			esc_html__( 'Enable OCR', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$settings[ 'enable_ocr' ],
+			$this->get_option_name(),
 			[
 				'label_for'     => 'enable_ocr',
 				'input_type'    => 'checkbox',
-				'default_value' => false,
+				'default_value' => $settings['enable_ocr'],
 				'description'   => __(
 					'Detect text in an image and store that as post content',
 					'classifai'
 				),
 			]
 		);
-		
 		add_settings_field(
 			'caption-threshold',
 			esc_html__( 'Caption Confidence Threshold', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$settings[ 'captions_threshold' ],
+			$this->get_option_name(),
 			[
 				'label_for'     => 'caption_threshold',
 				'input_type'    => 'number',
-				'default_value' => 75,
+				'default_value' => $settings['caption_threshold'],
 				'description'   => __( 'Minimum confidence score for automatically applied image captions, numeric value from 0-100. Recommended to be set to at least 75.', 'classifai' ),
 			]
 		);
-		
 		add_settings_field(
 			'image-tag-threshold',
 			esc_html__( 'Tag Confidence Threshold', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$settings[ 'tag_threshold' ],
+			$this->get_option_name(),
 			[
 				'label_for'     => 'tag_threshold',
 				'input_type'    => 'number',
-				'default_value' => 70,
+				'default_value' => $settings['tag_threshold'],
 				'description'   => __( 'Minimum confidence score for automatically applied image tags, numeric value from 0-100. Recommended to be set to at least 70.', 'classifai' ),
 			]
 		);
-
 		// What taxonomy should we tag images with?
 		$attachment_taxonomies = get_object_taxonomies( 'attachment', 'objects' );
 		$options               = [];
@@ -751,10 +743,11 @@ class ComputerVision extends Provider {
 			esc_html__( 'Tag Taxonomy', 'classifai' ),
 			[ $this, 'render_select' ],
 			$this->get_option_name(),
-			$settings[ 'image_tag_taxonomy' ],
+			$this->get_option_name(),
 			[
-				'label_for' => 'image_tag_taxonomy',
-				'options'   => $options,
+				'label_for'     => 'image_tag_taxonomy',
+				'options'       => $options,
+				'default_value' => $settings['image_tag_taxonomy']
 			]
 		);
 	}

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -39,9 +39,10 @@ class ComputerVision extends Provider {
 	public function reset_settings() {
 		update_option( $this->get_option_name(), $this->get_default_settings() );
 	}
-	
+
 	/**
 	 * Default settings for ComputerVision
+	 *
 	 * @return array
 	 */
 	private function get_default_settings() {
@@ -645,7 +646,7 @@ class ComputerVision extends Provider {
 			[
 				'label_for'     => 'api_key',
 				'input_type'    => 'password',
-				'default_value' => $settings['api_key']
+				'default_value' => $settings['api_key'],
 			]
 		);
 		add_settings_field(
@@ -747,7 +748,7 @@ class ComputerVision extends Provider {
 			[
 				'label_for'     => 'image_tag_taxonomy',
 				'options'       => $options,
-				'default_value' => $settings['image_tag_taxonomy']
+				'default_value' => $settings['image_tag_taxonomy'],
 			]
 		);
 	}

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -37,7 +37,19 @@ class ComputerVision extends Provider {
 	 * Resets settings for the ComputerVision provider.
 	 */
 	public function reset_settings() {
-		// TODO: Implement reset_settings() method.
+		$settings = [
+			'valid' => false,
+			'url' => '',
+			'api_key' => '',
+			'enable_image_captions' => '1',
+			'enable_image_tagging' => '1',
+			'enable_smart_cropping' => 'no',
+			'enable_ocr' => 'no',
+			'caption_threshold' => 75,
+			'tag_threshold' => 70,
+			'image_tag_taxonomy' => 'classifai-image-tags',
+		];
+		update_option( $this->get_option_name(), $settings );
 	}
 
 	/**

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -37,7 +37,15 @@ class ComputerVision extends Provider {
 	 * Resets settings for the ComputerVision provider.
 	 */
 	public function reset_settings() {
-		$settings = [
+		update_option( $this->get_option_name(), $this->get_default_settings() );
+	}
+	
+	/**
+	 * Default settings for ComputerVision
+	 * @return array
+	 */
+	private function get_default_settings() {
+		return [
 			'valid' => false,
 			'url' => '',
 			'api_key' => '',
@@ -49,7 +57,6 @@ class ComputerVision extends Provider {
 			'tag_threshold' => 70,
 			'image_tag_taxonomy' => 'classifai-image-tags',
 		];
-		update_option( $this->get_option_name(), $settings );
 	}
 
 	/**
@@ -615,35 +622,40 @@ class ComputerVision extends Provider {
 	 */
 	public function setup_fields_sections() {
 		add_settings_section( $this->get_option_name(), $this->provider_service_name, '', $this->get_option_name() );
+		
+		$settings = $this->get_default_settings();
+		
 		add_settings_field(
 			'url',
 			esc_html__( 'Endpoint URL', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$this->get_option_name(),
+			$settings[ 'url' ],
 			[
 				'label_for'   => 'url',
 				'input_type'  => 'text',
 				'description' => __( 'e.g. <code>https://REGION.api.cognitive.microsoft.com/</code>', 'classifai' ),
 			]
 		);
+		
 		add_settings_field(
 			'api-key',
 			esc_html__( 'API Key', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$this->get_option_name(),
+			$settings[ 'api_key' ],
 			[
 				'label_for'  => 'api_key',
 				'input_type' => 'password',
 			]
 		);
+		
 		add_settings_field(
 			'enable-image-captions',
 			esc_html__( 'Automatically Caption Images', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$this->get_option_name(),
+			$settings[ 'enable_image_captions' ],
 			[
 				'label_for'     => 'enable_image_captions',
 				'input_type'    => 'checkbox',
@@ -651,25 +663,13 @@ class ComputerVision extends Provider {
 				'description'   => __( 'Images will be captioned with alt text upon upload', 'classifai' ),
 			]
 		);
-		add_settings_field(
-			'caption-threshold',
-			esc_html__( 'Caption Confidence Threshold', 'classifai' ),
-			[ $this, 'render_input' ],
-			$this->get_option_name(),
-			$this->get_option_name(),
-			[
-				'label_for'     => 'caption_threshold',
-				'input_type'    => 'number',
-				'default_value' => 75,
-				'description'   => __( 'Minimum confidence score for automatically applied image captions, numeric value from 0-100. Recommended to be set to at least 75.', 'classifai' ),
-			]
-		);
+		
 		add_settings_field(
 			'enable-image-tagging',
 			esc_html__( 'Automatically Tag Images', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$this->get_option_name(),
+			$settings[ 'enable_image_captions' ],
 			[
 				'label_for'     => 'enable_image_tagging',
 				'input_type'    => 'checkbox',
@@ -677,12 +677,61 @@ class ComputerVision extends Provider {
 				'description'   => __( 'Images will be tagged upon upload', 'classifai' ),
 			]
 		);
+		
+		add_settings_field(
+			'enable-smart-cropping',
+			esc_html__( 'Enable smart cropping', 'classifai' ),
+			[ $this, 'render_input' ],
+			$this->get_option_name(),
+			$settings[ 'enable_smart_cropping' ],
+			[
+				'label_for'     => 'enable_smart_cropping',
+				'input_type'    => 'checkbox',
+				'default_value' => false,
+				'description'   => __(
+					'Crop images around a region of interest identified by ComputerVision',
+					'classifai'
+				),
+			]
+		);
+		
+		add_settings_field(
+			'enable-ocr',
+			esc_html__( 'Enable OCR', 'classifai' ),
+			[ $this, 'render_input' ],
+			$this->get_option_name(),
+			$settings[ 'enable_ocr' ],
+			[
+				'label_for'     => 'enable_ocr',
+				'input_type'    => 'checkbox',
+				'default_value' => false,
+				'description'   => __(
+					'Detect text in an image and store that as post content',
+					'classifai'
+				),
+			]
+		);
+		
+		add_settings_field(
+			'caption-threshold',
+			esc_html__( 'Caption Confidence Threshold', 'classifai' ),
+			[ $this, 'render_input' ],
+			$this->get_option_name(),
+			$settings[ 'captions_threshold' ],
+			[
+				'label_for'     => 'caption_threshold',
+				'input_type'    => 'number',
+				'default_value' => 75,
+				'description'   => __( 'Minimum confidence score for automatically applied image captions, numeric value from 0-100. Recommended to be set to at least 75.', 'classifai' ),
+			]
+		);
+		
 		add_settings_field(
 			'image-tag-threshold',
 			esc_html__( 'Tag Confidence Threshold', 'classifai' ),
 			[ $this, 'render_input' ],
 			$this->get_option_name(),
-			$this->get_option_name(),
+			$settings[ 'tag_threshold' ],
 			[
 				'label_for'     => 'tag_threshold',
 				'input_type'    => 'number',
@@ -702,44 +751,10 @@ class ComputerVision extends Provider {
 			esc_html__( 'Tag Taxonomy', 'classifai' ),
 			[ $this, 'render_select' ],
 			$this->get_option_name(),
-			$this->get_option_name(),
+			$settings[ 'image_tag_taxonomy' ],
 			[
 				'label_for' => 'image_tag_taxonomy',
 				'options'   => $options,
-			]
-		);
-
-		add_settings_field(
-			'enable-smart-cropping',
-			esc_html__( 'Enable smart cropping', 'classifai' ),
-			[ $this, 'render_input' ],
-			$this->get_option_name(),
-			$this->get_option_name(),
-			[
-				'label_for'     => 'enable_smart_cropping',
-				'input_type'    => 'checkbox',
-				'default_value' => false,
-				'description'   => __(
-					'Crop images around a region of interest identified by ComputerVision',
-					'classifai'
-				),
-			]
-		);
-
-		add_settings_field(
-			'enable-ocr',
-			esc_html__( 'Enable OCR', 'classifai' ),
-			[ $this, 'render_input' ],
-			$this->get_option_name(),
-			$this->get_option_name(),
-			[
-				'label_for'     => 'enable_ocr',
-				'input_type'    => 'checkbox',
-				'default_value' => false,
-				'description'   => __(
-					'Detect text in an image and store that as post content',
-					'classifai'
-				),
 			]
 		);
 	}

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -631,7 +631,7 @@ class ComputerVision extends Provider {
 	 */
 	public function setup_fields_sections() {
 		add_settings_section( $this->get_option_name(), $this->provider_service_name, '', $this->get_option_name() );
-		$settings = $this->get_default_settings();
+		$default_settings = $this->get_default_settings();
 		add_settings_field(
 			'url',
 			esc_html__( 'Endpoint URL', 'classifai' ),
@@ -641,7 +641,7 @@ class ComputerVision extends Provider {
 			[
 				'label_for'     => 'url',
 				'input_type'    => 'text',
-				'default_value' => $settings['url'],
+				'default_value' => $default_settings['url'],
 				'description'   => __( 'e.g. <code>https://REGION.api.cognitive.microsoft.com/</code>', 'classifai' ),
 			]
 		);
@@ -654,7 +654,7 @@ class ComputerVision extends Provider {
 			[
 				'label_for'     => 'api_key',
 				'input_type'    => 'password',
-				'default_value' => $settings['api_key'],
+				'default_value' => $default_settings['api_key'],
 			]
 		);
 		add_settings_field(
@@ -666,7 +666,7 @@ class ComputerVision extends Provider {
 			[
 				'label_for'     => 'enable_image_captions',
 				'input_type'    => 'checkbox',
-				'default_value' => $settings['enable_image_captions'],
+				'default_value' => $default_settings['enable_image_captions'],
 				'description'   => __( 'Images will be captioned with alt text upon upload', 'classifai' ),
 			]
 		);
@@ -679,7 +679,7 @@ class ComputerVision extends Provider {
 			[
 				'label_for'     => 'caption_threshold',
 				'input_type'    => 'number',
-				'default_value' => $settings['caption_threshold'],
+				'default_value' => $default_settings['caption_threshold'],
 				'description'   => __( 'Minimum confidence score for automatically applied image captions, numeric value from 0-100. Recommended to be set to at least 75.', 'classifai' ),
 			]
 		);
@@ -692,7 +692,7 @@ class ComputerVision extends Provider {
 			[
 				'label_for'     => 'enable_image_tagging',
 				'input_type'    => 'checkbox',
-				'default_value' => $settings['enable_image_tagging'],
+				'default_value' => $default_settings['enable_image_tagging'],
 				'description'   => __( 'Images will be tagged upon upload', 'classifai' ),
 			]
 		);
@@ -705,7 +705,7 @@ class ComputerVision extends Provider {
 			[
 				'label_for'     => 'tag_threshold',
 				'input_type'    => 'number',
-				'default_value' => $settings['tag_threshold'],
+				'default_value' => $default_settings['tag_threshold'],
 				'description'   => __( 'Minimum confidence score for automatically applied image tags, numeric value from 0-100. Recommended to be set to at least 70.', 'classifai' ),
 			]
 		);
@@ -724,7 +724,7 @@ class ComputerVision extends Provider {
 			[
 				'label_for'     => 'image_tag_taxonomy',
 				'options'       => $options,
-				'default_value' => $settings['image_tag_taxonomy'],
+				'default_value' => $default_settings['image_tag_taxonomy'],
 			]
 		);
 		add_settings_field(
@@ -736,7 +736,7 @@ class ComputerVision extends Provider {
 			[
 				'label_for'     => 'enable_smart_cropping',
 				'input_type'    => 'checkbox',
-				'default_value' => $settings['enable_smart_cropping'],
+				'default_value' => $default_settings['enable_smart_cropping'],
 				'description'   => __(
 					'Crop images around a region of interest identified by ComputerVision',
 					'classifai'
@@ -752,7 +752,7 @@ class ComputerVision extends Provider {
 			[
 				'label_for'     => 'enable_ocr',
 				'input_type'    => 'checkbox',
-				'default_value' => $settings['enable_ocr'],
+				'default_value' => $default_settings['enable_ocr'],
 				'description'   => __(
 					'Detect text in an image and store that as post content',
 					'classifai'

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -48,16 +48,16 @@ class ComputerVision extends Provider {
 	 */
 	private function get_default_settings() {
 		return [
-			'valid' => false,
-			'url' => '',
-			'api_key' => '',
+			'valid'                 => false,
+			'url'                   => '',
+			'api_key'               => '',
 			'enable_image_captions' => true,
-			'enable_image_tagging' => true,
+			'enable_image_tagging'  => true,
 			'enable_smart_cropping' => false,
-			'enable_ocr' => false,
-			'caption_threshold' => 75,
-			'tag_threshold' => 70,
-			'image_tag_taxonomy' => 'classifai-image-tags',
+			'enable_ocr'            => false,
+			'caption_threshold'     => 75,
+			'tag_threshold'         => 70,
+			'image_tag_taxonomy'    => 'classifai-image-tags',
 		];
 	}
 

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -671,6 +671,19 @@ class ComputerVision extends Provider {
 			]
 		);
 		add_settings_field(
+			'caption-threshold',
+			esc_html__( 'Caption Confidence Threshold', 'classifai' ),
+			[ $this, 'render_input' ],
+			$this->get_option_name(),
+			$this->get_option_name(),
+			[
+				'label_for'     => 'caption_threshold',
+				'input_type'    => 'number',
+				'default_value' => $settings['caption_threshold'],
+				'description'   => __( 'Minimum confidence score for automatically applied image captions, numeric value from 0-100. Recommended to be set to at least 75.', 'classifai' ),
+			]
+		);
+		add_settings_field(
 			'enable-image-tagging',
 			esc_html__( 'Automatically Tag Images', 'classifai' ),
 			[ $this, 'render_input' ],
@@ -681,6 +694,37 @@ class ComputerVision extends Provider {
 				'input_type'    => 'checkbox',
 				'default_value' => $settings['enable_image_tagging'],
 				'description'   => __( 'Images will be tagged upon upload', 'classifai' ),
+			]
+		);
+		add_settings_field(
+			'image-tag-threshold',
+			esc_html__( 'Tag Confidence Threshold', 'classifai' ),
+			[ $this, 'render_input' ],
+			$this->get_option_name(),
+			$this->get_option_name(),
+			[
+				'label_for'     => 'tag_threshold',
+				'input_type'    => 'number',
+				'default_value' => $settings['tag_threshold'],
+				'description'   => __( 'Minimum confidence score for automatically applied image tags, numeric value from 0-100. Recommended to be set to at least 70.', 'classifai' ),
+			]
+		);
+		// What taxonomy should we tag images with?
+		$attachment_taxonomies = get_object_taxonomies( 'attachment', 'objects' );
+		$options               = [];
+		foreach ( $attachment_taxonomies as $name => $taxonomy ) {
+			$options[ $name ] = $taxonomy->label;
+		}
+		add_settings_field(
+			'image-tag-taxonomy',
+			esc_html__( 'Tag Taxonomy', 'classifai' ),
+			[ $this, 'render_select' ],
+			$this->get_option_name(),
+			$this->get_option_name(),
+			[
+				'label_for'     => 'image_tag_taxonomy',
+				'options'       => $options,
+				'default_value' => $settings['image_tag_taxonomy'],
 			]
 		);
 		add_settings_field(
@@ -713,50 +757,6 @@ class ComputerVision extends Provider {
 					'Detect text in an image and store that as post content',
 					'classifai'
 				),
-			]
-		);
-		add_settings_field(
-			'caption-threshold',
-			esc_html__( 'Caption Confidence Threshold', 'classifai' ),
-			[ $this, 'render_input' ],
-			$this->get_option_name(),
-			$this->get_option_name(),
-			[
-				'label_for'     => 'caption_threshold',
-				'input_type'    => 'number',
-				'default_value' => $settings['caption_threshold'],
-				'description'   => __( 'Minimum confidence score for automatically applied image captions, numeric value from 0-100. Recommended to be set to at least 75.', 'classifai' ),
-			]
-		);
-		add_settings_field(
-			'image-tag-threshold',
-			esc_html__( 'Tag Confidence Threshold', 'classifai' ),
-			[ $this, 'render_input' ],
-			$this->get_option_name(),
-			$this->get_option_name(),
-			[
-				'label_for'     => 'tag_threshold',
-				'input_type'    => 'number',
-				'default_value' => $settings['tag_threshold'],
-				'description'   => __( 'Minimum confidence score for automatically applied image tags, numeric value from 0-100. Recommended to be set to at least 70.', 'classifai' ),
-			]
-		);
-		// What taxonomy should we tag images with?
-		$attachment_taxonomies = get_object_taxonomies( 'attachment', 'objects' );
-		$options               = [];
-		foreach ( $attachment_taxonomies as $name => $taxonomy ) {
-			$options[ $name ] = $taxonomy->label;
-		}
-		add_settings_field(
-			'image-tag-taxonomy',
-			esc_html__( 'Tag Taxonomy', 'classifai' ),
-			[ $this, 'render_select' ],
-			$this->get_option_name(),
-			$this->get_option_name(),
-			[
-				'label_for'     => 'image_tag_taxonomy',
-				'options'       => $options,
-				'default_value' => $settings['image_tag_taxonomy'],
 			]
 		);
 	}


### PR DESCRIPTION
### Description of the Change

Addressing TODO from https://github.com/10up/classifai/issues/260

```
public function reset_settings() {
    // TODO: Implement reset_settings() method.
}
```

### Alternate Designs

n/a

### Benefits

Addressing issue related to resolving TODOs in the repository. Presumably this function will allow for a quick reset of the settings back to the default so that the user doesn't have to go through resetting settings manually.

### Possible Drawbacks

none identified

### Verification Process

I looked the serialized array data in the database for what is there when the plugin is activated upon a fresh install and modelled the reset_settings() method off of that data and the includes/Classifai/Providers/Watson/NLU.php reset_settings() method.

Not sure if there is more that you are looking for or if you would also like a button on this page that triggers an event to reset the settings. If there is something like that you are looking for please let me know :)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

https://github.com/10up/classifai/issues/260

### Changelog Entry

Addressed TODO to implement ComputerVision::reset_settings() method
