### PR TITLE
Correctly add terms to posts generated by Watson content classifiers

### DIFF
--- a/includes/Classifai/Watson/Linker.php
+++ b/includes/Classifai/Watson/Linker.php
@@ -40,22 +40,22 @@ class Linker {
 		$all_terms = [];
 
 		if ( ! empty( $output['categories'] ) ) {
-			$terms     = $this->link_categories( $post_id, $output['categories'] );
+			$terms     = $this->link_categories( $post_id, $output['categories'], false );
 			$all_terms = $terms;
 		}
 
 		if ( ! empty( $output['keywords'] ) ) {
-			$terms     = $this->link_keywords( $post_id, $output['keywords'] );
+			$terms     = $this->link_keywords( $post_id, $output['keywords'], false );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
 		if ( ! empty( $output['concepts'] ) ) {
-			$terms     = $this->link_concepts( $post_id, $output['concepts'] );
+			$terms     = $this->link_concepts( $post_id, $output['concepts'], false );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
 		if ( ! empty( $output['entities'] ) ) {
-			$terms     = $this->link_entities( $post_id, $output['entities'] );
+			$terms     = $this->link_entities( $post_id, $output['entities'], false );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
@@ -87,11 +87,11 @@ class Linker {
 	 *
 	 * @param int   $post_id The id of the post to link.
 	 * @param array $categories The list of categories to link
-	 * @param bool  $link_terms Whether link terms to post or return terms.
+	 * @param bool  $link_categories Whether link categories to post or return array of term ids.
 	 *
 	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
-	public function link_categories( int $post_id, array $categories, bool $link_terms = false ) {
+	public function link_categories( int $post_id, array $categories, bool $link_categories = true ) {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'category' );
 
@@ -127,7 +127,7 @@ class Linker {
 			return [];
 		}
 
-		if ( $link_terms ) {
+		if ( $link_categories ) {
 			$result = wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
 
 			if ( is_wp_error( $result ) ) {
@@ -150,11 +150,11 @@ class Linker {
 	 *
 	 * @param int   $post_id The id of the post to link.
 	 * @param array $keywords NLU returned keywords
-	 * @param bool  $link_terms Whether link terms to post or return terms.
+	 * @param bool  $link_keywords Whether link keywords to post or return array of term ids.
 	 *
 	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
-	public function link_keywords( int $post_id, array $keywords, bool $link_terms = false ) {
+	public function link_keywords( int $post_id, array $keywords, bool $link_keywords = true ) {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'keyword' );
 
@@ -181,7 +181,7 @@ class Linker {
 			return [];
 		}
 
-		if ( $link_terms ) {
+		if ( $link_keywords ) {
 			$result = wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
 
 			if ( is_wp_error( $result ) ) {
@@ -204,11 +204,11 @@ class Linker {
 	 *
 	 * @param int   $post_id The id of the post to link.
 	 * @param array $concepts The NLU returned concepts.
-	 * @param bool  $link_terms Whether link terms to post or return terms.
+	 * @param bool  $link_concepts Whether link concepts to post or return array of term ids.
 	 *
 	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
-	public function link_concepts( int $post_id, array $concepts, bool $link_terms = false ) {
+	public function link_concepts( int $post_id, array $concepts, bool $link_concepts = true ) {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'concept' );
 
@@ -242,7 +242,7 @@ class Linker {
 			return [];
 		}
 
-		if ( $link_terms ) {
+		if ( $link_concepts ) {
 			$result = wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
 
 			if ( is_wp_error( $result ) ) {
@@ -265,11 +265,11 @@ class Linker {
 	 *
 	 * @param int   $post_id The id of the post to link.
 	 * @param array $entities The entities returned by the NLU api
-	 * @param bool  $link_terms Whether link terms to post or return terms.
+	 * @param bool  $link_entities Whether link entities to post or return array of term ids.
 	 *
 	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
-	public function link_entities( int $post_id, array $entities, bool $link_terms = false ) {
+	public function link_entities( int $post_id, array $entities, bool $link_entities = true ) {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'entity' );
 
@@ -314,7 +314,7 @@ class Linker {
 			return [];
 		}
 
-		if ( $link_terms ) {
+		if ( $link_entities ) {
 			$result = wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
 
 			if ( is_wp_error( $result ) ) {

--- a/includes/Classifai/Watson/Linker.php
+++ b/includes/Classifai/Watson/Linker.php
@@ -40,22 +40,22 @@ class Linker {
 		$all_terms = [];
 
 		if ( ! empty( $output['categories'] ) ) {
-			$terms = $this->link_categories( $post_id, $output['categories'], true );
+			$terms     = $this->link_categories( $post_id, $output['categories'], true );
 			$all_terms = $terms;
 		}
 
 		if ( ! empty( $output['keywords'] ) ) {
-			$terms = $this->link_keywords( $post_id, $output['keywords'], true );
+			$terms     = $this->link_keywords( $post_id, $output['keywords'], true );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
 		if ( ! empty( $output['concepts'] ) ) {
-			$terms = $this->link_concepts( $post_id, $output['concepts'], true );
+			$terms     = $this->link_concepts( $post_id, $output['concepts'], true );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
 		if ( ! empty( $output['entities'] ) ) {
-			$terms = $this->link_entities( $post_id, $output['entities'], true );
+			$terms     = $this->link_entities( $post_id, $output['entities'], true );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
@@ -86,6 +86,8 @@ class Linker {
 	 * @param int   $post_id The id of the post to link
 	 * @param array $categories The list of categories to link
 	 * @param bool  $return_terms Whether to return the terms to link or not
+	 *
+	 * @return array The terms to link
 	 */
 	public function link_categories( int $post_id, array $categories, bool $return_terms = false ): array {
 		$terms_to_link = [];
@@ -139,6 +141,8 @@ class Linker {
 	 * @param int   $post_id The id of the post to link
 	 * @param array $keywords NLU returned keywords
 	 * @param bool  $return_terms Whether to return the terms to link or not
+	 *
+	 * @return array The terms to link
 	 */
 	public function link_keywords( int $post_id, array $keywords, bool $return_terms = false ): array {
 		$terms_to_link = [];
@@ -183,6 +187,8 @@ class Linker {
 	 * @param int   $post_id The id of the post to link
 	 * @param array $concepts The NLU returned concepts.
 	 * @param bool  $return_terms Whether to return the terms to link or not
+	 *
+	 * @return array The terms to link
 	 */
 	public function link_concepts( int $post_id, array $concepts, bool $return_terms = false ): array {
 		$terms_to_link = [];
@@ -234,6 +240,8 @@ class Linker {
 	 * @param int   $post_id The id of the post to link
 	 * @param array $entities The entities returned by the NLU api
 	 * @param bool  $return_terms Whether to return the terms to link or not
+	 *
+	 * @return array The terms to link
 	 */
 	public function link_entities( int $post_id, array $entities, bool $return_terms = false ): array {
 		$terms_to_link = [];

--- a/includes/Classifai/Watson/Linker.php
+++ b/includes/Classifai/Watson/Linker.php
@@ -253,7 +253,7 @@ class Linker {
 					$term = wp_insert_term( $name, $taxonomy, [] );
 
 					if ( ! is_wp_error( $term ) ) {
-						$terms_to_link[] = intval( $term['term_id'] );
+						$terms_to_link[] = (int) $term['term_id'];
 
 						if ( ! empty( $entity['disambiguation']['dbpedia_resource'] ) ) {
 							update_term_meta(

--- a/includes/Classifai/Watson/Linker.php
+++ b/includes/Classifai/Watson/Linker.php
@@ -40,22 +40,22 @@ class Linker {
 		$all_terms = [];
 
 		if ( ! empty( $output['categories'] ) ) {
-			$terms     = $this->link_categories( $post_id, $output['categories'], true );
+			$terms     = $this->link_categories( $post_id, $output['categories'] );
 			$all_terms = $terms;
 		}
 
 		if ( ! empty( $output['keywords'] ) ) {
-			$terms     = $this->link_keywords( $post_id, $output['keywords'], true );
+			$terms     = $this->link_keywords( $post_id, $output['keywords'] );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
 		if ( ! empty( $output['concepts'] ) ) {
-			$terms     = $this->link_concepts( $post_id, $output['concepts'], true );
+			$terms     = $this->link_concepts( $post_id, $output['concepts'] );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
 		if ( ! empty( $output['entities'] ) ) {
-			$terms     = $this->link_entities( $post_id, $output['entities'], true );
+			$terms     = $this->link_entities( $post_id, $output['entities'] );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
@@ -83,13 +83,13 @@ class Linker {
 	 *
 	 * Eg:- /animals/pets/cats
 	 *
-	 * @param int   $post_id The id of the post to link
+	 * @param int   $post_id The id of the post to link.
 	 * @param array $categories The list of categories to link
-	 * @param bool  $return_terms Whether to return the terms to link or not
+	 * @param bool  $link_terms Whether link terms to post or return terms.
 	 *
-	 * @return array The terms to link
+	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
-	public function link_categories( int $post_id, array $categories, bool $return_terms = false ): array {
+	public function link_categories( int $post_id, array $categories, bool $link_terms = false ) {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'category' );
 
@@ -120,12 +120,20 @@ class Linker {
 			}
 		}
 
-		if ( ! $return_terms ) {
-			wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
+		// Exit if there are not any term to link.
+		if ( empty( $terms_to_link ) ) {
 			return [];
 		}
 
-		return $terms_to_link ? [ $taxonomy => $terms_to_link ] : [];
+		if ( $link_terms ) {
+			$result = wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
+		return $terms_to_link;
 	}
 
 	/**
@@ -138,13 +146,13 @@ class Linker {
 	 *   ...
 	 * ]
 	 *
-	 * @param int   $post_id The id of the post to link
+	 * @param int   $post_id The id of the post to link.
 	 * @param array $keywords NLU returned keywords
-	 * @param bool  $return_terms Whether to return the terms to link or not
+	 * @param bool  $link_terms Whether link terms to post or return terms.
 	 *
-	 * @return array The terms to link
+	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
-	public function link_keywords( int $post_id, array $keywords, bool $return_terms = false ): array {
+	public function link_keywords( int $post_id, array $keywords, bool $link_terms = false ) {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'keyword' );
 
@@ -166,12 +174,20 @@ class Linker {
 			}
 		}
 
-		if ( ! $return_terms ) {
-			wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
+		// Exit if there are not any term to link.
+		if ( empty( $terms_to_link ) ) {
 			return [];
 		}
 
-		return $terms_to_link ? [ $taxonomy => $terms_to_link ] : [];
+		if ( $link_terms ) {
+			$result = wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
+		return $terms_to_link;
 	}
 
 	/**
@@ -184,13 +200,13 @@ class Linker {
 	 *   ...
 	 * ]
 	 *
-	 * @param int   $post_id The id of the post to link
+	 * @param int   $post_id The id of the post to link.
 	 * @param array $concepts The NLU returned concepts.
-	 * @param bool  $return_terms Whether to return the terms to link or not
+	 * @param bool  $link_terms Whether link terms to post or return terms.
 	 *
-	 * @return array The terms to link
+	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
-	public function link_concepts( int $post_id, array $concepts, bool $return_terms = false ): array {
+	public function link_concepts( int $post_id, array $concepts, bool $link_terms = false ) {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'concept' );
 
@@ -219,12 +235,20 @@ class Linker {
 			}
 		}
 
-		if ( ! $return_terms ) {
-			wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
+		// Exit if there are not any term to link.
+		if ( empty( $terms_to_link ) ) {
 			return [];
 		}
 
-		return $terms_to_link ? [ $taxonomy => $terms_to_link ] : [];
+		if ( $link_terms ) {
+			$result = wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
+		return $terms_to_link;
 	}
 
 	/**
@@ -237,13 +261,13 @@ class Linker {
 	 *   ...
 	 * ]
 	 *
-	 * @param int   $post_id The id of the post to link
+	 * @param int   $post_id The id of the post to link.
 	 * @param array $entities The entities returned by the NLU api
-	 * @param bool  $return_terms Whether to return the terms to link or not
+	 * @param bool  $link_terms Whether link terms to post or return terms.
 	 *
-	 * @return array The terms to link
+	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
-	public function link_entities( int $post_id, array $entities, bool $return_terms = false ): array {
+	public function link_entities( int $post_id, array $entities, bool $link_terms = false ) {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'entity' );
 
@@ -283,12 +307,20 @@ class Linker {
 			}
 		}
 
-		if ( ! $return_terms ) {
-			wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
+		// Exit if there are not any term to link.
+		if ( empty( $terms_to_link ) ) {
 			return [];
 		}
 
-		return $terms_to_link ? [ $taxonomy => $terms_to_link ] : [];
+		if ( $link_terms ) {
+			$result = wp_set_object_terms( $post_id, $terms_to_link, $taxonomy, false );
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
+		return $terms_to_link;
 	}
 
 	/**

--- a/includes/Classifai/Watson/Linker.php
+++ b/includes/Classifai/Watson/Linker.php
@@ -151,10 +151,10 @@ class Linker {
 					$term = wp_insert_term( $name, $taxonomy, [] );
 
 					if ( ! is_wp_error( $term ) ) {
-						$terms_to_link[] = intval( $term['term_id'] );
+						$terms_to_link[] = (int) $term['term_id'];
 					}
 				} else {
-					$terms_to_link[] = intval( $term->term_id );
+					$terms_to_link[] = $term->term_id;
 				}
 			}
 		}
@@ -187,18 +187,18 @@ class Linker {
 					$term = wp_insert_term( $name, $taxonomy, [] );
 
 					if ( ! is_wp_error( $term ) ) {
-						$terms_to_link[] = intval( $term['term_id'] );
+						$terms_to_link[] = (int) $term['term_id'];
 
 						if ( ! empty( $concept['dbpedia_resource'] ) ) {
 							update_term_meta(
-								intval( $term['term_id'] ),
+								(int) $term['term_id'],
 								'dbpedia_resource',
 								$concept['dbpedia_resource']
 							);
 						}
 					}
 				} else {
-					$terms_to_link[] = intval( $term->term_id );
+					$terms_to_link[] = $term->term_id;
 				}
 			}
 		}
@@ -240,20 +240,20 @@ class Linker {
 
 						if ( ! empty( $entity['disambiguation']['dbpedia_resource'] ) ) {
 							update_term_meta(
-								intval( $term['term_id'] ),
+								(int) $term['term_id'],
 								'dbpedia_resource',
 								$entity['disambiguation']['dbpedia_resource']
 							);
 
 							update_term_meta(
-								intval( $term['term_id'] ),
+								(int) $term['term_id'],
 								'type',
 								$entity['type']
 							);
 						}
 					}
 				} else {
-					$terms_to_link[] = intval( $term->term_id );
+					$terms_to_link[] = $term->term_id;
 				}
 			}
 		}

--- a/includes/Classifai/Watson/Linker.php
+++ b/includes/Classifai/Watson/Linker.php
@@ -39,23 +39,23 @@ class Linker {
 	public function link( $post_id, $output, $options = [] ) {
 		$all_terms = [];
 
-		$terms = $this->link_categories( $post_id, $output['categories'], true );
 		if ( ! empty( $output['categories'] ) ) {
+			$terms = $this->link_categories( $post_id, $output['categories'], true );
 			$all_terms = $terms;
 		}
 
-		$terms = $this->link_keywords( $post_id, $output['keywords'], true );
 		if ( ! empty( $output['keywords'] ) ) {
+			$terms = $this->link_keywords( $post_id, $output['keywords'], true );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
-		$terms = $this->link_concepts( $post_id, $output['concepts'], true );
 		if ( ! empty( $output['concepts'] ) ) {
+			$terms = $this->link_concepts( $post_id, $output['concepts'], true );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
-		$terms = $this->link_entities( $post_id, $output['entities'], true );
 		if ( ! empty( $output['entities'] ) ) {
+			$terms = $this->link_entities( $post_id, $output['entities'], true );
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 

--- a/includes/Classifai/Watson/Linker.php
+++ b/includes/Classifai/Watson/Linker.php
@@ -34,7 +34,7 @@ class Linker {
 	 * @param array $output  The classification results from Watson NLU.
 	 * @param array $options Unused.
 	 *
-	 * @return void
+	 * @return array The terms that were linked.
 	 */
 	public function link( $post_id, $output, $options = [] ) {
 		$all_terms = [];
@@ -59,11 +59,13 @@ class Linker {
 			$all_terms = array_merge_recursive( $all_terms, $terms );
 		}
 
-		if ( $all_terms ) {
+		if ( ! empty( $all_terms ) ) {
 			foreach ( $all_terms as $taxonomy => $terms ) {
 				wp_set_object_terms( $post_id, $terms, $taxonomy, false );
 			}
 		}
+
+		return $all_terms;
 	}
 
 	/* helpers */
@@ -133,7 +135,7 @@ class Linker {
 			}
 		}
 
-		return $terms_to_link;
+		return [ $taxonomy => $terms_to_link ];
 	}
 
 	/**
@@ -187,7 +189,7 @@ class Linker {
 			}
 		}
 
-		return $terms_to_link;
+		return [ $taxonomy => $terms_to_link ];
 	}
 
 	/**
@@ -248,7 +250,7 @@ class Linker {
 			}
 		}
 
-		return $terms_to_link;
+		return [ $taxonomy => $terms_to_link ];
 	}
 
 	/**
@@ -320,7 +322,7 @@ class Linker {
 			}
 		}
 
-		return $terms_to_link;
+		return [ $taxonomy => $terms_to_link ];
 	}
 
 	/**

--- a/includes/Classifai/Watson/Linker.php
+++ b/includes/Classifai/Watson/Linker.php
@@ -85,7 +85,7 @@ class Linker {
 	 *
 	 * @param array $categories The list of categories to link
 	 */
-	protected function link_categories( array $categories ): array {
+	public function link_categories( array $categories ): array {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'category' );
 
@@ -137,7 +137,7 @@ class Linker {
 	 *
 	 * @param array $keywords NLU returned keywords
 	 */
-	protected function link_keywords( $keywords ): array {
+	public function link_keywords( $keywords ): array {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'keyword' );
 
@@ -174,7 +174,7 @@ class Linker {
 	 *
 	 * @param array $concepts The NLU returned concepts.
 	 */
-	protected function link_concepts( array $concepts ): array {
+	public function link_concepts( array $concepts ): array {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'concept' );
 
@@ -218,7 +218,7 @@ class Linker {
 	 *
 	 * @param array $entities The entities returned by the NLU api
 	 */
-	protected function link_entities( array $entities ): array {
+	public function link_entities( array $entities ): array {
 		$terms_to_link = [];
 		$taxonomy      = \Classifai\get_feature_taxonomy( 'entity' );
 

--- a/includes/Classifai/Watson/Linker.php
+++ b/includes/Classifai/Watson/Linker.php
@@ -39,7 +39,7 @@ class Linker {
 	public function link( $post_id, $output, $options = [] ) {
 		$all_terms = [];
 
-		$terms = $this->link_categories( $output['categories'] )
+		$terms = $this->link_categories( $output['categories'] );
 		if ( ! empty( $output['categories'] ) ) {
 			$all_terms = $terms;
 		}

--- a/tests/Classifai/PostClassifierTest.php
+++ b/tests/Classifai/PostClassifierTest.php
@@ -6,6 +6,7 @@ use Classifai\Taxonomy\TaxonomyFactory;
 
 class PostClassifierTest extends \WP_UnitTestCase {
 
+	/* @var PostClassifier $classifier */
 	public $classifier;
 
 	function set_up() {

--- a/tests/Classifai/Watson/LinkerTest.php
+++ b/tests/Classifai/Watson/LinkerTest.php
@@ -4,6 +4,7 @@ namespace Classifai\Watson;
 
 class LinkerTest extends \WP_UnitTestCase {
 
+	/* @var Linker $linker */
 	public $linker;
 
 	function set_up() {
@@ -25,7 +26,7 @@ class LinkerTest extends \WP_UnitTestCase {
 		];
 
 		$post_id = $this->factory->post->create();
-		$this->linker->link_categories( $post_id, $categories );
+		$this->linker->link_categories( $post_id, $categories, true );
 
 		$actual = wp_get_object_terms( $post_id, [ WATSON_CATEGORY_TAXONOMY ] );
 		$actual = array_map( function( $term ) {
@@ -48,7 +49,7 @@ class LinkerTest extends \WP_UnitTestCase {
 		];
 
 		$post_id = $this->factory->post->create();
-		$this->linker->link_keywords( $post_id, $keywords );
+		$this->linker->link_keywords( $post_id, $keywords, true );
 
 		$actual = wp_get_object_terms( $post_id, [ WATSON_KEYWORD_TAXONOMY ] );
 		$actual = array_map( function( $term ) {
@@ -73,7 +74,7 @@ class LinkerTest extends \WP_UnitTestCase {
 		];
 
 		$post_id = $this->factory->post->create();
-		$this->linker->link_concepts( $post_id, $concepts );
+		$this->linker->link_concepts( $post_id, $concepts, true );
 
 		$actual = wp_get_object_terms( $post_id, [ WATSON_CONCEPT_TAXONOMY ] );
 		$actual = array_map( function( $term ) {
@@ -106,7 +107,7 @@ class LinkerTest extends \WP_UnitTestCase {
 		];
 
 		$post_id = $this->factory->post->create();
-		$this->linker->link_entities( $post_id, $entities );
+		$this->linker->link_entities( $post_id, $entities, true );
 
 		$actual = wp_get_object_terms( $post_id, [ WATSON_ENTITY_TAXONOMY ] );
 		$actual = array_map( function( $term ) {
@@ -175,7 +176,7 @@ class LinkerTest extends \WP_UnitTestCase {
 
 
 		$post_id = $this->factory->post->create();
-		$this->linker->link( $post_id, $output );
+		$result = $this->linker->link( $post_id, $output );
 
 		// categories
 		$actual = wp_get_object_terms( $post_id, [ WATSON_CATEGORY_TAXONOMY ] );

--- a/tests/Classifai/Watson/LinkerTest.php
+++ b/tests/Classifai/Watson/LinkerTest.php
@@ -176,7 +176,7 @@ class LinkerTest extends \WP_UnitTestCase {
 
 
 		$post_id = $this->factory->post->create();
-		$result = $this->linker->link( $post_id, $output );
+		$this->linker->link( $post_id, $output );
 
 		// categories
 		$actual = wp_get_object_terms( $post_id, [ WATSON_CATEGORY_TAXONOMY ] );

--- a/tests/Classifai/Watson/LinkerTest.php
+++ b/tests/Classifai/Watson/LinkerTest.php
@@ -26,7 +26,7 @@ class LinkerTest extends \WP_UnitTestCase {
 		];
 
 		$post_id = $this->factory->post->create();
-		$this->linker->link_categories( $post_id, $categories, true );
+		$this->linker->link_categories( $post_id, $categories );
 
 		$actual = wp_get_object_terms( $post_id, [ WATSON_CATEGORY_TAXONOMY ] );
 		$actual = array_map( function( $term ) {
@@ -49,7 +49,7 @@ class LinkerTest extends \WP_UnitTestCase {
 		];
 
 		$post_id = $this->factory->post->create();
-		$this->linker->link_keywords( $post_id, $keywords, true );
+		$this->linker->link_keywords( $post_id, $keywords );
 
 		$actual = wp_get_object_terms( $post_id, [ WATSON_KEYWORD_TAXONOMY ] );
 		$actual = array_map( function( $term ) {
@@ -74,7 +74,7 @@ class LinkerTest extends \WP_UnitTestCase {
 		];
 
 		$post_id = $this->factory->post->create();
-		$this->linker->link_concepts( $post_id, $concepts, true );
+		$this->linker->link_concepts( $post_id, $concepts );
 
 		$actual = wp_get_object_terms( $post_id, [ WATSON_CONCEPT_TAXONOMY ] );
 		$actual = array_map( function( $term ) {
@@ -107,7 +107,7 @@ class LinkerTest extends \WP_UnitTestCase {
 		];
 
 		$post_id = $this->factory->post->create();
-		$this->linker->link_entities( $post_id, $entities, true );
+		$this->linker->link_entities( $post_id, $entities );
 
 		$actual = wp_get_object_terms( $post_id, [ WATSON_ENTITY_TAXONOMY ] );
 		$actual = array_map( function( $term ) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
I found that we overwrite terms when adding new terms to a post. Admin can set same or different WordPress taxonomy for Watson `Category`,  `Keyword `, `Entity` & `Concept`. When the admin sets the same category for two or more Watson content classifiers, the term does not add correctly to the post. I update the logic to handle this use case.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #340 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
-  Add the same taxonomy to all Watson content classifiers in `ClassifAI` >` Language Processing` and the new post. The post should have the correct terms.
-  Add the different or same taxonomy to all Watson content classifiers in `ClassifAI` >` Language Processing` and the new post. The post should have the correct terms.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Correctly add terms to posts generated by Watson content classifiers


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh , @ravinderk


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
