### PR TITLE
Update `yahnis-elsts/plugin-update-checker` from 4.6 to 4.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "license": "GPLv2",
   "require": {
     "php": ">=7.2",
-    "yahnis-elsts/plugin-update-checker": "4.6",
+    "yahnis-elsts/plugin-update-checker": "4.13",
     "ua-parser/uap-php": "dev-master"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1f2a9f8a955c4d41c55ed4966e61f972",
+    "content-hash": "d639edc8e5a46bb27962d4b225e48456",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -149,25 +149,26 @@
         },
         {
             "name": "yahnis-elsts/plugin-update-checker",
-            "version": "v4.6",
+            "version": "v4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/YahnisElsts/plugin-update-checker.git",
-                "reference": "45374e3c02126fbebebf0244c5d5da4c5e0166ac"
+                "reference": "6eb27a6911e0e0880d09e5b11f577d3f688f7da7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/YahnisElsts/plugin-update-checker/zipball/45374e3c02126fbebebf0244c5d5da4c5e0166ac",
-                "reference": "45374e3c02126fbebebf0244c5d5da4c5e0166ac",
+                "url": "https://api.github.com/repos/YahnisElsts/plugin-update-checker/zipball/6eb27a6911e0e0880d09e5b11f577d3f688f7da7",
+                "reference": "6eb27a6911e0e0880d09e5b11f577d3f688f7da7",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "php": ">=5.2.0"
             },
             "type": "library",
             "autoload": {
                 "files": [
-                    "plugin-update-checker.php"
+                    "load-v4p13.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -192,9 +193,9 @@
             ],
             "support": {
                 "issues": "https://github.com/YahnisElsts/plugin-update-checker/issues",
-                "source": "https://github.com/YahnisElsts/plugin-update-checker/tree/v4.6"
+                "source": "https://github.com/YahnisElsts/plugin-update-checker/tree/v4.13"
             },
-            "time": "2019-04-02T17:56:11+00:00"
+            "time": "2022-07-29T12:36:25+00:00"
         }
     ],
     "packages-dev": [
@@ -2694,7 +2695,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0"
+        "php": ">=7.2"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"


### PR DESCRIPTION
### Description of the Change

The Plugin Update Checker library we use is also used on a few other 10up projects. Some of those are running different versions though, leading to conflicts (especially when using composer to manage all dependencies of a project). This PR updates this library to the latest version, which will also be done in other repos that are using this library.

- [Distributor](https://github.com/10up/distributor/pull/937)
- [10up Experience](https://github.com/10up/10up-experience/pull/116)

Alternatively we could use something like [mozart](https://github.com/coenjacobs/mozart) or [PHP-Scoper](https://github.com/humbug/php-scoper) to add a distinct namespace to this dependency. I'm not opposed to this necessarily but because we're seeing conflicts with other plugins that we fully control, I like the idea of just ensuring all of those projects are using the same version.

### How to test the Change

1. Pull these changes down
2. Within the `classifai.php` file, set the version number to something lower, like 1.6.0
3. Ensure you have a proper license in place
4. Go to the plugins section and ensure you see an update notice for Classifai (may need to click the `Check for updates` link; also ensure the plugin is active)
5. Click on the `View version X.X.X details` link and ensure you see proper details
6. Go to the WordPress Updates page and ensure you see Classifai there as well, with the icon
7. Click on the `View version X.X.X details` link and ensure you see proper details
8. If desired, click the `update now` link and ensure an update works (either from the plugins page or the main updates page). Note though that this will wipe out your version controlled `classifai` directory, so proceed with caution

### Changelog Entry

> Changed - Upgrade the Plugin Update Checker library to 4.13

### Credits

Props @dkotter

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
