### PR TITLE
415: Remove the authentication check when registering the Watson NLU

### DIFF
--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -122,8 +122,10 @@ class NLU extends Provider {
 	 * @return bool
 	 */
 	public function can_register() {
-		if ( $this->nlu_authentication_check_failed( $this->get_settings() ) ) {
-			return false;
+		$settings = $this->get_settings();
+
+		if ( empty( $settings ) || ( isset( $settings['authenticated'] ) && false === $settings['authenticated'] ) ) {
+			false;
 		}
 
 		return true;


### PR DESCRIPTION

### Description of the Change

When the Watson `NLU` Provider is registered with the plugin, instead of calling the Watson API to check whether the API key is valid, instead this now just checks whether we've saved whether the API key was previously authenticated. That means we're no longer pinging the Watson API for every request made to the server.

Closes #415

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry

Fixed: Removes an unnecessary Watson API authentication check on every page load.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dkotter, @benlk 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
