### PR TITLE
fix: hide Scan Text checkbox if OCR is disabled

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -229,12 +229,14 @@ class ComputerVision extends Provider {
 					<?php echo esc_html( $tags ); ?>
 				</label>
 			</div>
+		<?php if ( $settings && isset( $settings['enable_ocr'] ) && '1' === $settings['enable_ocr'] ) : ?>
 			<div class="misc-pub-section">
 				<label for="rescan-ocr">
 					<input type="checkbox" value="yes" id="rescan-ocr" name="rescan-ocr"/>
 					<?php echo esc_html( $ocr ); ?>
 				</label>
 			</div>
+		<?php endif; ?>
 		<?php if ( $settings && isset( $settings['enable_smart_cropping'] ) && '1' === $settings['enable_smart_cropping'] ) : ?>
 			<div class="misc-pub-section">
 				<label for="rescan-smart-crop">


### PR DESCRIPTION
Resolves #279 

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Hides the 'Scan Text' checkbox field if OCR is disabled.
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->


### Verification Process
How did you verify that all new functionality works as expected?
Enabled/Disabled OCR setting to verify if the Scan Text checkbox was shown or hidden.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry
Fix - Hides the Scan Text checkbox field on the media edit page when OCR is disabled
