### PR TITLE
Fix: OCR block stops working on WP 5.7

### DIFF
--- a/includes/Classifai/Providers/Azure/OCR.php
+++ b/includes/Classifai/Providers/Azure/OCR.php
@@ -29,7 +29,7 @@ class OCR {
 	 *
 	 * @var string
 	 */
-	const API_PATH = 'vision/v3.1/ocr/';
+	const API_PATH = 'vision/v3.2/ocr/';
 
 	/**
 	 * ComputerVision settings.

--- a/src/js/editor-ocr.js
+++ b/src/js/editor-ocr.js
@@ -51,12 +51,8 @@ const getImageOcrScannedText = async ( imageId ) => {
  * @param {int} imageId - Image ID.
  * @param {string} scannedText - Text to insert to editor.
 */
-const insertOcrScannedText = async ( clientId, imageId, scannedText = '' ) => {
+const insertOcrScannedText = async ( clientId, imageId, scannedText ) => {
 	const { getBlockIndex } = select( 'core/block-editor' );
-
-	if( ! scannedText ) {
-		scannedText = await getImageOcrScannedText( imageId );
-	}
 
 	if( ! scannedText ) {
 		return;

--- a/src/js/editor-ocr.js
+++ b/src/js/editor-ocr.js
@@ -97,18 +97,18 @@ const imageOcrControl = createHigherOrderComponent( ( BlockEdit ) => { // eslint
 			return <BlockEdit {...props} />;
 		}
 
-		if ( ! attributes.orcChecked && attributes.id ) {
+		if ( ! attributes.ocrChecked && attributes.id ) {
 			getImageOcrScannedText( attributes.id )
 				.then( data => {
 					if ( data ) {
 						setAttributes( {
 							ocrScannedText: data,
-							orcChecked: true,
+							ocrChecked: true,
 						} );
 						setModalOpen( true );
 					} else {
 						setAttributes( {
-							orcChecked: true,
+							ocrChecked: true,
 						} );
 					}
 				} );
@@ -174,7 +174,7 @@ const modifyImageAttributes = ( settings, name ) => {
 			type: 'string',
 			default: ''
 		};
-		settings.attributes.orcChecked = {
+		settings.attributes.ocrChecked = {
 			type: 'boolean',
 			default: false,
 		};


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Due to changes of Gutenberg shipped in WP 5.7, the OCR block has been stopped working:

- The modal doesn't show up after inserting an image into the editor.
- The OCR text inserter inserts only group block, not the text inside it.

This PR fixes those issues by:

- Removing the usage of `registerPlugin`, moving the modal into the image control.
- Use `await` to ensure the text block is inserted only after the group block has been inserted into the editor.
- Simply the modal logic.

### Verification Process

1. Setup and config the Image processing API, enable OCR feature.
2. Make sure the image is accessible from the Azure server.
3. Insert a new image that contains text, see:
  - the modal shows up after the image has been inserted into the editor.
  - Click on the Insert button, see a new group contains a paragraph with the text on the image as content.
  - Click on the image, see a new disabled button (with clipboard icon).
  - Delete the group block, click on the image again, see the clipboard button enabled.
  - Click on that button, see the new description as using modal above.

Please check OCR functionality on both WP 5.6 and 5.7.

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
