### PR TITLE
Fix Generate/Regenerate/Scan buttons for newly uploaded media.

### DIFF
--- a/src/js/media.js
+++ b/src/js/media.js
@@ -148,5 +148,10 @@
 		if ( wp.media.frame ) {
 			wp.media.frame.on( 'edit:attachment', handleButtonsClick );
 		}
+
+		// For new uploaded media.
+		if ( wp.Uploader && wp.Uploader.queue ) {
+			wp.Uploader.queue.on( 'reset', handleButtonsClick );
+		}
 	} );
 } )( jQuery );


### PR DESCRIPTION
### Description of the Change
As described in #304, generate/regenerate/rescan buttons are not working for newly uploaded images, This PR contains changes to make it work.

Closes #304

### How to test the Change
1. Create a new post.
2. Add Image block and click "Media Library" 
3. Switch to the "Upload files" tab in the media library.
4. Upload the image and wait for success and buttons in the attachment details sidebar.
5. Click on any Generate/Regenerate/Scan button and make sure it works fine. 

### Changelog Entry
> Fixed - Generate/Regenerate/Scan buttons for newly uploaded media.

### Credits
Props @iamdharmesh @jeffpaul @dkotter 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
