### PR TITLE
Fix errors with the `get_formatted_latest_response` method

### DIFF
--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -374,7 +374,7 @@ class ChatGPT extends Provider {
 			__( 'Generate titles', 'classifai' )         => $enable_titles ? __( 'yes', 'classifai' ) : __( 'no', 'classifai' ),
 			__( 'Allowed roles (titles)', 'classifai' )  => implode( ', ', $settings['title_roles'] ?? [] ),
 			__( 'Number of titles', 'classifai' )        => absint( $settings['number_titles'] ?? 1 ),
-			__( 'Latest response', 'classifai' )         => $this->get_formatted_latest_response( 'classifai_openai_chatgpt_latest_response' ),
+			__( 'Latest response', 'classifai' )         => $this->get_formatted_latest_response( get_transient( 'classifai_openai_chatgpt_latest_response' ) ),
 		];
 	}
 

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -333,7 +333,7 @@ class DallE extends Provider {
 			__( 'Allowed roles', 'classifai' )    => implode( ', ', $settings['roles'] ?? [] ),
 			__( 'Number of images', 'classifai' ) => absint( $settings['number'] ?? 1 ),
 			__( 'Image size', 'classifai' )       => sanitize_text_field( $settings['size'] ?? '1024x1024' ),
-			__( 'Latest response', 'classifai' )  => $this->get_formatted_latest_response( 'classifai_openai_dalle_latest_response' ),
+			__( 'Latest response', 'classifai' )  => $this->get_formatted_latest_response( get_transient( 'classifai_openai_dalle_latest_response' ) ),
 		];
 	}
 

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -314,7 +314,7 @@ class Embeddings extends Provider {
 			__( 'Post statuses', 'classifai' )          => implode( ', ', $settings['post_statuses'] ?? [] ),
 			__( 'Taxonomies', 'classifai' )             => implode( ', ', $settings['taxonomies'] ?? [] ),
 			__( 'Number of terms', 'classifai' )        => $settings['number'] ?? 1,
-			__( 'Latest response', 'classifai' )        => $this->get_formatted_latest_response( 'classifai_openai_embeddings_latest_response' ),
+			__( 'Latest response', 'classifai' )        => $this->get_formatted_latest_response( get_transient( 'classifai_openai_embeddings_latest_response' ) ),
 		];
 	}
 

--- a/includes/Classifai/Providers/OpenAI/Whisper.php
+++ b/includes/Classifai/Providers/OpenAI/Whisper.php
@@ -328,7 +328,7 @@ class Whisper extends Provider {
 			__( 'Authenticated', 'classifai' )        => $authenticated ? __( 'yes', 'classifai' ) : __( 'no', 'classifai' ),
 			__( 'Generate transcripts', 'classifai' ) => $enable_transcript ? __( 'yes', 'classifai' ) : __( 'no', 'classifai' ),
 			__( 'Allowed roles', 'classifai' )        => implode( ', ', $settings['roles'] ?? [] ),
-			__( 'Latest response', 'classifai' )      => $this->get_formatted_latest_response( 'classifai_openai_whisper_latest_response' ),
+			__( 'Latest response', 'classifai' )      => $this->get_formatted_latest_response( get_transient( 'classifai_openai_whisper_latest_response' ) ),
 		];
 	}
 

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -397,11 +397,11 @@ abstract class Provider {
 	/**
 	 * Format the result of most recent request.
 	 *
-	 * @param string $data Response data to format.
+	 * @param array|WP_Error $data Response data to format.
 	 *
 	 * @return string
 	 */
-	protected function get_formatted_latest_response( string $data = '' ) {
+	protected function get_formatted_latest_response( $data ) {
 		if ( ! $data ) {
 			return __( 'N/A', 'classifai' );
 		}

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -758,20 +758,18 @@ class NLU extends Provider {
 			__( 'API username', 'classifai' )    => $credentials['watson_username'] ?? '',
 			__( 'Post types', 'classifai' )      => implode( ', ', $post_types ),
 			__( 'Features', 'classifai' )        => preg_replace( '/,"/', ', "', wp_json_encode( $settings['features'] ?? '' ) ),
-			__( 'Latest response', 'classifai' ) => $this->get_formatted_latest_response(),
+			__( 'Latest response', 'classifai' ) => $this->get_formatted_latest_response( get_transient( 'classifai_watson_nlu_latest_response' ) ),
 		];
 	}
 
 	/**
 	 * Format the result of most recent request.
 	 *
-	 * @param string $data Response data to format.
+	 * @param array|WP_Error $data Response data to format.
 	 *
 	 * @return string
 	 */
-	protected function get_formatted_latest_response( string $data = '' ) {
-		$data = get_transient( 'classifai_watson_nlu_latest_response' );
-
+	protected function get_formatted_latest_response( $data ) {
 		if ( ! $data ) {
 			return __( 'N/A', 'classifai' );
 		}


### PR DESCRIPTION
### Description of the Change

In #403, some refactoring was done to the `get_formatted_latest_response` method. There was two problems introduced here though:

1. This method forced all data passed in to be a `string`, though most of the time the data was pass in here is an `array`. This caused fatal errors on the site health screen
2. For the OpenAI integrations, we were passing in the transient key but not the actual data, so the data we were outputting was not helpful

This PR fixes both of these issues.

Closes #463 

### How to test the Change

1. Go to your Site Health screen
2. Ensure this screen loads without any errors
3. Open the ClassifAI panel and ensure data shows there

### Changelog Entry

> Fixed - Ensure we properly output data on the Site Health screen without causing errors

### Credits

Props @dkotter, @hugosolar 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
