### PR TITLE
#433: Define $attachment_id, replace $metadata with useful information

### DIFF
--- a/includes/Classifai/Providers/Azure/Read.php
+++ b/includes/Classifai/Providers/Azure/Read.php
@@ -125,7 +125,20 @@ class Read {
 
 		$filesize = filesize( get_attached_file( $this->attachment_id ) );
 		if ( ! $filesize || $filesize > computer_vision_max_filesize() ) {
-			return $this->log_error( new WP_Error( 'size_error', esc_html__( 'Document does not meet size requirements. Please ensure it is smaller than the maximum threshold (defaults to 4MB).', 'classifai' ), $metadata ), $attachment_id );
+			return $this->log_error(
+				new WP_Error(
+					'size_error',
+					esc_html(
+						sprintf(
+							// translators: %1$s is a file size
+							__( 'Document does not meet size requirements. Please ensure it is smaller than the maximum threshold (currently %1$s, defaults to 4MB).', 'classifai' ),
+							computer_vision_max_filesize()
+						)
+					),
+					$filesize
+				),
+				$this->attachment_id
+			);
 		}
 
 		/**

--- a/includes/Classifai/Providers/Azure/Read.php
+++ b/includes/Classifai/Providers/Azure/Read.php
@@ -131,7 +131,7 @@ class Read {
 					esc_html(
 						sprintf(
 							// translators: %1$s is the document file size, %2$s is the current default max filesize
-							__( 'Document (%1$s) does not meet size requirements. Please ensure it is smaller than the maximum threshold (currently %1$s, defaults to 4MB).', 'classifai' ),
+							__( 'Document (%1$s) does not meet size requirements. Please ensure it is smaller than the maximum threshold (currently %2$s, defaults to 4MB).', 'classifai' ),
 							! $filesize ? __( 'size not found', 'classifai' ) : $filesize,
 							computer_vision_max_filesize()
 						)

--- a/includes/Classifai/Providers/Azure/Read.php
+++ b/includes/Classifai/Providers/Azure/Read.php
@@ -130,8 +130,9 @@ class Read {
 					'size_error',
 					esc_html(
 						sprintf(
-							// translators: %1$s is a file size
-							__( 'Document does not meet size requirements. Please ensure it is smaller than the maximum threshold (currently %1$s, defaults to 4MB).', 'classifai' ),
+							// translators: %1$s is the document file size, %2$s is the current default max filesize
+							__( 'Document (%1$s) does not meet size requirements. Please ensure it is smaller than the maximum threshold (currently %1$s, defaults to 4MB).', 'classifai' ),
+							$filesize,
 							computer_vision_max_filesize()
 						)
 					),

--- a/includes/Classifai/Providers/Azure/Read.php
+++ b/includes/Classifai/Providers/Azure/Read.php
@@ -136,8 +136,7 @@ class Read {
 						)
 					),
 					$filesize
-				),
-				$this->attachment_id
+				)
 			);
 		}
 

--- a/includes/Classifai/Providers/Azure/Read.php
+++ b/includes/Classifai/Providers/Azure/Read.php
@@ -132,7 +132,7 @@ class Read {
 						sprintf(
 							// translators: %1$s is the document file size, %2$s is the current default max filesize
 							__( 'Document (%1$s) does not meet size requirements. Please ensure it is smaller than the maximum threshold (currently %1$s, defaults to 4MB).', 'classifai' ),
-							$filesize,
+							! $filesize ? __( 'size not found', 'classifai' ) : $filesize,
 							computer_vision_max_filesize()
 						)
 					),

--- a/includes/Classifai/Providers/Azure/Read.php
+++ b/includes/Classifai/Providers/Azure/Read.php
@@ -130,10 +130,11 @@ class Read {
 					'size_error',
 					esc_html(
 						sprintf(
-							// translators: %1$s is the document file size, %2$s is the current default max filesize
-							__( 'Document (%1$s) does not meet size requirements. Please ensure it is smaller than the maximum threshold (currently %2$s, defaults to 4MB).', 'classifai' ),
+							// translators: %1$s is the document file size in bytes, %2$s is the current default max filesize in bytes, %3$s is the integer '4 * MB_IN_BYTES'
+							__( 'Document (%1$s bytes) does not meet size requirements. Please ensure it is smaller than the maximum threshold (currently %2$s bytes, defaults to %3$s bytes).', 'classifai' ),
 							! $filesize ? __( 'size not found', 'classifai' ) : $filesize,
-							computer_vision_max_filesize()
+							computer_vision_max_filesize(),
+							4 * MB_IN_BYTES
 						)
 					),
 					$filesize


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

In the section of the Azure document read function, this code change replaces some undefined variables with useful information.

- Removed undefined `$attachment_id` which was used as the second parameter on `$this->log_error()`, a method which only accepts one parameter
- Removes undefined `$metadata` as the third parameter of the `WP_Error` call — The third parameter of the `WP_Error` constructor gets saved as the error's `data` property, which code within `\Classifai\Providers\Azure\Read` does not use. Consumers of this object would have been given an undefined or empty `data` property because `$metadata` was undefined, so removing the undefined value won't break anything.
- changes the error message to include:
    - the current file size
    - the current file size limits in addition to the default.
- changes one internationalizable string to include placeholders so that we can add that additional information about file sizes.

Alternative implementations considered:
- replacing `$metadata` with `$filesize` — since `$metadata` was undefined before, we'd be changing what upstream consumers of the `WP_Error` object would see in its `data` property.
- not changing the translation string — since the data was already available within this function, I thought it best to add that data to the log message since I was in here anyways. This changeset doesn't change the error code, so it ought not affect upstream consumers of the `WP_Error` object unless they were parsing the error _message_ instead of the _code_. **Potential drawback**: Confusing consumers of the error message who rely on strict text matching.

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Testing completed:
- [x] PHPCS
- [ ] ran tests
- [ ] tested on a site connected to Azure

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/classifai/issues/433

### How to test the Change

- [ ] Verify that the variables used are defined within the function
- [ ] Run the code on a server configured to talk to Azure, and have Azure try to scan an oversized document.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability

Changed:

- When attempting to use Azure to parse a too-large document, the error log message will include the document size and the maximum document size.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->

@benlk

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
