### PR TITLE
Bumped WP and PHP Minimums

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@
 
 ## Requirements
 
-* PHP 7.2+
-* [WordPress](http://wordpress.org) 5.6+
+* PHP 7.4+
+* [WordPress](http://wordpress.org) 5.7+
 * To utilize the Language Processing functionality, you will need an active [IBM Watson](https://cloud.ibm.com/registration) account.
 * To utilize the Image Processing functionality, you will need an active [Microsoft Azure](https://signup.azure.com/signup) account.
 

--- a/classifai.php
+++ b/classifai.php
@@ -21,12 +21,12 @@
 register_activation_hook(
 	__FILE__,
 	function() {
-		if ( version_compare( PHP_VERSION, '7.2.0', '<' ) ) {
+		if ( version_compare( PHP_VERSION, '7.4.0', '<' ) ) {
 			wp_die(
 				sprintf(
 					wp_kses(
 						/* translators: PHP Update guide URL */
-						__( 'ClassifAI requires PHP version 7.2. <a href="%s">Click here</a> to learn how to update your PHP version.', 'classifai' ),
+						__( 'ClassifAI requires PHP version 7.4. <a href="%s">Click here</a> to learn how to update your PHP version.', 'classifai' ),
 						array(
 							'a' => array( 'href' => array() ),
 						)

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "type": "wordpress-plugin",
   "license": "GPLv2",
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "yahnis-elsts/plugin-update-checker": "4.13",
     "ua-parser/uap-php": "dev-master"
   },

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === ClassifAI ===
 Contributors:      10up
 Tags:              AI, Artifical Intelligence, ML, Machine Learning, Microsoft Azure, IBM Watson, Content Tagging, Classification, Smart Cropping, Alt Text
-Requires at least: 5.6
+Requires at least: 5.7
 Tested up to:      6.0
-Requires PHP:      7.2
+Requires PHP:      7.4
 Stable tag:        1.7.3
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
### Description of the Change
Bumped up the WordPress and PHP minimum requirements. Please note that for some weird reason updating the README.MD file breaks the formatting in my mac so I haven't edited the README.MD file.

Closes #352 

### Changelog Entry

> Changed - Bump WordPress minimum from 5.6 to 5.7
> Changed - Bump PHP minimum from 7.2 to 7.4

### Credits
Props @jeffpaul @zamanq 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
