### PR TITLE
Fix failing E2E tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#5.6'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#5.7'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dependencies
       run: npm install
@@ -43,7 +43,7 @@ jobs:
       run: npm run cypress:run
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: cypress-artifact-classifai

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,9 @@
   "requires": true,
   "dependencies": {
     "@10up/cypress-wp-utils": {
-      "version": "github:10up/cypress-wp-utils#ec20aed9c16f460f3e7d0c06c447f4fb8d030404",
-      "from": "github:10up/cypress-wp-utils#build",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.1.0.tgz",
+      "integrity": "sha512-6yige9N0kqG0XM4HBQBPcr2k7TwUV+4PLESvQEvsDyIkvRvLzL1Fnbork+s1+hvni+2qL6Ghjhjjd2npTNbqRg==",
       "dev": true
     },
     "@ampproject/remapping": {
@@ -2563,9 +2564,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.0.27",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.27.tgz",
-      "integrity": "sha512-3vtRKHgVxu3Jp9t718R9BuzoD4NcQ8YJ5XRzsSKxNDiDonD2MXIT1TmSkenxuCycZJoQT5d2vE8LwWJxBC1gmA==",
+      "version": "18.0.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
+      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2573,9 +2574,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
-      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
+      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
       "requires": {
         "@types/react": "*"
       }
@@ -3324,18 +3325,28 @@
       }
     },
     "@wordpress/element": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.2.0.tgz",
-      "integrity": "sha512-0hhFhzcQChSIT5pcOCSGVSK4DEi3xBtuu3uRj3HrYefcthmRdZnAeLGUGaebO5HgcxnImJ/Y0u4r948XFjj9SA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.5.0.tgz",
+      "integrity": "sha512-fyePV7Zso797R2FyeOQG6y1nZA77NAa+fyGk6wE90KoKDQY+8FD38eHpri29G0SkXXrI7BT+QOtH6tpr+d2ifg==",
       "requires": {
         "@babel/runtime": "^7.16.0",
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.6",
-        "@wordpress/escape-html": "^2.25.0",
+        "@wordpress/escape-html": "^2.28.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
+      },
+      "dependencies": {
+        "@wordpress/escape-html": {
+          "version": "2.28.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.28.0.tgz",
+          "integrity": "sha512-GvtHuTfmfaIQ05BHUHGMmAKM1vU9Z2glE02m+7a0NqlzQAaNK3zG4tQ1xeu1kLEt+iHcTnLhYgPVBDxTNbN/FA==",
+          "requires": {
+            "@babel/runtime": "^7.16.0"
+          }
+        }
       }
     },
     "@wordpress/env": {
@@ -3362,6 +3373,7 @@
       "version": "2.25.0",
       "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.25.0.tgz",
       "integrity": "sha512-a+k2g/fg/E+XEAjq5O9iFFFMZ1+04JvaekF/ZUzDLLyBzk12D8Zfmg3UiHs0HkMFwZM1uyofpen9TOdGk9Op8Q==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.0"
       }
@@ -3533,6 +3545,14 @@
         "webpack-bundle-analyzer": "^4.4.2",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.4.0"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "npm:wp-prettier@2.6.2",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
+          "integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
+          "dev": true
+        }
       }
     },
     "@wordpress/stylelint-config": {
@@ -12340,12 +12360,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true
-    },
-    "prettier": {
-      "version": "npm:wp-prettier@2.6.2",
-      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
-      "integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "role": "developer"
   },
   "devDependencies": {
-    "@10up/cypress-wp-utils": "github:10up/cypress-wp-utils#build",
+    "@10up/cypress-wp-utils": "^0.1.0",
     "@wordpress/env": "^5.3.0",
     "@wordpress/scripts": "^23.4.0",
     "cypress": "^11.2.0",


### PR DESCRIPTION
### Description of the Change

Update to the latest version of our Cypress WP Util library to fix failing E2E tests. Also bumps our minimum WordPress version we test on to 5.7 since that's the minimum version we support and updates a few GitHub Actions used in our E2E testing.

**Note**
Our eslint test is failing; looks like some existing JS issues that need fixed up. I'll tackle that in a separate PR.

### How to test the Change

Ensure the E2E checks are passing on this PR.

### Changelog Entry
_Not sure this even needs to go in our changelog_
> Fixed - Ensure our E2E tests pass

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
