### PR TITLE
Issue #307 PDF scan button improvement

### DIFF
--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -154,10 +154,11 @@ class Plugin {
 			'classifai-admin-script',
 			'ClassifAI',
 			[
-				'api_password'    => __( 'API Password', 'classifai' ),
-				'api_key'         => __( 'API Key', 'classifai' ),
-				'use_key'         => __( 'Use an API Key instead?', 'classifai' ),
-				'use_password'    => __( 'Use a username/password instead?', 'classifai' ),
+				'api_password' => __( 'API Password', 'classifai' ),
+				'api_key'      => __( 'API Key', 'classifai' ),
+				'use_key'      => __( 'Use an API Key instead?', 'classifai' ),
+				'use_password' => __( 'Use a username/password instead?', 'classifai' ),
+				'ajax_nonce'   => wp_create_nonce( 'classifai' ),
 			]
 		);
 	}

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -338,7 +338,9 @@ class ComputerVision extends Provider {
 	 * @return array Read and running status.
 	 */
 	public static function get_read_status( $attachment_id = null ) {
-		if ( isset( $_POST['attachment_id'] ) ) {
+		$doing_ajax = defined( 'DOING_AJAX' ) && DOING_AJAX;
+
+		if ( $doing_ajax ) {
 			$attachment_id = filter_input( INPUT_POST, 'attachment_id', FILTER_SANITIZE_NUMBER_INT );
 		}
 
@@ -355,7 +357,7 @@ class ComputerVision extends Provider {
 			'running' => $running,
 		];
 
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		if ( $doing_ajax ) {
 			wp_send_json_success( $resp );
 		} else {
 			return $resp;

--- a/src/js/media.js
+++ b/src/js/media.js
@@ -1,3 +1,5 @@
+/* global ClassifAI */
+
 import { handleClick } from './helpers';
 
 ( function ( $ ) {
@@ -146,13 +148,19 @@ import { handleClick } from './helpers';
 			data: {
 				action: 'classifai_get_read_status',
 				attachment_id: postId,
+				nonce: ClassifAI.ajax_nonce,
 			},
 			success: ( resp ) => {
-				if ( resp?.data?.running ) {
-					readButton.setAttribute( 'disabled', 'disabled' );
-					readButton.textContent = __( 'In progress!', 'classifai' );
-				} else if ( resp?.data?.read ) {
-					readButton.textContent = __( 'Rescan', 'classifai' );
+				if ( resp?.success ) {
+					if ( resp?.data?.running ) {
+						readButton.setAttribute( 'disabled', 'disabled' );
+						readButton.textContent = __(
+							'In progress!',
+							'classifai'
+						);
+					} else if ( resp?.data?.read ) {
+						readButton.textContent = __( 'Rescan', 'classifai' );
+					}
 				}
 			},
 		} );

--- a/src/js/media.js
+++ b/src/js/media.js
@@ -128,15 +128,45 @@ import { handleClick } from './helpers';
 		}
 	};
 
+	/**
+	 * Check the PDF Scanner status and disable button if in progress.
+	 */
+	const checkPdfReadStatus = () => {
+		const readButton = document.getElementById( 'classifai-rescan-pdf' );
+
+		if ( ! readButton ) {
+			return;
+		}
+
+		const postId = readButton.getAttribute( 'data-id' );
+
+		$.ajax( {
+			url: ajaxurl,
+			type: 'POST',
+			data: {
+				action: 'classifai_get_read_status',
+				attachment_id: postId,
+			},
+			success: ( resp ) => {
+				if ( resp && resp.data ) {
+					readButton.setAttribute( 'disabled', 'disabled' );
+					readButton.textContent = __( 'In progress!', 'classifai' );
+				}
+			},
+		} );
+	};
+
 	$( document ).ready( function () {
 		if ( wp.media ) {
 			wp.media.view.Modal.prototype.on( 'open', function () {
 				wp.media.frame.on( 'selection:toggle', handleButtonsClick );
+				wp.media.frame.on( 'selection:toggle', checkPdfReadStatus );
 			} );
 		}
 
 		if ( wp.media.frame ) {
 			wp.media.frame.on( 'edit:attachment', handleButtonsClick );
+			wp.media.frame.on( 'edit:attachment', checkPdfReadStatus );
 		}
 
 		// For new uploaded media.

--- a/src/js/media.js
+++ b/src/js/media.js
@@ -148,9 +148,11 @@ import { handleClick } from './helpers';
 				attachment_id: postId,
 			},
 			success: ( resp ) => {
-				if ( resp && resp.data ) {
+				if ( resp?.data?.running ) {
 					readButton.setAttribute( 'disabled', 'disabled' );
 					readButton.textContent = __( 'In progress!', 'classifai' );
+				} else if ( resp?.data?.read ) {
+					readButton.textContent = __( 'Rescan', 'classifai' );
 				}
 			},
 		} );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR implements an AJAX function to check the "read" status of the PDF Scanner in the Media Library and disable the button if the scanner is currently running.

Previously if a user initiated a scan and then closed/reopened the modal the Scan button would be available even if the previous scan was not complete.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/classifai/issues/307

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Pull down branch [`feature/issue-307-scan-button`](https://github.com/10up/classifai/tree/feature/issue-307-scan-button) & build assets
2. Enable PDF Scanning by visiting **ClassifAI** > **Image Processing** and toggling the `Enable Scanning PDF`
3. Open a PDF document in the Media Library and click the "Scan" button in the modal window.
4. Button should change to indicate the scanning has started (button will be disabled)
5. Close the modal window, open a different media item, close it, re-open the PDF being scanned.
6. At this point an AJAX request will run to retrieve the scanning progress. 
    - If scanner was still running the button would read "In progress!". 
    - If it was completed the button would read "Rescan".

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Implement check to prevent requesting a PDF scan on a document which a scan is already in progress.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @TylerB24890 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
