### PR TITLE
Ensure you can properly remove Providers

### DIFF
--- a/includes/Classifai/Admin/Onboarding.php
+++ b/includes/Classifai/Admin/Onboarding.php
@@ -424,6 +424,10 @@ class Onboarding {
 			$service_slug = $service->get_menu_slug();
 			$features     = array();
 
+			if ( empty( $service->provider_classes ) ) {
+				continue;
+			}
+
 			foreach ( $service->provider_classes as $provider_class ) {
 				$options = $provider_class->get_onboarding_options();
 				if ( ! empty( $options ) && ! empty( $options['features'] ) ) {
@@ -458,6 +462,10 @@ class Onboarding {
 		$providers       = [];
 
 		foreach ( $service_manager->service_classes as $service ) {
+			if ( empty( $service->provider_classes ) ) {
+				continue;
+			}
+
 			foreach ( $service->provider_classes as $provider_class ) {
 				$providers[ $provider_class->get_option_name() ] = $provider_class;
 			}

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -44,9 +44,16 @@ function get_plugin_settings( $service = '', $provider = '' ) {
 		return [];
 	}
 
+	// Ensure we have at least one provider.
+	$providers = $service_manager->service_classes[ $service ]->provider_classes;
+
+	if ( empty( $providers ) ) {
+		return [];
+	}
+
 	// If we want settings for a specific provider, find the proper provider service.
 	if ( ! empty( $provider ) ) {
-		foreach ( $service_manager->service_classes[ $service ]->provider_classes as $provider_class ) {
+		foreach ( $providers as $provider_class ) {
 			if ( $provider_class->provider_service_name === $provider ) {
 				return $provider_class->get_settings();
 			}
@@ -56,7 +63,7 @@ function get_plugin_settings( $service = '', $provider = '' ) {
 	}
 
 	/** @var Provider $provider An instance or extension of the provider abstract class. */
-	$provider = $service_manager->service_classes[ $service ]->provider_classes[0];
+	$provider = $providers[0];
 	return $provider->get_settings();
 }
 

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -5,6 +5,7 @@ namespace Classifai;
 use Classifai\Providers\Provider;
 use Classifai\Services\Service;
 use Classifai\Services\ServicesManager;
+use WP_Error;
 
 /**
  * Miscellaneous Helper functions to access different parts of the
@@ -660,4 +661,27 @@ function clean_input( string $key = '', bool $is_get = false, string $sanitize_c
 	}
 
 	return false;
+}
+
+/**
+ * Find the provider class that a service belongs to.
+ *
+ * @param array  $provider_classes Provider classes to look in.
+ * @param string $service_name Service name to look for.
+ * @return Provider|WP_Error
+ */
+function find_provider_class( array $provider_classes = [], string $service_name = '' ) {
+	$provider = '';
+
+	foreach ( $provider_classes as $provider_class ) {
+		if ( $service_name === $provider_class->provider_service_name ) {
+			$provider = $provider_class;
+		}
+	}
+
+	if ( ! $provider ) {
+		return new WP_Error( 'provider_class_required', esc_html__( 'Provider class not found.', 'classifai' ) );
+	}
+
+	return $provider;
 }

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -51,7 +51,7 @@ class ImageProcessing extends Service {
 			true
 		);
 
-		$provider = find_provider_class( $this->provider_classes, 'Computer Vision' );
+		$provider = find_provider_class( $this->provider_classes ?? [], 'Computer Vision' );
 		if ( ! is_wp_error( $provider ) ) {
 			wp_add_inline_script(
 				'classifai-media-script',
@@ -236,7 +236,7 @@ class ImageProcessing extends Service {
 		}
 
 		// Find the right provider class.
-		$provider = find_provider_class( $this->provider_classes, 'Computer Vision' );
+		$provider = find_provider_class( $this->provider_classes ?? [], 'Computer Vision' );
 
 		// Ensure we have a provider class. Should never happen but :shrug:
 		if ( is_wp_error( $provider ) ) {
@@ -304,7 +304,7 @@ class ImageProcessing extends Service {
 	 */
 	public function generate_image( WP_REST_Request $request ) {
 		// Find the right provider class.
-		$provider = find_provider_class( $this->provider_classes, 'DALL·E' );
+		$provider = find_provider_class( $this->provider_classes ?? [], 'DALL·E' );
 
 		// Ensure we have a provider class. Should never happen but :shrug:
 		if ( is_wp_error( $provider ) ) {

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -9,8 +9,8 @@ use Classifai\Taxonomy\ImageTagTaxonomy;
 use WP_REST_Server;
 use WP_REST_Request;
 use WP_Error;
-use function Classifai\attachment_is_pdf;
 use function Classifai\get_asset_info;
+use function Classifai\find_provider_class;
 
 class ImageProcessing extends Service {
 
@@ -51,15 +51,18 @@ class ImageProcessing extends Service {
 			true
 		);
 
-		wp_add_inline_script(
-			'classifai-media-script',
-			'const classifaiMediaVars = ' . wp_json_encode(
-				array(
-					'enabledAltTextFields' => $this->provider_classes[0]->get_alt_text_settings() ? $this->provider_classes[0]->get_alt_text_settings() : array(),
-				)
-			),
-			'before'
-		);
+		$provider = find_provider_class( $this->provider_classes, 'Computer Vision' );
+		if ( ! is_wp_error( $provider ) ) {
+			wp_add_inline_script(
+				'classifai-media-script',
+				'const classifaiMediaVars = ' . wp_json_encode(
+					array(
+						'enabledAltTextFields' => $provider->get_alt_text_settings() ? $provider->get_alt_text_settings() : array(),
+					)
+				),
+				'before'
+			);
+		}
 	}
 
 	/**
@@ -220,7 +223,6 @@ class ImageProcessing extends Service {
 		$attachment_id = $request->get_param( 'id' );
 		$custom_atts   = $request->get_attributes();
 		$route_to_call = empty( $custom_atts['args']['route'] ) ? false : strtolower( $custom_atts['args']['route'][0] );
-		$provider      = '';
 
 		// Check to be sure the post both exists and is an attachment.
 		if ( ! get_post( $attachment_id ) || 'attachment' !== get_post_type( $attachment_id ) ) {
@@ -234,15 +236,11 @@ class ImageProcessing extends Service {
 		}
 
 		// Find the right provider class.
-		foreach ( $this->provider_classes as $provider_class ) {
-			if ( 'Computer Vision' === $provider_class->provider_service_name ) {
-				$provider = $provider_class;
-			}
-		}
+		$provider = find_provider_class( $this->provider_classes, 'Computer Vision' );
 
 		// Ensure we have a provider class. Should never happen but :shrug:
-		if ( ! $provider ) {
-			return new WP_Error( 'provider_class_required', esc_html__( 'Provider class not found.', 'classifai' ) );
+		if ( is_wp_error( $provider ) ) {
+			return $provider;
 		}
 
 		// Call the provider endpoint function
@@ -305,18 +303,12 @@ class ImageProcessing extends Service {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public function generate_image( WP_REST_Request $request ) {
-		$provider = '';
-
 		// Find the right provider class.
-		foreach ( $this->provider_classes as $provider_class ) {
-			if ( 'DALL·E' === $provider_class->provider_service_name ) {
-				$provider = $provider_class;
-			}
-		}
+		$provider = find_provider_class( $this->provider_classes, 'DALL·E' );
 
 		// Ensure we have a provider class. Should never happen but :shrug:
-		if ( ! $provider ) {
-			return new WP_Error( 'provider_class_required', esc_html__( 'Provider class not found.', 'classifai' ) );
+		if ( is_wp_error( $provider ) ) {
+			return $provider;
 		}
 
 		return rest_ensure_response(

--- a/includes/Classifai/Services/LanguageProcessing.php
+++ b/includes/Classifai/Services/LanguageProcessing.php
@@ -6,6 +6,7 @@
 namespace Classifai\Services;
 
 use Classifai\Admin\SavePostHandler;
+use function Classifai\find_provider_class;
 use WP_REST_Server;
 use WP_REST_Request;
 use WP_Error;
@@ -174,19 +175,14 @@ class LanguageProcessing extends Service {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public function generate_post_excerpt( WP_REST_Request $request ) {
-		$post_id  = $request->get_param( 'id' );
-		$provider = '';
+		$post_id = $request->get_param( 'id' );
 
 		// Find the right provider class.
-		foreach ( $this->provider_classes as $provider_class ) {
-			if ( 'ChatGPT' === $provider_class->provider_service_name ) {
-				$provider = $provider_class;
-			}
-		}
+		$provider = find_provider_class( $this->provider_classes, 'DALL·E' );
 
 		// Ensure we have a provider class. Should never happen but :shrug:
-		if ( ! $provider ) {
-			return new WP_Error( 'provider_class_required', esc_html__( 'Provider class not found.', 'classifai' ) );
+		if ( is_wp_error( $provider ) ) {
+			return $provider;
 		}
 
 		return rest_ensure_response( $provider->rest_endpoint_callback( $post_id, 'excerpt' ) );

--- a/includes/Classifai/Services/LanguageProcessing.php
+++ b/includes/Classifai/Services/LanguageProcessing.php
@@ -178,7 +178,7 @@ class LanguageProcessing extends Service {
 		$post_id = $request->get_param( 'id' );
 
 		// Find the right provider class.
-		$provider = find_provider_class( $this->provider_classes ?? [], 'DALL·E' );
+		$provider = find_provider_class( $this->provider_classes ?? [], 'ChatGPT' );
 
 		// Ensure we have a provider class. Should never happen but :shrug:
 		if ( is_wp_error( $provider ) ) {

--- a/includes/Classifai/Services/LanguageProcessing.php
+++ b/includes/Classifai/Services/LanguageProcessing.php
@@ -178,7 +178,7 @@ class LanguageProcessing extends Service {
 		$post_id = $request->get_param( 'id' );
 
 		// Find the right provider class.
-		$provider = find_provider_class( $this->provider_classes, 'DALL·E' );
+		$provider = find_provider_class( $this->provider_classes ?? [], 'DALL·E' );
 
 		// Ensure we have a provider class. Should never happen but :shrug:
 		if ( is_wp_error( $provider ) ) {

--- a/includes/Classifai/Services/Personalizer.php
+++ b/includes/Classifai/Services/Personalizer.php
@@ -69,7 +69,7 @@ class Personalizer extends Service {
 			}
 		}
 
-		$provider = find_provider_class( $this->provider_classes, 'Personalizer' );
+		$provider = find_provider_class( $this->provider_classes ?? [], 'Personalizer' );
 
 		if ( ! is_wp_error( $provider ) ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -146,7 +146,7 @@ class Personalizer extends Service {
 			}
 
 			// Find the right provider class.
-			$provider = find_provider_class( $this->provider_classes, 'Personalizer' );
+			$provider = find_provider_class( $this->provider_classes ?? [], 'Personalizer' );
 
 			// Ensure we have a provider class. Should never happen but :shrug:
 			if ( is_wp_error( $provider ) ) {

--- a/includes/Classifai/Services/Personalizer.php
+++ b/includes/Classifai/Services/Personalizer.php
@@ -5,6 +5,7 @@
 
 namespace Classifai\Services;
 
+use function Classifai\find_provider_class;
 use WP_REST_Server;
 use WP_REST_Request;
 use WP_Error;
@@ -68,8 +69,13 @@ class Personalizer extends Service {
 			}
 		}
 
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo $this->provider_classes[0]->render_recommended_content( $attributes );
+		$provider = find_provider_class( $this->provider_classes, 'Personalizer' );
+
+		if ( ! is_wp_error( $provider ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $provider->render_recommended_content( $attributes );
+		}
+
 		exit();
 	}
 
@@ -128,7 +134,6 @@ class Personalizer extends Service {
 		$event_id = $request->get_param( 'eventId' );
 		$reward   = ( '1' === $request->get_param( 'rewarded' ) ) ? 1 : 0;
 		$route    = $request->get_param( 'route' ) ?? false;
-		$provider = '';
 
 		// If no args, respond 404.
 		if ( false === $route ) {
@@ -141,15 +146,11 @@ class Personalizer extends Service {
 			}
 
 			// Find the right provider class.
-			foreach ( $this->provider_classes as $provider_class ) {
-				if ( 'Personalizer' === $provider_class->provider_service_name ) {
-					$provider = $provider_class;
-				}
-			}
+			$provider = find_provider_class( $this->provider_classes, 'Personalizer' );
 
 			// Ensure we have a provider class. Should never happen but :shrug:
-			if ( ! $provider ) {
-				return new WP_Error( 'provider_class_required', esc_html__( 'Provider class not found.', 'classifai' ) );
+			if ( is_wp_error( $provider ) ) {
+				return $provider;
 			}
 
 			// Send reward to personalizer.

--- a/includes/Classifai/Services/Service.php
+++ b/includes/Classifai/Services/Service.php
@@ -127,6 +127,7 @@ abstract class Service {
 				<?php
 				if ( empty( $this->provider_classes ) ) {
 					echo '<p>' . esc_html__( 'No providers available for this service.', 'classifai' ) . '</p>';
+					echo '</div></div>';
 					return;
 				}
 				?>

--- a/includes/Classifai/Services/Service.php
+++ b/includes/Classifai/Services/Service.php
@@ -5,6 +5,7 @@
 
 namespace Classifai\Services;
 
+use function Classifai\find_provider_class;
 use WP_Error;
 
 abstract class Service {
@@ -137,7 +138,12 @@ abstract class Service {
 						submit_button();
 					?>
 					</form>
-					<?php if ( isset( $this->provider_classes[0] ) && ! empty( $this->provider_classes[0]->can_register() ) ) : ?>
+					<?php
+					// Find the right provider class.
+					$provider = find_provider_class( $this->provider_classes, 'Natural Language Understanding' );
+
+					if ( ! is_wp_error( $provider ) && ! empty( $provider->can_register() ) ) :
+						?>
 					<div id="classifai-post-preview-app">
 						<?php
 							$supported_post_statuses = \Classifai\get_supported_post_statuses();

--- a/includes/Classifai/Services/Service.php
+++ b/includes/Classifai/Services/Service.php
@@ -123,14 +123,22 @@ abstract class Service {
 			?>
 			<div class="classifai-wrap wrap wrap--nlu">
 				<h2><?php echo esc_html( $this->display_name ); ?></h2>
-				<?php if ( ! empty( $this->provider_classes ) ) : ?>
+
+				<?php
+				if ( empty( $this->provider_classes ) ) {
+					echo '<p>' . esc_html__( 'No providers available for this service.', 'classifai' ) . '</p>';
+					return;
+				}
+				?>
+
 				<h2 class="nav-tab-wrapper">
 					<?php foreach ( $this->provider_classes as $provider_class ) : ?>
 						<a href="<?php echo esc_url( add_query_arg( 'provider', $provider_class->get_settings_section(), $base_url ) ); ?>" class="nav-tab <?php echo $provider_class->get_settings_section() === $active_tab ? 'nav-tab-active' : ''; ?>"><?php echo esc_html( $provider_class->provider_name ); ?></a>
 					<?php endforeach; ?>
 				</h2>
-				<?php endif; ?>
+
 				<?php settings_errors(); ?>
+
 				<div class="classifai-nlu-sections">
 					<form method="post" action="options.php">
 					<?php

--- a/includes/Classifai/Services/Service.php
+++ b/includes/Classifai/Services/Service.php
@@ -107,7 +107,8 @@ abstract class Service {
 	 * Render the start of a settings page. The rest is added by the providers
 	 */
 	public function render_settings_page() {
-		$active_tab = isset( $_GET['provider'] ) ? sanitize_text_field( $_GET['provider'] ) : $this->provider_classes[0]->get_settings_section(); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$active_tab = $this->provider_classes ? $this->provider_classes[0]->get_settings_section() : '';
+		$active_tab = isset( $_GET['provider'] ) ? sanitize_text_field( $_GET['provider'] ) : $active_tab; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$base_url   = add_query_arg(
 			array(
 				'page' => 'classifai',
@@ -140,7 +141,7 @@ abstract class Service {
 					</form>
 					<?php
 					// Find the right provider class.
-					$provider = find_provider_class( $this->provider_classes, 'Natural Language Understanding' );
+					$provider = find_provider_class( $this->provider_classes ?? [], 'Natural Language Understanding' );
 
 					if ( ! is_wp_error( $provider ) && ! empty( $provider->can_register() ) ) :
 						?>


### PR DESCRIPTION
### Description of the Change

There's an existing filter, `{$this->menu_slug}_providers`, that allows you to filter the available Providers for each Service. This filter has been around for 4 years but in testing it out, it doesn't work properly.

The problem is we have a number of places where we reference our Provider Service with code like `$this->provider_classes[0]`. There are two issues with this:

1. We assume the Provider Service we want is always going to be the first within the `array`, which may not be true now that we've started to add multiple Services in each Provider
2. It assumes this is always an `array` that has at least one value. This is the issue that is preventing full usage of the mentioned filter

This PR fixes the second point in its entirety by making sure we always have an `array` of at least one Provider Service before we use that variable. This allows you to remove all Services from a particular Provider and not get any PHP errors.

It mostly fixes the first point as well by adding a new `find_provider_class` helper function to get the Provider Service based on the Provider name, instead of position within the `array`. I think there is still one place that references the Provider Service by `array` position but it seemed fine to leave for now.

If no Providers are registered within a Service, the Service still shows up in our settings but no inputs show and instead we show an error message:

<img width="747" alt="Service removed" src="https://github.com/10up/classifai/assets/916738/9040a13b-310d-4879-9d12-b097c59053cf">

Options also won't show in the new onboarding:

<img width="1281" alt="Only have a single Service registered" src="https://github.com/10up/classifai/assets/916738/4636d67d-e974-4ff7-a4d9-983a0d01a886">

This helps with #404 but doesn't completely close it 

### How to test the Change

1. Either within your theme's `functions.php` or within a custom plugin, utilize the `{$this->menu_slug}_providers` filter to remove one or more Services. Here's the code I've been using:
```php
add_action(
	'init',
	function() {
		$services = [
			'image_processing',
			'language_processing',
			'personalizer',
		];

		foreach ( $services as $service ) {
			add_filter(
				"{$service}_providers",
				function( array $providers = [] ) use ( $service ) {
					if ( 'image_processing' === $service ) {
						/**
						 * Default providers:
						 * 'Classifai\Providers\Azure\ComputerVision'
						 * 'Classifai\Providers\OpenAI\DallE'
						 */
						return [ 'Classifai\Providers\OpenAI\DallE' ];
					}

					if ( 'language_processing' === $service ) {
						/**
						 * Default providers:
						 * 'Classifai\Providers\Watson\NLU'
						 * 'Classifai\Providers\OpenAI\ChatGPT'
						 */
						return [];
					}

					if ( 'personalizer' === $service ) {
						/**
						 * Default providers:
						 * Classifai\Providers\Azure\Personalizer
						 */
						return [];
					}
				}
			);
		}
	}
);
```
2. Go to the ClassifAI settings and ensure the Services you've removed don't show any options but the ones you've left do show proper options
3. Ensure whichever Services you've left still work properly
4. Remove the above filter so all Services are back and ensure settings for all of them show and that all features work as expected
5. Ensure no PHP warnings/errors are logged at any step

### Changelog Entry

> Fixed - Ensure the `{$this->menu_slug}_providers` filter works as expected when used to remove Providers

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
