### PR TITLE
Fix/classify post action

### DIFF
--- a/includes/Classifai/Admin/BulkActions.php
+++ b/includes/Classifai/Admin/BulkActions.php
@@ -122,6 +122,12 @@ class BulkActions {
 	 * @return array
 	 */
 	public function register_row_action( $actions, $post ) {
+		$post_types = get_supported_post_types();
+
+		if ( ! in_array( $post->post_type, $post_types, true ) ) {
+			return $actions;
+		}
+
 		$actions['classify'] = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url( wp_nonce_url( admin_url( sprintf( 'edit.php?action=classify&ids=%d&post_type=%s', $post->ID, $post->post_type ) ), 'bulk-posts' ) ),

--- a/includes/Classifai/Admin/BulkActions.php
+++ b/includes/Classifai/Admin/BulkActions.php
@@ -72,6 +72,7 @@ class BulkActions {
 		if ( 'classify' !== $doaction ) {
 			return $redirect_to;
 		}
+
 		foreach ( $post_ids as $post_id ) {
 			$this->save_post_handler->classify( $post_id );
 		}
@@ -123,7 +124,7 @@ class BulkActions {
 	public function register_row_action( $actions, $post ) {
 		$actions['classify'] = sprintf(
 			'<a href="%s">%s</a>',
-			esc_url( wp_nonce_url( admin_url( 'edit.php?action=classify&ids=' . $post->ID ), 'bulk-posts' ) ),
+			esc_url( wp_nonce_url( admin_url( sprintf( 'edit.php?action=classify&ids=%d&post_type=%s', $post->ID, $post->post_type ) ), 'bulk-posts' ) ),
 			esc_html__( 'Classify', 'classifai' )
 		);
 


### PR DESCRIPTION
### Description of the Change

These changes address 2 issues with CPT.

1) Don't show the "Classify" action when the `post_type` is not supported. (`post_row_actions`, `page_row_actions` could allow to shown classify action on unregistered post type)
2) Pass `post_type` for individual classify action.  (eg: when you enable classify for the "page" and click on the row item, it doesn't work due to missing `post_type` on request.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Making ClassifAI work better in admin UI.

### Possible Drawbacks

Haven't seen any drawback, changes are relatively small.

### Verification Process

1) Register CPT: 
```
function setup_test_post_type() {
	$args = array(
		'public' => true,
		'label'  => esc_html__( 'FooBar', 'foobar' ),
	);
	register_post_type( 'foobar', $args );
}

add_action( 'init', 'setup_test_post_type' );
```
2) Enable ClassifAI for `foobar` only
3) Click to "Classify" action on `/wp-admin/edit.php?post_type=foobar` for a post
4) See "Classified 1 post." message.


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

I couldn't add tests at this time, but it might be worth adding some testing 🤷🏻‍♂️


### Changelog Entry

* Fix individual classify action.
