### PR TITLE
Do not cache node_modules/

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,23 +21,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-node-modules
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-
     - name: Setup node v16 and npm cache
       uses: actions/setup-node@v3
       with:
         node-version: 16
-        cache: 'npm'
+        cache: npm
 
     - name: Install Node dependencies
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm ci --no-optional
 
     - name: Get updated JS files


### PR DESCRIPTION
It is already handled by `actions/setup-node`.
Never cache `node_modules/`. It results in an unpredictable state.
It takes 1-2 seconds to copy files from npm cache to `node_modules/`.
