### PR TITLE
Enhancement/266 A filter to manipulate the post statuses when classifying with Watson

### DIFF
--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -437,9 +437,22 @@ class ClassifaiCommand extends \WP_CLI_Command {
 	 * @return array
 	 */
 	private function get_posts_to_classify( $opts = [] ) {
+		/**
+		 * Filter post statuses when classifying with Watson.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_post_statuses_for_watson
+		 *
+		 * @param array $post_statuses Array of post statuses to be classified with language processing.
+		 * @param array $opts Options from WP CLI.
+		 *
+		 * @return array Array of post statuses.
+		 */
+		$post_statuses = apply_filters( 'classifai_post_statuses_for_watson', array( 'publish' ), $opts );
+
 		$query_params = [
 			'post_type'      => ! empty( $opts['post_type'] ) ? $opts['post_type'] : 'any',
-			'post_status'    => 'publish',
+			'post_status'    => $post_statuses,
 			'fields'         => 'ids',
 			'posts_per_page' => -1,
 		];


### PR DESCRIPTION
### Description of the Change

This PR introduces a filter to manipulate the post statuses of posts need to be classified with Watson.

<!-- Enter any applicable Issues here. Example: -->
Closes #266.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Added - A filter to manipulate post statuses to classify with Watson

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @
