### PR TITLE
Ensure we don't send unnecessary API requests to NLU

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -113,20 +113,6 @@ class ComputerVision extends Provider {
 	}
 
 	/**
-	 * Can the functionality be initialized?
-	 *
-	 * @return bool
-	 */
-	public function can_register() {
-		$options = get_option( $this->get_option_name() );
-		if ( empty( $options ) || ( isset( $options['authenticated'] ) && false === $options['authenticated'] ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Register the functionality.
 	 */
 	public function register() {

--- a/includes/Classifai/Providers/Azure/Personalizer.php
+++ b/includes/Classifai/Providers/Azure/Personalizer.php
@@ -71,20 +71,6 @@ class Personalizer extends Provider {
 	}
 
 	/**
-	 * Can the functionality be initialized?
-	 *
-	 * @return bool
-	 */
-	public function can_register() {
-		$options = get_option( $this->get_option_name() );
-		if ( empty( $options ) || ( isset( $options['authenticated'] ) && false === $options['authenticated'] ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Register the functionality.
 	 */
 	public function register() {

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -61,21 +61,6 @@ class ChatGPT extends Provider {
 	}
 
 	/**
-	 * Can the functionality be initialized?
-	 *
-	 * @return bool
-	 */
-	public function can_register() {
-		$settings = $this->get_settings();
-
-		if ( empty( $settings ) || ( isset( $settings['authenticated'] ) && false === $settings['authenticated'] ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Register what we need for the plugin.
 	 *
 	 * This only fires if can_register returns true.

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -45,21 +45,6 @@ class DallE extends Provider {
 	}
 
 	/**
-	 * Can the functionality be initialized?
-	 *
-	 * @return bool
-	 */
-	public function can_register() {
-		$settings = $this->get_settings();
-
-		if ( empty( $settings ) || ( isset( $settings['authenticated'] ) && false === $settings['authenticated'] ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Register what we need for the provider.
 	 *
 	 * This only fires if can_register returns true.

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -110,7 +110,9 @@ abstract class Provider {
 	/**
 	 * Can the Provider be initalized?
 	 */
-	abstract public function can_register();
+	public function can_register() {
+		return $this->is_configured();
+	}
 
 	/**
 	 * Register the functionality for the Provider.

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -118,15 +118,6 @@ class NLU extends Provider {
 	}
 
 	/**
-	 * Can the functionality be initialized?
-	 *
-	 * @return bool
-	 */
-	public function can_register() {
-		return $this->is_configured();
-	}
-
-	/**
 	 * Register what we need for the plugin.
 	 */
 	public function register() {

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -9,6 +9,7 @@ use Classifai\Admin\SavePostHandler;
 use Classifai\Admin\PreviewClassifierData;
 use Classifai\Providers\Provider;
 use Classifai\Taxonomy\TaxonomyFactory;
+use WP_Error;
 
 use function Classifai\get_asset_info;
 use function Classifai\get_post_types_for_language_settings;
@@ -122,11 +123,7 @@ class NLU extends Provider {
 	 * @return bool
 	 */
 	public function can_register() {
-		if ( $this->nlu_authentication_check_failed( $this->get_settings() ) ) {
-			return false;
-		}
-
-		return true;
+		return $this->is_configured();
 	}
 
 	/**
@@ -600,9 +597,9 @@ class NLU extends Provider {
 	 *
 	 * @param array $settings The list of settings to be saved
 	 *
-	 * @return bool
+	 * @return bool|WP_Error
 	 */
-	protected function nlu_authentication_check_failed( $settings ) {
+	protected function nlu_authentication_check( $settings ) {
 
 		// Check that we have credentials before hitting the API.
 		if ( ! isset( $settings['credentials'] )
@@ -610,7 +607,7 @@ class NLU extends Provider {
 			|| empty( $settings['credentials']['watson_password'] )
 			|| empty( $settings['credentials']['watson_url'] )
 		) {
-			return true;
+			return new WP_Error( 'auth', esc_html__( 'Please enter your credentials.', 'classifai' ) );
 		}
 
 		$request           = new \Classifai\Watson\APIRequest();
@@ -634,15 +631,13 @@ class NLU extends Provider {
 		];
 		$response          = $request->post( $url, $options );
 
-		$is_error = is_wp_error( $response );
-		if ( ! $is_error ) {
+		if ( ! is_wp_error( $response ) ) {
 			update_option( 'classifai_configured', true );
+			return true;
 		} else {
 			delete_option( 'classifai_configured' );
+			return $response;
 		}
-
-		return $is_error;
-
 	}
 
 
@@ -654,14 +649,19 @@ class NLU extends Provider {
 	 * @return array The sanitized settings to be saved.
 	 */
 	public function sanitize_settings( $settings ) {
-		$new_settings = $this->get_settings();
-		if ( $this->nlu_authentication_check_failed( $settings ) ) {
+		$new_settings  = $this->get_settings();
+		$authenticated = $this->nlu_authentication_check( $settings );
+
+		if ( is_wp_error( $authenticated ) ) {
+			$new_settings['authenticated'] = false;
 			add_settings_error(
 				'credentials',
 				'classifai-auth',
-				esc_html__( 'IBM Watson NLU Authentication Failed. Please check credentials.', 'classifai' ),
+				$authenticated->get_error_message(),
 				'error'
 			);
+		} else {
+			$new_settings['authenticated'] = true;
 		}
 
 		if ( isset( $settings['credentials']['watson_url'] ) ) {
@@ -903,9 +903,20 @@ class NLU extends Provider {
 	/**
 	 * Returns whether the provider is configured or not.
 	 *
+	 * For backwards compat, we've maintained the use of the
+	 * `classifai_configured` option. We default to looking for
+	 * the `authenticated` setting though.
+	 *
 	 * @return bool
 	 */
 	public function is_configured() {
-		return get_option( 'classifai_configured', false );
+		$is_configured = parent::is_configured();
+
+		if ( ! $is_configured ) {
+			$is_configured = (bool) get_option( 'classifai_configured', false );
+		}
+
+		return $is_configured;
 	}
+
 }


### PR DESCRIPTION
### Description of the Change

As detailed in #415, there's a request on each page load (admin or front-end) to the NLU API to check to see if authentication is valid. These requests are unnecessary, leading to potential performance issues but more importantly, extra API usage.

This PR fixes that by refactoring the `can_register` method that all Providers use. For all other Providers besides NLU, we've removed the `can_register` method and instead rely on the parent `can_register` method.

For NLU, the `can_register` method now calls the `is_configured` method, which calls the parent `is_configured` method (matching what other providers do) but also checks the existing `classifai_configured` option to retain backwards compatibility. These changes fix the extra API requests, remove duplicate code and helps make things a little more consistent between Providers. 

Closes #415 

### How to test the Change

Ensure all Providers still work if configured properly and don't work if not configured properly

### Changelog Entry

> Changed - Standardize on how we determine if a Provider is configured
> Fixed - Avoid extra API requests to the NLU endpoint

### Credits

Props @dkotter, @benlk 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
