### PR TITLE
Excerpt Pre-publish Check

### DIFF
--- a/src/js/post-excerpt/index.js
+++ b/src/js/post-excerpt/index.js
@@ -25,7 +25,9 @@ const PostExcerpt = () => {
 			<PluginDocumentSettingPanel title={ __( 'Excerpt' ) }>
 				<PostExcerptForm />
 			</PluginDocumentSettingPanel>
-			<MaybeExcerptPanel />
+			<MaybeExcerptPanel>
+				<PostExcerptForm />
+			</MaybeExcerptPanel>
 		</PostExcerptCheck>
 	);
 };

--- a/src/js/post-excerpt/index.js
+++ b/src/js/post-excerpt/index.js
@@ -3,7 +3,7 @@
  */
 const { __ } = wp.i18n;
 const { dispatch } = wp.data;
-const { PluginDocumentSettingPanel } = wp.editPost;
+const { PluginDocumentSettingPanel, PluginPrePublishPanel } = wp.editPost;
 const { PostExcerptCheck } = wp.editor;
 const { registerPlugin } = wp.plugins;
 
@@ -24,6 +24,13 @@ const PostExcerpt = () => {
 			<PluginDocumentSettingPanel title={ __( 'Excerpt' ) }>
 				<PostExcerptForm />
 			</PluginDocumentSettingPanel>
+			<PluginPrePublishPanel
+				title={ __( 'Excerpt' ) }
+				icon='aside'
+				initialOpen={ true }
+			>
+				<PostExcerptForm />
+			</PluginPrePublishPanel>
 		</PostExcerptCheck>
 	);
 };

--- a/src/js/post-excerpt/index.js
+++ b/src/js/post-excerpt/index.js
@@ -3,7 +3,7 @@
  */
 const { __ } = wp.i18n;
 const { dispatch } = wp.data;
-const { PluginDocumentSettingPanel, PluginPrePublishPanel } = wp.editPost;
+const { PluginDocumentSettingPanel } = wp.editPost;
 const { PostExcerptCheck } = wp.editor;
 const { registerPlugin } = wp.plugins;
 
@@ -11,6 +11,7 @@ const { registerPlugin } = wp.plugins;
  * Internal dependencies
  */
 import PostExcerptForm from './panel';
+import MaybeExcerptPanel from './maybe-excerpt-panel';
 
 // Remove core Post Excerpt panel.
 ( () => {
@@ -24,13 +25,7 @@ const PostExcerpt = () => {
 			<PluginDocumentSettingPanel title={ __( 'Excerpt' ) }>
 				<PostExcerptForm />
 			</PluginDocumentSettingPanel>
-			<PluginPrePublishPanel
-				title={ __( 'Excerpt' ) }
-				icon='aside'
-				initialOpen={ true }
-			>
-				<PostExcerptForm />
-			</PluginPrePublishPanel>
+			<MaybeExcerptPanel />
 		</PostExcerptCheck>
 	);
 };

--- a/src/js/post-excerpt/maybe-excerpt-panel.js
+++ b/src/js/post-excerpt/maybe-excerpt-panel.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+const { __ } = wp.i18n;
+const { PluginPrePublishPanel } = wp.editPost;
+const { useSelect } = wp.data;
+
+/**
+ * Internal dependencies
+ */
+import ExcerptForm from './panel';
+
+function MaybeExcerptPanel() {
+	const excerpt = useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'excerpt' ) );
+
+	const panelTitle = [
+		__( 'Suggestion:', 'classifai' ),
+		<span className="editor-post-publish-panel__link" key="label">
+			{ __( 'Generate excerpt', 'classifai' ) }
+		</span>,
+	];
+
+	if ( '' !== excerpt ) {
+		return null;
+	}
+
+	return (
+		<PluginPrePublishPanel initialOpen={ false } title={ panelTitle } icon='aside'>
+			<ExcerptForm />
+		</PluginPrePublishPanel>
+	)
+}
+
+export default MaybeExcerptPanel;

--- a/src/js/post-excerpt/panel.js
+++ b/src/js/post-excerpt/panel.js
@@ -14,24 +14,27 @@ import { handleClick } from '../helpers';
 function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	const { select } = wp.data;
 	const postId = select( 'core/editor' ).getCurrentPostId();
-	const buttonText = __( 'Generate excerpt', 'classifai' );
+	const buttonText = '' === excerpt ? __( 'Generate excerpt', 'classifai' ) : __( 'Re-generate excerpt', 'classifai' );
+	const isPublishPanelOpen = select( 'core/edit-post' ).isPublishSidebarOpened();
 
 	return (
 		<div className="editor-post-excerpt">
 			<TextareaControl
 				__nextHasNoMarginBottom
-				label={ __( 'Write an excerpt (optional)' ) }
+				label={ ! isPublishPanelOpen ? __( 'Write an excerpt (optional)' ) : null }
 				className="editor-post-excerpt__textarea"
 				onChange={ ( value ) => onUpdateExcerpt( value ) }
 				value={ excerpt }
 			/>
-			<ExternalLink
-				href={ __(
-					'https://wordpress.org/support/article/settings-sidebar/#excerpt'
-				) }
-			>
-				{ __( 'Learn more about manual excerpts' ) }
-			</ExternalLink>
+			{ ! isPublishPanelOpen &&
+				<ExternalLink
+					href={ __(
+						'https://wordpress.org/support/article/settings-sidebar/#excerpt'
+					) }
+				>
+					{ __( 'Learn more about manual excerpts' ) }
+				</ExternalLink>
+			}
 			<Button
 				variant={ 'secondary' }
 				data-id={ postId }


### PR DESCRIPTION
### Description of the Change
This is an enhancement to the existing PR for Automatic excerpt generation: #405 

I've added the excerpt generation option in the Pre Publish Panel so that if needed the excerpt can be re-generated in that screen before publishing.

I've also made some minor changes to the button label i.e if the excerpt is not yet generated or empty the button will say "Generate excerpt" if the excerpt is already generated, then it would say "Re-generate excerpt"

### How to test the Change
The testing process is same as this PR: #405 
In addition, when clicked on the Publish button, the pre-publish panel will open and at the bottom you'll see the excerpt textarea with the button to generate/re-generate the excerpt.

<img width="282" alt="Screenshot 2023-03-12 at 10 04 11 PM" src="https://user-images.githubusercontent.com/45451844/224557762-b0c21d59-acf1-4a2e-a018-81f66cf1b1ca.png">

### Changelog Entry
Improvement: Added excerpt generation option to the Pre Publish Panel


### Credits
@dkotter @jeffpaul @zamanq 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
