### PR TITLE
Added "Build release zip" Workflow.

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -1,0 +1,47 @@
+name: Build release zip
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build_zip:
+    name: New release
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set Node.js 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+
+    - name: npm install and build
+      run: |
+        npm install
+        npm run build
+        npm run makepot
+        composer install --no-dev
+        npm run archive
+
+    - name: Upload the ZIP file as an artifact
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.event.repository.name }}
+        path: release
+        retention-days: 5
+
+    - name: Upload release asset
+      if: ${{ github.event_name == 'release' }}
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{github.workspace}}/${{ github.event.repository.name }}.zip
+        asset_name: ${{ github.event.repository.name }}.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
### Description of the Change
PR adds a "Build release zip" workflow to upload built ZIP file on GH release, workflow also can be manually triggered to generate a zip for a specific branch of the repo.

Closes #367

### How to test the Change
**Upload zip to release:** We can test during the release process. Not sure how we can test before that.
**Generate zip manually:** We can test this after merging this PR. 

### Changelog Entry
> Added - "Build release zip" Workflow.


### Credits
Props @iamdharmesh @jeffpaul 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
