### PR TITLE
Added function to retrieve filterable post statuses for classification.

### DIFF
--- a/includes/Classifai/Admin/SavePostHandler.php
+++ b/includes/Classifai/Admin/SavePostHandler.php
@@ -61,7 +61,7 @@ class SavePostHandler {
 		$supported     = \Classifai\get_supported_post_types();
 		$post_type     = get_post_type( $post_id );
 		$post_status   = get_post_status( $post_id );
-		$post_statuses = $this->get_post_statuses( $post_type, $post_id );
+		$post_statuses = \Classifai\get_supported_post_statuses();
 
 		// Process posts in allowed post statuses, supported items and only if features are enabled
 		if ( in_array( $post_status, $post_statuses, true ) && in_array( $post_type, $supported, true ) && \Classifai\language_processing_features_enabled() ) {
@@ -185,26 +185,6 @@ class SavePostHandler {
 			</div>
 			<?php
 		}
-	}
-
-	/**
-	 * Get the post statuses allowed to classify content
-	 *
-	 * @since 1.7.1 @TODO: Ensure this is updated to the version
-	 * @hook classifai_post_statuses
-	 *
-	 * @param string $post_type     The current post type.
-	 * @param int    $post_id       The current post ID.
-	 *
-	 * @return array $post_statuses The filtered array of post statuses.
-	 */
-	public function get_post_statuses( $post_type, $post_id ) {
-		// Defaults to published content only
-		$post_statuses = [ 'publish' ];
-
-		$post_statuses = apply_filters( 'classifai_post_statuses', $post_statuses, $post_type, $post_id );
-
-		return $post_statuses;
 	}
 
 	/**

--- a/includes/Classifai/Admin/SavePostHandler.php
+++ b/includes/Classifai/Admin/SavePostHandler.php
@@ -58,12 +58,13 @@ class SavePostHandler {
 			return;
 		}
 
-		$supported   = \Classifai\get_supported_post_types();
-		$post_type   = get_post_type( $post_id );
-		$post_status = get_post_status( $post_id );
+		$supported     = \Classifai\get_supported_post_types();
+		$post_type     = get_post_type( $post_id );
+		$post_status   = get_post_status( $post_id );
+		$post_statuses = $this->get_post_statuses( $post_type, $post_id );
 
-		// Only process published, supported items and only if features are enabled
-		if ( 'publish' === $post_status && in_array( $post_type, $supported, true ) && \Classifai\language_processing_features_enabled() ) {
+		// Process posts in allowed post statuses, supported items and only if features are enabled
+		if ( in_array( $post_status, $post_statuses, true ) && in_array( $post_type, $supported, true ) && \Classifai\language_processing_features_enabled() ) {
 			$this->classify( $post_id );
 		}
 	}
@@ -184,6 +185,26 @@ class SavePostHandler {
 			</div>
 			<?php
 		}
+	}
+
+	/**
+	 * Get the post statuses allowed to classify content
+	 *
+	 * @since 1.7.1 @TODO: Ensure this is updated to the version
+	 * @hook classifai_post_statuses
+	 *
+	 * @param string $post_type     The current post type.
+	 * @param int    $post_id       The current post ID.
+	 *
+	 * @return array $post_statuses The filtered array of post statuses.
+	 */
+	public function get_post_statuses( $post_type, $post_id ) {
+		// Defaults to published content only
+		$post_statuses = [ 'publish' ];
+
+		$post_statuses = apply_filters( 'classifai_post_statuses', $post_statuses, $post_type, $post_id );
+
+		return $post_statuses;
 	}
 
 	/**

--- a/includes/Classifai/Admin/SavePostHandler.php
+++ b/includes/Classifai/Admin/SavePostHandler.php
@@ -63,6 +63,21 @@ class SavePostHandler {
 		$post_status   = get_post_status( $post_id );
 		$post_statuses = \Classifai\get_supported_post_statuses();
 
+
+		/**
+		 * Filter post statuses for post type or ID.
+		 *
+		 * @since 1.0.0
+		 * @hook classifai_post_statuses_for_post_type_or_id
+		 *
+		 * @param {array} $post_statuses Array of post statuses to be classified with language processing.
+		 * @param {string} $post_type The post type.
+		 * @param {int} $post_id The post ID.
+		 *
+		 * @return {array} Array of post statuses.
+		 */
+		$post_statuses = apply_filters( 'classifai_post_statuses_for_post_type_or_id', $post_statuses, $post_type, $post_id );
+
 		// Process posts in allowed post statuses, supported items and only if features are enabled
 		if ( in_array( $post_status, $post_statuses, true ) && in_array( $post_type, $supported, true ) && \Classifai\language_processing_features_enabled() ) {
 			$this->classify( $post_id );

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -198,6 +198,29 @@ function get_post_types_for_language_settings() {
 }
 
 /**
+ * Get post types we want to show in the language processing settings
+ *
+ * @since 1.6.0
+ *
+ * @return array
+ */
+function get_post_statuses_for_language_settings() {
+	$post_statuses = get_post_statuses();
+
+	/**
+	 * Filter post statuses shown in language processing settings.
+	 *
+	 * @since 1.7.1 @TODO: Ensure this is updated to the correct version
+	 * @hook classifai_language_settings_post_statuses
+	 *
+	 * @param {array} $post_statuses Array of post statuses to show in language processing settings.
+	 *
+	 * @return {array} Array of post statuses.
+	 */
+	return apply_filters( 'classifai_language_settings_post_statuses', $post_statuses );
+}
+
+/**
  * The list of post types that get the ClassifAI taxonomies. Defaults
  * to 'post'.
  *
@@ -230,6 +253,41 @@ function get_supported_post_types() {
 	$post_types = apply_filters( 'classifai_post_types', $post_types );
 
 	return $post_types;
+}
+
+/**
+ * The list of post statuses that get the ClassifAI taxonomies. Defaults
+ * to 'publish'.
+ *
+ * return array
+ */
+function get_supported_post_statuses() {
+	$classifai_settings = get_plugin_settings( 'language_processing' );
+
+	if ( empty( $classifai_settings ) ) {
+		$post_statuses = [ 'publish' ];
+	} else {
+		$post_statuses = [];
+		foreach ( $classifai_settings['post_statuses'] as $post_status => $enabled ) {
+			if ( ! empty( $enabled ) ) {
+				$post_statuses[] = $post_status;
+			}
+		}
+	}
+
+	/**
+	 * Filter post statuses supported for language processing.
+	 *
+	 * @since 1.0.0
+	 * @hook classifai_post_statuses
+	 *
+	 * @param {array} $post_types Array of post statuses to be classified with language processing.
+	 *
+	 * @return {array} Array of post statuses.
+	 */
+	$post_statuses = apply_filters( 'classifai_post_statuses', $post_statuses );
+
+	return $post_statuses;
 }
 
 /**

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -614,6 +614,16 @@ class NLU extends Provider {
 			}
 		}
 
+		// Sanitize the post statuses checkboxes
+		$post_statuses = get_post_statuses_for_language_settings();
+		foreach ( $post_statuses as $post_status_key => $post_status_value ) {
+			if ( isset( $settings['post_statuses'][ $post_status_key ] ) ) {
+				$new_settings['post_statuses'][ $post_status_key ] = absint( $settings['post_statuses'][ $post_status_key ] );
+			} else {
+				$new_settings['post_statuses'][ $post_status_key ] = null;
+			}
+		}
+
 		foreach ( $this->nlu_features as $feature => $labels ) {
 			// Set the enabled flag.
 			if ( isset( $settings['features'][ $feature ] ) ) {

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -9,6 +9,7 @@ use Classifai\Admin\SavePostHandler;
 use Classifai\Providers\Provider;
 use Classifai\Taxonomy\TaxonomyFactory;
 use function Classifai\get_post_types_for_language_settings;
+use function Classifai\get_post_statuses_for_language_settings;
 
 class NLU extends Provider {
 
@@ -324,6 +325,17 @@ class NLU extends Provider {
 			]
 		);
 
+		add_settings_field(
+			'post-statuses',
+			esc_html__( 'Post Statuses to Classify', 'classifai' ),
+			[ $this, 'render_post_statuses_checkboxes' ],
+			$this->get_option_name(),
+			$this->get_option_name(),
+			[
+				'option_index' => 'post_statuses',
+			]
+		);
+
 		foreach ( $this->nlu_features as $feature => $labels ) {
 			add_settings_field(
 				$feature,
@@ -402,6 +414,33 @@ class NLU extends Provider {
 			echo '<li>';
 			$this->render_input( $args );
 			echo '<label for="classifai-settings-' . esc_attr( $post_type->name ) . '">' . esc_html( $post_type->label ) . '</label>';
+			echo '</li>';
+		}
+
+		echo '</ul>';
+	}
+
+
+	/**
+	 * Render the post statuses checkbox array.
+	 *
+	 * @param array $args Settings for the input
+	 *
+	 * @return void
+	 */
+	public function render_post_statuses_checkboxes( $args ) {
+		echo '<ul>';
+		$post_statuses = get_post_statuses_for_language_settings();
+		foreach ( $post_statuses as $post_status_key => $post_status_label ) {
+			$args = [
+				'label_for'    => $post_status_key,
+				'option_index' => 'post_statuses',
+				'input_type'   => 'checkbox',
+			];
+
+			echo '<li>';
+			$this->render_input( $args );
+			echo '<label for="classifai-settings-' . esc_attr( $post_status_key ) . '">' . esc_html( $post_status_label ) . '</label>';
 			echo '</li>';
 		}
 

--- a/tests/Classifai/Admin/SavePostHandlerTest.php
+++ b/tests/Classifai/Admin/SavePostHandlerTest.php
@@ -26,6 +26,42 @@ class SavePostHandlerTest extends WP_UnitTestCase {
 		$this->save_post_handler = new SavePostHandler();
 	}
 
+	function test_get_post_statuses() {
+		global $wp_filter;
+
+		$saved_filters = $wp_filter['classifai_post_statuses'] ?? null;
+		unset( $wp_filter['classifai_post_statuses'] );
+
+		$default_post_statuses_array = array(
+			'publish',
+		);
+
+		$post_type = 'post';
+		$post_id   = 1;
+
+		$this->assertEqualSets( $default_post_statuses_array, $this->save_post_handler->get_post_statuses( $post_type, $post_id ) );
+
+		$filtered_post_statuses_array = array(
+			'publish',
+			'draft',
+			'future',
+		);
+
+		add_filter(
+			'classifai_post_statuses',
+			function( $post_statuses, $post_type, $post_id ) use ( $filtered_post_statuses_array ) {
+				return $filteredpost_statuses_array;
+			},
+			10,
+			3
+		);
+		$this->assertEqualSets( $post_statuses_array, $this->save_post_handler->get_post_statuses( $post_type, $post_id ) );
+
+		if ( ! is_null( $saved_filters ) ) {
+			$wp_filter['classifai_post_statuses'] = $saved_filters;
+		}
+	}
+
 	function test_is_rest_route() {
 		global $wp_filter;
 


### PR DESCRIPTION
### Description of the Change

Adds a filter to allow post statuses other than `publish` to be allowed to classify content.

### Benefits

Users will be able to save content in other post statuses - e.g. `draft` and this content will be classified.

### Possible Drawbacks

If `publish` is removed from the array, content will not be classified on publication.

### Verification Process

I ran the following code in a MU plugin to modify the post statuses:

```
add_action(
	'after_setup_theme',
	function() {
		add_filter(
			'classifai_post_statuses_for_post_type_or_id',
			function( $post_statuses, $post_type, $post_id ) {
				return array(
					'publish',
					'draft',
					'future',
				);
			},
			10,
			3
		);
	}
);
```

The resulting data upon saving a draft post was:

```
{"post_statuses":["publish","draft","future"],"post_status":"draft","post_type":"post","post_id":2285}
```

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

https://github.com/10up/classifai/issues/309

### Changelog Entry

Added: `classifai_post_statuses` filter; allows post statuses for content classification to be changed as required (but would apply to all post types).

Added: `classifai_post_statuses_for_post_type_or_id` filter; allows post statuses for content classification to be changed as required based on post type / post ID.
