### PR TITLE
Hide `Descriptive text` and `Image tags` buttons if the corresponding options aren't enabled.

### DIFF
--- a/includes/Classifai/Admin/BulkActions.php
+++ b/includes/Classifai/Admin/BulkActions.php
@@ -81,7 +81,7 @@ class BulkActions {
 
 		if (
 			'no' !== $settings['enable_image_tagging'] ||
-			empty( $this->computer_vision->get_alt_text_settings() )
+			! empty( $this->computer_vision->get_alt_text_settings() )
 		) {
 			$bulk_actions['scan_image'] = __( 'Scan Image', 'classifai' );
 		}

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -274,7 +274,7 @@ class ComputerVision extends Provider {
 		$smart_crop = get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ? __( 'Regenerate smart thumbnail', 'classifai' ) : __( 'Create smart thumbnail', 'classifai' );
 		?>
 		<div class="misc-publishing-actions">
-			<?php if ( $settings && isset( $settings['enable_image_captions']['description'] ) && '1' === $settings['enable_image_captions']['description'] ) : ?>
+			<?php if ( $settings && isset( $settings['enable_image_captions']['description'] ) && 'description' === $settings['enable_image_captions']['description'] ) : ?>
 				<div class="misc-pub-section">
 					<label for="rescan-captions">
 						<input type="checkbox" value="yes" id="rescan-captions" name="rescan-captions"/>

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -71,7 +71,6 @@ class ComputerVision extends Provider {
 
 	/**
 	 * Returns an array of fields enabled to be set to store image captions.
-	 * Returns `false` if no fields are selected.
 	 *
 	 * @return array
 	 */
@@ -249,7 +248,7 @@ class ComputerVision extends Provider {
 			);
 		}
 
-		if ( attachment_is_pdf( $post ) && $settings && isset( $settings['enable_read_pdf'] ) && '1' === $settings['enable_read_pdf'] ) {
+		if ( attachment_is_pdf( $post ) && is_array( $settings ) && isset( $settings['enable_read_pdf'] ) && '1' === $settings['enable_read_pdf'] ) {
 			add_meta_box(
 				'attachment_meta_box',
 				__( 'ClassifAI PDF Processing', 'classifai' ),
@@ -267,14 +266,15 @@ class ComputerVision extends Provider {
 	 * @param \WP_Post $post The post object.
 	 */
 	public function attachment_data_meta_box( $post ) {
-		$settings   = get_option( 'classifai_computer_vision' );
+		$settings   = $this->get_settings();
 		$captions   = get_post_meta( $post->ID, '_wp_attachment_image_alt', true ) ? __( 'No descriptive text? Rescan image', 'classifai' ) : __( 'Generate descriptive text', 'classifai' );
 		$tags       = ! empty( wp_get_object_terms( $post->ID, 'classifai-image-tags' ) ) ? __( 'Rescan image for new tags', 'classifai' ) : __( 'Generate image tags', 'classifai' );
 		$ocr        = get_post_meta( $post->ID, 'classifai_computer_vision_ocr', true ) ? __( 'Rescan for text', 'classifai' ) : __( 'Scan image for text', 'classifai' );
 		$smart_crop = get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ? __( 'Regenerate smart thumbnail', 'classifai' ) : __( 'Create smart thumbnail', 'classifai' );
 		?>
+
 		<div class="misc-publishing-actions">
-			<?php if ( $settings && isset( $settings['enable_image_captions']['description'] ) && 'description' === $settings['enable_image_captions']['description'] ) : ?>
+			<?php if ( ! empty( $this->get_alt_text_settings() ) ) : ?>
 				<div class="misc-pub-section">
 					<label for="rescan-captions">
 						<input type="checkbox" value="yes" id="rescan-captions" name="rescan-captions"/>
@@ -283,7 +283,7 @@ class ComputerVision extends Provider {
 				</div>
 			<?php endif; ?>
 
-			<?php if ( $settings && isset( $settings['enable_image_tagging'] ) && '1' === $settings['enable_image_tagging'] ) : ?>
+			<?php if ( is_array( $settings ) && isset( $settings['enable_image_tagging'] ) && '1' === $settings['enable_image_tagging'] ) : ?>
 				<div class="misc-pub-section">
 					<label for="rescan-tags">
 						<input type="checkbox" value="yes" id="rescan-tags" name="rescan-tags"/>
@@ -292,7 +292,7 @@ class ComputerVision extends Provider {
 				</div>
 			<?php endif; ?>
 
-			<?php if ( $settings && isset( $settings['enable_ocr'] ) && '1' === $settings['enable_ocr'] ) : ?>
+			<?php if ( is_array( $settings ) && isset( $settings['enable_ocr'] ) && '1' === $settings['enable_ocr'] ) : ?>
 				<div class="misc-pub-section">
 					<label for="rescan-ocr">
 						<input type="checkbox" value="yes" id="rescan-ocr" name="rescan-ocr"/>
@@ -301,7 +301,7 @@ class ComputerVision extends Provider {
 				</div>
 			<?php endif; ?>
 
-			<?php if ( $settings && isset( $settings['enable_smart_cropping'] ) && '1' === $settings['enable_smart_cropping'] ) : ?>
+			<?php if ( is_array( $settings ) && isset( $settings['enable_smart_cropping'] ) && '1' === $settings['enable_smart_cropping'] ) : ?>
 				<div class="misc-pub-section">
 					<label for="rescan-smart-crop">
 						<input type="checkbox" value="yes" id="rescan-smart-crop" name="rescan-smart-crop"/>

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -274,34 +274,41 @@ class ComputerVision extends Provider {
 		$smart_crop = get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ? __( 'Regenerate smart thumbnail', 'classifai' ) : __( 'Create smart thumbnail', 'classifai' );
 		?>
 		<div class="misc-publishing-actions">
-			<div class="misc-pub-section">
-				<label for="rescan-captions">
-					<input type="checkbox" value="yes" id="rescan-captions" name="rescan-captions"/>
-					<?php echo esc_html( $captions ); ?>
-				</label>
-			</div>
-			<div class="misc-pub-section">
-				<label for="rescan-tags">
-					<input type="checkbox" value="yes" id="rescan-tags" name="rescan-tags"/>
-					<?php echo esc_html( $tags ); ?>
-				</label>
-			</div>
-		<?php if ( $settings && isset( $settings['enable_ocr'] ) && '1' === $settings['enable_ocr'] ) : ?>
-			<div class="misc-pub-section">
-				<label for="rescan-ocr">
-					<input type="checkbox" value="yes" id="rescan-ocr" name="rescan-ocr"/>
-					<?php echo esc_html( $ocr ); ?>
-				</label>
-			</div>
-		<?php endif; ?>
-		<?php if ( $settings && isset( $settings['enable_smart_cropping'] ) && '1' === $settings['enable_smart_cropping'] ) : ?>
-			<div class="misc-pub-section">
-				<label for="rescan-smart-crop">
-					<input type="checkbox" value="yes" id="rescan-smart-crop" name="rescan-smart-crop"/>
-					<?php echo esc_html( $smart_crop ); ?>
-				</label>
-			</div>
-		<?php endif; ?>
+			<?php if ( $settings && isset( $settings['enable_image_captions']['description'] ) && '1' === $settings['enable_image_captions']['description'] ) : ?>
+				<div class="misc-pub-section">
+					<label for="rescan-captions">
+						<input type="checkbox" value="yes" id="rescan-captions" name="rescan-captions"/>
+						<?php echo esc_html( $captions ); ?>
+					</label>
+				</div>
+			<?php endif; ?>
+
+			<?php if ( $settings && isset( $settings['enable_image_tagging'] ) && '1' === $settings['enable_image_tagging'] ) : ?>
+				<div class="misc-pub-section">
+					<label for="rescan-tags">
+						<input type="checkbox" value="yes" id="rescan-tags" name="rescan-tags"/>
+						<?php echo esc_html( $tags ); ?>
+					</label>
+				</div>
+			<?php endif; ?>
+
+			<?php if ( $settings && isset( $settings['enable_ocr'] ) && '1' === $settings['enable_ocr'] ) : ?>
+				<div class="misc-pub-section">
+					<label for="rescan-ocr">
+						<input type="checkbox" value="yes" id="rescan-ocr" name="rescan-ocr"/>
+						<?php echo esc_html( $ocr ); ?>
+					</label>
+				</div>
+			<?php endif; ?>
+
+			<?php if ( $settings && isset( $settings['enable_smart_cropping'] ) && '1' === $settings['enable_smart_cropping'] ) : ?>
+				<div class="misc-pub-section">
+					<label for="rescan-smart-crop">
+						<input type="checkbox" value="yes" id="rescan-smart-crop" name="rescan-smart-crop"/>
+						<?php echo esc_html( $smart_crop ); ?>
+					</label>
+				</div>
+			<?php endif; ?>
 		</div>
 		<?php
 	}

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -590,7 +590,7 @@ class ComputerVision extends Provider {
 		$settings   = $this->get_settings();
 		if (
 			'no' !== $settings['enable_image_tagging'] ||
-			empty( $this->get_alt_text_settings() )
+			! empty( $this->get_alt_text_settings() )
 		) {
 
 			// Allow scanning image that are not stored in local storage.
@@ -743,13 +743,17 @@ class ComputerVision extends Provider {
 	protected function prep_api_url( array $routes = [] ) {
 		$settings     = $this->get_settings();
 		$api_features = [];
-		if ( in_array( 'alt-tags', $routes, true ) || ( isset( $settings['enable_image_captions'] ) && 'no' !== $settings['enable_image_captions'] ) ) {
+
+		if ( in_array( 'alt-tags', $routes, true ) || ! empty( $this->get_alt_text_settings() ) ) {
 			$api_features[] = 'Description';
 		}
-		if ( in_array( 'image-tags', $routes, true ) || ( isset( $settings['enable_image_captions'] ) && 'no' !== $settings['enable_image_tagging'] ) ) {
+
+		if ( in_array( 'image-tags', $routes, true ) || ( isset( $settings['enable_image_tagging'] ) && 'no' !== $settings['enable_image_tagging'] ) ) {
 			$api_features[] = 'Tags';
 		}
+
 		$endpoint = add_query_arg( 'visualFeatures', implode( ',', $api_features ), trailingslashit( $settings['url'] ) . $this->analyze_url );
+
 		return $endpoint;
 	}
 
@@ -980,7 +984,7 @@ class ComputerVision extends Provider {
 				'label_for'     => 'enable_image_captions',
 				'input_type'    => 'checkbox',
 				'default_value' => $default_settings['enable_image_captions'],
-				'description'   => __( 'The alt text field will be filled out automatically.', 'classifai' ),
+				'description'   => __( 'Choose image fields where the generated captions should be applied.', 'classifai' ),
 			]
 		);
 		add_settings_field(

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -118,23 +118,22 @@ class ComputerVision extends Provider {
 	 */
 	public function register() {
 		add_action( 'add_meta_boxes_attachment', [ $this, 'setup_attachment_meta_box' ] );
+		add_filter( 'attachment_fields_to_edit', [ $this, 'add_rescan_button_to_media_modal' ], 10, 2 );
 		add_action( 'edit_attachment', [ $this, 'maybe_rescan_image' ] );
 		add_filter( 'posts_clauses', [ $this, 'filter_attachment_query_keywords' ], 10, 1 );
 		add_filter( 'wp_generate_attachment_metadata', [ $this, 'smart_crop_image' ], 7, 2 );
 		add_filter( 'wp_generate_attachment_metadata', [ $this, 'generate_image_alt_tags' ], 8, 2 );
 		add_filter( 'posts_clauses', [ $this, 'filter_attachment_query_keywords' ], 10, 1 );
 
-		$settings   = $this->get_settings();
-		$enable_ocr = isset( $settings['enable_ocr'] ) && '1' === $settings['enable_ocr'];
+		$settings = $this->get_settings();
 
-		if ( $enable_ocr ) {
+		if ( isset( $settings['enable_ocr'] ) && '1' === $settings['enable_ocr'] ) {
 			add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_editor_assets' ] );
 			add_filter( 'the_content', [ $this, 'add_ocr_aria_describedby' ] );
 			add_filter( 'rest_api_init', [ $this, 'add_ocr_data_to_api_response' ] );
 		}
 
-		$enable_read_pdf = isset( $settings['enable_read_pdf'] ) && '1' === $settings['enable_read_pdf'];
-		if ( $enable_read_pdf ) {
+		if ( isset( $settings['enable_read_pdf'] ) && '1' === $settings['enable_read_pdf'] ) {
 			add_action( 'add_attachment', [ $this, 'read_pdf' ] );
 			add_action( 'classifai_retry_get_read_result', [ $this, 'do_read_cron' ], 10, 2 );
 			add_action( 'wp_ajax_classifai_get_read_status', [ $this, 'get_read_status_ajax' ] );
@@ -235,7 +234,7 @@ class ComputerVision extends Provider {
 	 * @param \WP_Post $post The post object.
 	 */
 	public function setup_attachment_meta_box( $post ) {
-		$settings = get_option( 'classifai_computer_vision' );
+		$settings = $this->get_settings();
 
 		if ( wp_attachment_is_image( $post ) ) {
 			add_meta_box(
@@ -335,6 +334,78 @@ class ComputerVision extends Provider {
 			</div>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Adds the rescan buttons to the media modal.
+	 *
+	 * @param array    $form_fields Array of fields
+	 * @param \WP_post $post        Post object for the attachment being viewed.
+	 */
+	public function add_rescan_button_to_media_modal( $form_fields, $post ) {
+		$settings = $this->get_settings();
+
+		if ( attachment_is_pdf( $post ) && is_array( $settings ) && isset( $settings['enable_read_pdf'] ) && '1' === $settings['enable_read_pdf'] ) {
+			$read_text = empty( get_the_content( null, false, $post ) ) ? __( 'Scan', 'classifai' ) : __( 'Rescan', 'classifai' );
+			$status    = get_post_meta( $post->ID, '_classifai_azure_read_status', true );
+			if ( ! empty( $status['status'] ) && 'running' === $status['status'] ) {
+				$html = '<button class="button secondary" disabled>' . esc_html__( 'In progress!', 'classifai' ) . '</button>';
+			} else {
+				$html = '<button class="button secondary" id="classifai-rescan-pdf" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $read_text ) . '</button>';
+			}
+
+			$form_fields['rescan_pdf'] = [
+				'label'        => __( 'Scan PDF for text', 'classifai' ),
+				'input'        => 'html',
+				'html'         => $html,
+				'show_in_edit' => false,
+			];
+		}
+
+		if ( wp_attachment_is_image( $post ) ) {
+			$alt_tags_text   = empty( get_post_meta( $post->ID, '_wp_attachment_image_alt', true ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
+			$image_tags_text = empty( wp_get_object_terms( $post->ID, 'classifai-image-tags' ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
+			$ocr_text        = empty( get_post_meta( $post->ID, 'classifai_computer_vision_ocr', true ) ) ? __( 'Scan', 'classifai' ) : __( 'Rescan', 'classifai' );
+			$smart_crop_text = empty( get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ) ? __( 'Generate', 'classifai' ) : __( 'Regenerate', 'classifai' );
+
+			if ( ! empty( $this->get_alt_text_settings() ) ) {
+				$form_fields['rescan_alt_tags'] = [
+					'label'        => __( 'Descriptive text', 'classifai' ),
+					'input'        => 'html',
+					'html'         => '<button class="button secondary" id="classifai-rescan-alt-tags" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $alt_tags_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
+					'show_in_edit' => false,
+				];
+			}
+
+			if ( is_array( $settings ) && isset( $settings['enable_image_tagging'] ) && '1' === $settings['enable_image_tagging'] ) {
+				$form_fields['rescan_captions'] = [
+					'label'        => __( 'Image tags', 'classifai' ),
+					'input'        => 'html',
+					'html'         => '<button class="button secondary" id="classifai-rescan-image-tags" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $image_tags_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
+					'show_in_edit' => false,
+				];
+			}
+
+			if ( is_array( $settings ) && isset( $settings['enable_smart_cropping'] ) && '1' === $settings['enable_smart_cropping'] ) {
+				$form_fields['rescan_smart_crop'] = [
+					'label'        => __( 'Smart thumbnail', 'classifai' ),
+					'input'        => 'html',
+					'html'         => '<button class="button secondary" id="classifai-rescan-smart-crop" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $smart_crop_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
+					'show_in_edit' => false,
+				];
+			}
+
+			if ( is_array( $settings ) && isset( $settings['enable_ocr'] ) && '1' === $settings['enable_ocr'] ) {
+				$form_fields['rescan_ocr'] = [
+					'label'        => __( 'Scan image for text', 'classifai' ),
+					'input'        => 'html',
+					'html'         => '<button class="button secondary" id="classifai-rescan-ocr" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $ocr_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
+					'show_in_edit' => false,
+				];
+			}
+		}
+
+		return $form_fields;
 	}
 
 	/**

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -269,10 +269,12 @@ abstract class Provider {
 		$default_value = '';
 
 		if ( isset( $setting_index['enable_image_captions'] ) ) {
-			if ( ! is_array( $setting_index['enable_image_captions'] ) && '1' === $setting_index['enable_image_captions'] ) {
-				$default_value = 'alt';
-			} elseif ( ! is_array( $setting_index['enable_image_captions'] ) && 'no' === $setting_index['enable_image_captions'] ) {
-				$default_value = '';
+			if ( ! is_array( $setting_index['enable_image_captions'] ) ) {
+				if ( '1' === $setting_index['enable_image_captions'] ) {
+					$default_value = 'alt';
+				} elseif ( 'no' === $setting_index['enable_image_captions'] ) {
+					$default_value = '';
+				}
 			}
 		}
 
@@ -307,10 +309,13 @@ abstract class Provider {
 			);
 		}
 
-		printf(
-			'<span class="description">%s</span>',
-			esc_html__( 'Choose image fields where the generated captions should be applied.', 'classifai' )
-		);
+		// Render description, if any.
+		if ( ! empty( $args['description'] ) ) {
+			printf(
+				'<span class="description classifai-input-description">%s</span>',
+				esc_html( $args['description'] )
+			);
+		}
 	}
 
 	/**

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -94,20 +94,25 @@ class ImageProcessing extends Service {
 			$image_tags_text = empty( wp_get_object_terms( $post->ID, 'classifai-image-tags' ) ) ? __( 'Generate', 'classifai' ) : __( 'Rescan', 'classifai' );
 			$ocr_text        = empty( get_post_meta( $post->ID, 'classifai_computer_vision_ocr', true ) ) ? __( 'Scan', 'classifai' ) : __( 'Rescan', 'classifai' );
 			$smart_crop_text = empty( get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ) ? __( 'Generate', 'classifai' ) : __( 'Regenerate', 'classifai' );
+			$settings        = get_option( 'classifai_computer_vision' );
 
-			$form_fields['rescan_alt_tags'] = [
-				'label'        => __( 'Descriptive text', 'classifai' ),
-				'input'        => 'html',
-				'html'         => '<button class="button secondary" id="classifai-rescan-alt-tags" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $alt_tags_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
-				'show_in_edit' => false,
-			];
+			if ( $settings && isset( $settings['enable_image_captions']['description'] ) && '1' === $settings['enable_image_captions']['description'] ) {
+				$form_fields['rescan_alt_tags'] = [
+					'label'        => __( 'Descriptive text', 'classifai' ),
+					'input'        => 'html',
+					'html'         => '<button class="button secondary" id="classifai-rescan-alt-tags" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $alt_tags_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
+					'show_in_edit' => false,
+				];
+			}
 
-			$form_fields['rescan_captions'] = [
-				'label'        => __( 'Image tags', 'classifai' ),
-				'input'        => 'html',
-				'html'         => '<button class="button secondary" id="classifai-rescan-image-tags" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $image_tags_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
-				'show_in_edit' => false,
-			];
+			if ( $settings && isset( $settings['enable_image_tagging'] ) && '1' === $settings['enable_image_tagging'] ) {
+				$form_fields['rescan_captions'] = [
+					'label'        => __( 'Image tags', 'classifai' ),
+					'input'        => 'html',
+					'html'         => '<button class="button secondary" id="classifai-rescan-image-tags" data-id="' . esc_attr( absint( $post->ID ) ) . '">' . esc_html( $image_tags_text ) . '</button><span class="spinner" style="display:none;float:none;"></span><span class="error" style="display:none;color:#bc0b0b;padding:5px;"></span>',
+					'show_in_edit' => false,
+				];
+			}
 
 			if ( $settings && isset( $settings['enable_smart_cropping'] ) && '1' === $settings['enable_smart_cropping'] ) {
 				$form_fields['rescan_smart_crop'] = [

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -96,7 +96,7 @@ class ImageProcessing extends Service {
 			$smart_crop_text = empty( get_transient( 'classifai_azure_computer_vision_smart_cropping_latest_response' ) ) ? __( 'Generate', 'classifai' ) : __( 'Regenerate', 'classifai' );
 			$settings        = get_option( 'classifai_computer_vision' );
 
-			if ( $settings && isset( $settings['enable_image_captions']['description'] ) && '1' === $settings['enable_image_captions']['description'] ) {
+			if ( $settings && isset( $settings['enable_image_captions']['description'] ) && 'description' === $settings['enable_image_captions']['description'] ) {
 				$form_fields['rescan_alt_tags'] = [
 					'label'        => __( 'Descriptive text', 'classifai' ),
 					'input'        => 'html',

--- a/tests/Classifai/Providers/Azure/ComputerVisionTest.php
+++ b/tests/Classifai/Providers/Azure/ComputerVisionTest.php
@@ -98,6 +98,7 @@ class ComputerVisionTest extends WP_UnitTestCase {
 		// Create A settings object
 		$settings = [
 			'url'                   => '',
+			'api_key'               => '',
 			'enable_image_tagging'  => 'no',
 			'enable_image_captions' => array(
 				'alt'         => 0,

--- a/tests/Classifai/Providers/Azure/ComputerVisionTest.php
+++ b/tests/Classifai/Providers/Azure/ComputerVisionTest.php
@@ -97,7 +97,8 @@ class ComputerVisionTest extends WP_UnitTestCase {
 	public function test_set_image_meta_data() {
 		// Create A settings object
 		$settings = [
-			'enable_image_tagging' => 'no',
+			'url'                   => '',
+			'enable_image_tagging'  => 'no',
 			'enable_image_captions' => array(
 				'alt'         => 0,
 				'caption'     => 0,

--- a/tests/cypress/integration/image-processing.test.js
+++ b/tests/cypress/integration/image-processing.test.js
@@ -92,6 +92,8 @@ describe('Image processing Tests', () => {
 		cy.visit('/wp-admin/admin.php?page=image_processing');
 
 		// Disable features
+		cy.get('#computer_vision_enable_image_captions_alt').uncheck();
+		cy.get('#computer_vision_enable_image_captions_caption').uncheck();
 		cy.get('#computer_vision_enable_image_captions_description').uncheck();
 		cy.get('#enable_image_tagging').uncheck();
 		cy.get('#enable_smart_cropping').uncheck();

--- a/tests/cypress/integration/image-processing.test.js
+++ b/tests/cypress/integration/image-processing.test.js
@@ -92,12 +92,20 @@ describe('Image processing Tests', () => {
 		cy.visit('/wp-admin/admin.php?page=image_processing');
 
 		// Disable features
+		cy.get('#computer_vision_enable_image_captions_description').uncheck();
+		cy.get('#enable_image_tagging').uncheck();
 		cy.get('#enable_smart_cropping').uncheck();
 		cy.get('#enable_ocr').uncheck();
 		cy.get('#submit').click();
 
 		// Verify with Image processing features are not present in attachment metabox.
 		cy.visit(imageEditLink);
+		cy.get('.misc-publishing-actions label[for=rescan-captions]').should(
+			'not.exist'
+		);
+		cy.get('.misc-publishing-actions label[for=rescan-tags]').should(
+			'not.exist'
+		);
 		cy.get('.misc-publishing-actions label[for=rescan-ocr]').should(
 			'not.exist'
 		);
@@ -108,6 +116,8 @@ describe('Image processing Tests', () => {
 		// Verify with Image processing features are not present in media model.
 		cy.visit(mediaModelLink);
 		cy.get('.media-modal').should('exist');
+		cy.get('#classifai-rescan-alt-tags').should('not.exist');
+		cy.get('#classifai-rescan-captions').should('not.exist');
 		cy.get('#classifai-rescan-smart-crop').should('not.exist');
 		cy.get('#classifai-rescan-ocr').should('not.exist');
 	});

--- a/tests/cypress/integration/image-processing.test.js
+++ b/tests/cypress/integration/image-processing.test.js
@@ -17,6 +17,8 @@ describe('Image processing Tests', () => {
 			.type('http://e2e-test-image-processing.test');
 		cy.get('#api_key').clear().type('password');
 		cy.get('#computer_vision_enable_image_captions_alt').check();
+		cy.get('#computer_vision_enable_image_captions_description').check();
+		cy.get('#enable_image_tagging').check();
 		cy.get('#enable_smart_cropping').check();
 		cy.get('#enable_ocr').check();
 		cy.get('#submit').click();


### PR DESCRIPTION
### Description of the Change

- When Dashboard > ClassifAI > Image Processing > Microsoft Azure > Generate descriptive text > "Image description" is unchecked, the corresponding "Generate" button should be hidden in the Media Library's view for individual images
- When Dashboard > ClassifAI > Image Processing > Microsoft Azure > Tag Images > "Image tags will be added automatically" is unchecked, the corresponding "Generate" button should be hidden in the Media Library's view for individual images
- Updates tests for same

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/classifai/issues/427

### How to test the Change

In Dashboard > ClassifAI > Image Processing > Microsoft Azure, for different combinations of these settings:

- Generate descriptive text > Image description
- Tag Images
- Enable smart cropping (not modified in this PR, used as a control test)
- Scan images for text (not modified in this PR, used as a control test)

Do:

1. check or uncheck the box
2. Save the Image Processing settings changes
3. Go to the Media Library and edit a piece of media. The buttons displayed at the bottom of the details pane should correspond to checked settings as follows:

Setting | Button
:-- | :--
Generate descriptive text | Descriptive text [Generate]
Tag images | Image tags [Generate]
Enable smart cropping | Smart thumbnail [Generate]
Scan images for text | Scan image for text [Scan]

### Changelog Entry

Fixed: Buttons to generate descriptive text and tags for images are no longer displayed when those settings are disabled in Microsoft Azure Image Processing settings


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dkotter, @benlk


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
