### PR TITLE
Classifai/Providers/Watson/NLU.php updates

### DIFF
--- a/includes/Classifai/Admin/SavePostHandler.php
+++ b/includes/Classifai/Admin/SavePostHandler.php
@@ -63,7 +63,6 @@ class SavePostHandler {
 		$post_status   = get_post_status( $post_id );
 		$post_statuses = \Classifai\get_supported_post_statuses();
 
-
 		/**
 		 * Filter post statuses for post type or ID.
 		 *

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -355,7 +355,7 @@ class ComputerVision extends Provider {
 			$this->ocr_processing( wp_get_attachment_metadata( $attachment_id ), $attachment_id, true );
 		}
 
-		if ( filter_input( INPUT_POST, 'rescan-pdf' ) ) {
+		if ( filter_input( INPUT_POST, 'rescan-pdf', FILTER_DEFAULT ) ) {
 			$this->read_pdf( $attachment_id );
 		}
 

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -355,7 +355,7 @@ class ComputerVision extends Provider {
 			$this->ocr_processing( wp_get_attachment_metadata( $attachment_id ), $attachment_id, true );
 		}
 
-		if ( filter_input( INPUT_POST, 'rescan-pdf', FILTER_DEFAULT ) ) {
+		if ( filter_input( INPUT_POST, 'rescan-pdf', FILTER_SANITIZE_STRING ) ) {
 			$this->read_pdf( $attachment_id );
 		}
 

--- a/includes/Classifai/Providers/Azure/Read.php
+++ b/includes/Classifai/Providers/Azure/Read.php
@@ -206,6 +206,7 @@ class Read {
 		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
 			$response = vip_safe_wp_remote_get( $operation_url );
 		} else {
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get -- use of `vip_safe_wp_remote_get` is done when available.
 			$response = wp_remote_get(
 				$operation_url,
 				[

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -105,7 +105,10 @@ class NLU extends Provider {
 	 * @return bool
 	 */
 	public function can_register() {
-		// TODO: Implement can_register() method.
+		if ( $this->nlu_authentication_check_failed( $this->get_settings() ) ) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -649,41 +649,6 @@ class NLU extends Provider {
 	}
 
 	/**
-	 * Hit license API to see if key/email is valid
-	 *
-	 * @param string $email Email address.
-	 * @param string $license_key License key.
-	 *
-	 * @return bool
-	 * @since  1.2
-	 *
-	 * @todo Is this function supposed to be here?
-	 */
-	public function check_license_key( $email, $license_key ) {
-
-		$request = wp_remote_post(
-			'https://classifaiplugin.com/wp-json/classifai-theme/v1/validate-license',
-			[
-				'timeout' => 10, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
-				'body'    => [
-					'license_key' => $license_key,
-					'email'       => $email,
-				],
-			]
-		);
-
-		if ( is_wp_error( $request ) ) {
-			return false;
-		}
-
-		if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * Provides debug information related to the provider.
 	 *
 	 * @param array|null $settings Settings array. If empty, settings will be retrieved.

--- a/tests/Classifai/Admin/SavePostHandlerTest.php
+++ b/tests/Classifai/Admin/SavePostHandlerTest.php
@@ -26,42 +26,6 @@ class SavePostHandlerTest extends WP_UnitTestCase {
 		$this->save_post_handler = new SavePostHandler();
 	}
 
-	function test_get_post_statuses() {
-		global $wp_filter;
-
-		$saved_filters = $wp_filter['classifai_post_statuses'] ?? null;
-		unset( $wp_filter['classifai_post_statuses'] );
-
-		$default_post_statuses_array = array(
-			'publish',
-		);
-
-		$post_type = 'post';
-		$post_id   = 1;
-
-		$this->assertEqualSets( $default_post_statuses_array, $this->save_post_handler->get_post_statuses( $post_type, $post_id ) );
-
-		$filtered_post_statuses_array = array(
-			'publish',
-			'draft',
-			'future',
-		);
-
-		add_filter(
-			'classifai_post_statuses',
-			function( $post_statuses, $post_type, $post_id ) use ( $filtered_post_statuses_array ) {
-				return $filteredpost_statuses_array;
-			},
-			10,
-			3
-		);
-		$this->assertEqualSets( $post_statuses_array, $this->save_post_handler->get_post_statuses( $post_type, $post_id ) );
-
-		if ( ! is_null( $saved_filters ) ) {
-			$wp_filter['classifai_post_statuses'] = $saved_filters;
-		}
-	}
-
 	function test_is_rest_route() {
 		global $wp_filter;
 

--- a/tests/Classifai/PostClassifierTest.php
+++ b/tests/Classifai/PostClassifierTest.php
@@ -2,6 +2,8 @@
 
 namespace Classifai;
 
+use Classifai\Taxonomy\TaxonomyFactory;
+
 class PostClassifierTest extends \WP_UnitTestCase {
 
 	public $classifier;
@@ -10,6 +12,8 @@ class PostClassifierTest extends \WP_UnitTestCase {
 		parent::setUp();
 
 		$this->classifier = new PostClassifier();
+		$this->taxonomy_factory = new TaxonomyFactory();
+		$this->taxonomy_factory->build_all();
 	}
 
 	function test_it_has_an_api_request() {


### PR DESCRIPTION

### Description of the Change

- Implement `can_register()` method for `Classifai/Providers/Watson/NLU.php`.
- Remove `check_license_key` from `Classifai/Providers/Watson/NLU.php`.


### Alternate Designs

N/A

### Benefits

- Doesn't load assets unless valid credentials exist.

### Possible Drawbacks

N/A

### Verification Process

- Not seeing errors after the change

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


### Applicable Issues

#260

### Changelog Entry

Implement `can_register` for NLU.
Remove unused `check_license_key` method.