### PR TITLE
Remove some code in the preview section that isn't needed

### DIFF
--- a/includes/Classifai/Admin/PreviewClassifierData.php
+++ b/includes/Classifai/Admin/PreviewClassifierData.php
@@ -28,17 +28,8 @@ class PreviewClassifierData {
 		$classifier = new \Classifai\Watson\Classifier();
 		$normalizer = new \Classifai\Watson\Normalizer();
 
-		$features['categories'] = (object) [];
-		$features['concepts']   = (object) [];
-		$features['entities']   = (object) [];
-		$features['keywords']   = [
-			'emotion'   => false,
-			'sentiment' => false,
-			'limit'     => defined( 'WATSON_KEYWORD_LIMIT' ) ? WATSON_KEYWORD_LIMIT : 10,
-		];
-
 		$text_to_classify        = $normalizer->normalize( $post_id );
-		$body                    = $classifier->get_body( $text_to_classify, $features );
+		$body                    = $classifier->get_body( $text_to_classify );
 		$request_options['body'] = $body;
 		$request                 = $classifier->get_request();
 

--- a/includes/Classifai/Watson/Classifier.php
+++ b/includes/Classifai/Watson/Classifier.php
@@ -115,7 +115,7 @@ class Classifier {
 				'keywords'   => [
 					'emotion'   => false,
 					'sentiment' => false,
-					'limit'     => 10,
+					'limit'     => defined( 'WATSON_KEYWORD_LIMIT' ) ? WATSON_KEYWORD_LIMIT : 10,
 				],
 				'concepts'   => (object) [],
 				'entities'   => (object) [],


### PR DESCRIPTION
### Description of the Change

In #351, a previewer was added to the admin. This makes a request to the `Classifier::get_body` method, passing in some options. The problem here is that this method expects the options array to look like this:

```php
[
    'text' => 'Some Text'
    'language' => 'en',
    'features' => [
        'categories' => [],
        'concepts' => [],
        // etc
    ],
]
```

But all we are passing in is a single array containing features part, which looks like:
```php
[
    'categories' => [],
    'concepts' => [],
    // etc
]
```

These values end up being ignored because they don't follow the format we expect. In addition, these values are the same as the default values in the `Classifier::get_body` method, so there's no real reason I can see to pass those in the first place. I discovered this while using the preview section to quickly verify a new feature and found out the values I was passing in weren't being recognized. 

This PR removes those and also changes the default `limit` value to match how we set the limit in other places (using our constant first). An alternative approach here is to change the format of the data we pass in to match what we expect but because we just pass in default values, doesn't seem to add any value currently.

### How to test the Change

Ensure the preview area still functions as expected

### Changelog Entry

> Fixed - Removed some unnecessary code in the preview feature

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
