### PR TITLE
Update hooks priority for `wp_generate_attachment_metadata` 

### DIFF
--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -483,3 +483,29 @@ function get_largest_size_and_dimensions_image_url( $full_image, $full_url, $met
 
 	return null;
 }
+
+/**
+ * Allows returning modified image URL for a given attachment.
+ *
+ * @param int $post_id Post ID.
+ *
+ * @return mixed
+ */
+function get_modified_image_source_url( $post_id ) {
+	/**
+	 * Filter to modify image source URL in order to allow scanning images,
+	 * stored on third party storages that cannot be used by
+	 * helper function `get_largest_acceptable_image_url()` to determine `filesize()` locally.
+	 *
+	 * Default is null, return filtered string to allow classifying image on external source.
+	 *
+	 * @since 1.6.0
+	 * @hook classifai_generate_image_alt_tags_source_url
+	 *
+	 * @param {mixed} $image_url New image path for given attachment ID.
+	 * @param {int}   $post_id   The ID of the attachment to be used in classification.
+	 *
+	 * @return {mixed} NULL or filtered URl for given attachment id.
+	 */
+	return apply_filters( 'classifai_generate_image_alt_tags_source_url', null, $post_id );
+}

--- a/tests/Classifai/PostClassifierTest.php
+++ b/tests/Classifai/PostClassifierTest.php
@@ -125,6 +125,8 @@ class PostClassifierTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_can_classify_post() {
+		$this->test_can_have_empty_assertion();
+
 		if ( defined( 'WATSON_USERNAME' ) && ! empty( WATSON_USERNAME ) && defined( 'WATSON_PASSWORD' ) && ! empty( WATSON_PASSWORD ) ) {
 			$text = 'The quick brown fox jumps over the lazy dog.';
 			$post_id = $this->factory->post->create( [
@@ -139,6 +141,8 @@ class PostClassifierTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_can_classify_and_link_post() {
+		$this->test_can_have_empty_assertion();
+
 		if ( defined( 'WATSON_USERNAME' ) && ! empty( WATSON_USERNAME ) && defined( 'WATSON_PASSWORD' ) && ! empty( WATSON_PASSWORD ) ) {
 			$text = <<<TEXT
     Albert Einstein (/ˈaɪnstaɪn/; German: [ˈalbɛɐ̯t
@@ -175,6 +179,8 @@ TEXT;
 	}
 
 	function test_it_only_classifies_configured_features() {
+		$this->test_can_have_empty_assertion();
+
 		if ( defined( 'WATSON_USERNAME' ) && ! empty( WATSON_USERNAME ) && defined( 'WATSON_PASSWORD' ) && ! empty( WATSON_PASSWORD ) ) {
 			$text = <<<TEXT
     Albert Einstein (/ˈaɪnstaɪn/; German: [ˈalbɛɐ̯t
@@ -216,6 +222,15 @@ TEXT;
 
 			$actual = wp_get_object_terms( $post_id, [ WATSON_ENTITY_TAXONOMY ] );
 			$this->assertEmpty( $actual );
+		}
+	}
+
+	/**
+	 * Set test to not perform assertion to fix risky tests.
+	 */
+	public function test_can_have_empty_assertion() {
+		if ( ! defined( 'WATSON_USERNAME' ) && ! defined( 'WATSON_PASSWORD' ) ) {
+			$this->expectNotToPerformAssertions();
 		}
 	}
 }

--- a/tests/Classifai/Providers/Azure/ComputerVisionTest.php
+++ b/tests/Classifai/Providers/Azure/ComputerVisionTest.php
@@ -94,9 +94,8 @@ class ComputerVisionTest extends WP_UnitTestCase {
 		// Instantiate the hooks
 		$this->get_computer_vision()->register();
 
-		$attachment = $this->factory->attachment->create_and_get();
-		wp_generate_attachment_metadata( $attachment->ID, DIR_TESTDATA .'/images/33772.jpg' );
-		$meta = wp_get_attachment_metadata( $attachment->ID );
+		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/33772.jpg' );
+		$meta       = wp_get_attachment_metadata( $attachment );
 		$this->assertNotFalse( $meta );
 	}
 }

--- a/tests/Classifai/Watson/APIRequestTest.php
+++ b/tests/Classifai/Watson/APIRequestTest.php
@@ -19,6 +19,8 @@ class APIRequestTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_uses_constant_username_if_present() {
+		$this->test_can_have_empty_assertion();
+
 		if ( defined( 'WATSON_USERNAME' ) ) {
 			$actual = $this->request->get_username();
 			$this->assertEquals( WATSON_USERNAME, $actual );
@@ -38,6 +40,8 @@ class APIRequestTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_constant_password_if_present() {
+		$this->test_can_have_empty_assertion();
+
 		if ( defined( 'WATSON_PASSWORD' ) ) {
 			$actual = $this->request->get_password();
 			$this->assertEquals( WATSON_PASSWORD, $actual );
@@ -81,6 +85,8 @@ class APIRequestTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_can_make_an_api_request() {
+		$this->test_can_have_empty_assertion();
+
 		if ( defined( 'WATSON_USERNAME' ) && defined( 'WATSON_PASSWORD' ) ) {
 			$url = 'https://gateway.watsonplatform.net/natural-language-understanding/api/v1/analyze?version=2017-02-27';
 			$options = [
@@ -98,6 +104,15 @@ class APIRequestTest extends \WP_UnitTestCase {
 
 			$actual = $this->request->post( $url, $options );
 			$this->assertTrue( ! empty( $actual['keywords'] ) );
+		}
+	}
+
+	/**
+	 * Set test to not perform assertion to fix risky tests.
+	 */
+	public function test_can_have_empty_assertion() {
+		if ( ! defined( 'WATSON_USERNAME' ) && ! defined( 'WATSON_PASSWORD' ) ) {
+			$this->expectNotToPerformAssertions();
 		}
 	}
 

--- a/tests/Classifai/Watson/ClassifierTest.php
+++ b/tests/Classifai/Watson/ClassifierTest.php
@@ -32,6 +32,10 @@ class ClassifierTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_can_classify_text() {
+		if ( ! defined( 'WATSON_USERNAME' ) && ! defined( 'WATSON_PASSWORD' ) ) {
+			$this->expectNotToPerformAssertions();
+		}
+
 		if ( defined( 'WATSON_USERNAME' ) && ! empty( WATSON_USERNAME ) && defined( 'WATSON_PASSWORD' ) && ! empty( WATSON_PASSWORD ) ) {
 			$text = 'The quick brown fox jumps over the lazy dog.';
 			$actual = $this->classifier->classify( $text );


### PR DESCRIPTION
- Update hooks priority for `wp_generate_attachment_metadata` to work with azure storage
- Move `classifai_generate_image_alt_tags_source_url` filter to helper function
- Use `get_modified_image_source_url` where rescanning is done local file


### Description of the Change

- ClassifAI is generating tags on `10` [priority](https://github.com/10up/classifai/blob/develop/includes/Classifai/Providers/Azure/ComputerVision.php#L68), while the storage plugin uploads image to storage blob and deletes locally on [priority](https://github.com/10up/windows-azure-storage/blob/develop/windows-azure-storage.php#L125-L127) `9`, by the time it is getting there to generate tags, the local image is gone and alt text is not generated, reducing priority of the hook will allow it to generate the text and then upload to storage.

- I found a related PR https://github.com/10up/classifai/pull/250 where the hook priority was increased due to similar issues, setting hook priority to be in following order `smart_crop` at `7` and `alt_text` at `8` should hopefully fix issues both issues.

- The above changes only fix issue when the image is being uploaded, it doesn't work when we try to generate/re-generate/rescan image tags from media modal for an existing image, adding the filter introduced in https://github.com/10up/classifai/pull/217 it other places will help with the same.

### Verification Process

- Tested on project that was facing this issue, applying these changes fixed the alt generation for images and image was successfully uploaded to Azure storage as well.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

- Doesn't have one right now, happy to open one if needed.
