### PR TITLE
Fix PHP warnings

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -396,11 +396,6 @@ class ComputerVision extends Provider {
 	 */
 	public function maybe_rescan_image( $attachment_id ) {
 		$routes   = [];
-
-		if ( ! wp_attachment_is_image( $attachment_id ) ) {
-			return;
-		}
-
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
 		// Allow rescanning image that are not stored in local storage.
@@ -410,7 +405,7 @@ class ComputerVision extends Provider {
 			$image_url = get_largest_acceptable_image_url(
 				get_attached_file( $attachment_id ),
 				wp_get_attachment_url( $attachment_id ),
-				$metadata['sizes'],
+				wp_attachment_is_image( $attachment_id ) ? $metadata['sizes'] : [],
 				computer_vision_max_filesize()
 			);
 		}

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -396,6 +396,11 @@ class ComputerVision extends Provider {
 	 */
 	public function maybe_rescan_image( $attachment_id ) {
 		$routes   = [];
+
+		if ( ! wp_attachment_is_image( $attachment_id ) ) {
+			return;
+		}
+
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
 		// Allow rescanning image that are not stored in local storage.

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -395,6 +395,11 @@ class ComputerVision extends Provider {
 	 * @param int $attachment_id Post id for the attachment
 	 */
 	public function maybe_rescan_image( $attachment_id ) {
+		if ( filter_input( INPUT_POST, 'rescan-pdf', FILTER_SANITIZE_STRING ) ) {
+			$this->read_pdf( $attachment_id );
+			return; // We can exit early, if this is a call for PDF scanning - everything else relates to images.
+		}
+
 		$routes   = [];
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
@@ -405,7 +410,7 @@ class ComputerVision extends Provider {
 			$image_url = get_largest_acceptable_image_url(
 				get_attached_file( $attachment_id ),
 				wp_get_attachment_url( $attachment_id ),
-				wp_attachment_is_image( $attachment_id ) ? $metadata['sizes'] : [],
+				$metadata['sizes'],
 				computer_vision_max_filesize()
 			);
 		}
@@ -442,11 +447,6 @@ class ComputerVision extends Provider {
 		if ( filter_input( INPUT_POST, 'rescan-ocr', FILTER_SANITIZE_STRING ) ) {
 			$this->ocr_processing( wp_get_attachment_metadata( $attachment_id ), $attachment_id, true );
 		}
-
-		if ( filter_input( INPUT_POST, 'rescan-pdf', FILTER_SANITIZE_STRING ) ) {
-			$this->read_pdf( $attachment_id );
-		}
-
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
Make sure that an attachment is a valid image, before performing any image processing.

Closes #422 

### How to test the Change
See #422 for steps to replicate

### Changelog Entry
Fixed - PHP notice when editing non-image attachments

### Credits
Props @av3nger 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
