### PR TITLE
fix/359: load previewer in NLU section only

### DIFF
--- a/includes/Classifai/Services/Service.php
+++ b/includes/Classifai/Services/Service.php
@@ -160,6 +160,8 @@ abstract class Service {
 							),
 						);
 						?>
+
+					<?php if ( 'watson_nlu' === $active_tab ) : ?>
 					<h2><?php esc_html_e( 'Preview Language Processing', 'classifai' ); ?></h2>
 					<div id="classifai-post-preview-controls">
 						<select id="classifai-preview-post-selector">
@@ -179,6 +181,7 @@ abstract class Service {
 							</div>
 						<?php endforeach; ?>
 					</div>
+					<?php endif; ?>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Adds a check to load previewer for the NLU admin section only.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #359 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - bug that loaded previewer on sections other than NLU


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @Sidsector9 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
