### PR TITLE
Ensure we don't allow image prompts that exceed 1000 characters

### DIFF
--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -22,6 +22,13 @@ class DallE extends Provider {
 	protected $dalle_url = 'https://api.openai.com/v1/images/generations';
 
 	/**
+	 * Maximum number of characters a prompt can have
+	 *
+	 * @var int
+	 */
+	public $max_prompt_chars = 1000;
+
+	/**
 	 * OpenAI DALL·E constructor.
 	 *
 	 * @param string $service The service this class belongs to.
@@ -139,7 +146,7 @@ class DallE extends Provider {
 				<p>
 					<?php esc_html_e( 'Once images are generated, choose one or more of those to import into your Media Library and then choose one image to insert.', 'classifai' ); ?>
 				</p>
-				<textarea class="prompt" placeholder="<?php esc_attr_e( 'Enter prompt', 'classifai' ); ?>" rows="4"></textarea>
+				<textarea class="prompt" placeholder="<?php esc_attr_e( 'Enter prompt', 'classifai' ); ?>" rows="4" maxlength="<?php echo absint( $this->max_prompt_chars ); ?>"></textarea>
 				<button type="button" class="button button-secondary button-large button-generate"><?php esc_html_e( 'Generate images', 'classifai' ); ?></button>
 				<span class="error"></span>
 			</div>
@@ -382,6 +389,11 @@ class DallE extends Provider {
 		 * @return {string} Prompt.
 		 */
 		$prompt = apply_filters( 'classifai_dalle_prompt', $prompt );
+
+		// If our prompt exceeds the max length, throw an error.
+		if ( mb_strlen( $prompt ) > $this->max_prompt_chars ) {
+			return new WP_Error( 'invalid_param', esc_html__( 'Your image prompt is too long. Please ensure it doesn\'t exceed 1000 characters.', 'classifai' ) );
+		}
 
 		$request = new APIRequest( $settings['api_key'] ?? '' );
 

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -311,9 +311,16 @@ class ImageProcessing extends Service {
 			return $provider;
 		}
 
+		$prompt = $request->get_param( 'prompt' );
+
+		// If our prompt exceeds the max length, throw an error.
+		if ( mb_strlen( $prompt ) > $provider->max_prompt_chars ) {
+			return new WP_Error( 'invalid_param', esc_html__( 'Your image prompt is too long. Please ensure it doesn\'t exceed 1000 characters.', 'classifai' ) );
+		}
+
 		return rest_ensure_response(
 			$provider->generate_image_callback(
-				$request->get_param( 'prompt' ),
+				$prompt,
 				[
 					'num'    => $request->get_param( 'n' ),
 					'size'   => $request->get_param( 'size' ),

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -311,16 +311,9 @@ class ImageProcessing extends Service {
 			return $provider;
 		}
 
-		$prompt = $request->get_param( 'prompt' );
-
-		// If our prompt exceeds the max length, throw an error.
-		if ( mb_strlen( $prompt ) > $provider->max_prompt_chars ) {
-			return new WP_Error( 'invalid_param', esc_html__( 'Your image prompt is too long. Please ensure it doesn\'t exceed 1000 characters.', 'classifai' ) );
-		}
-
 		return rest_ensure_response(
 			$provider->generate_image_callback(
-				$prompt,
+				$request->get_param( 'prompt' ),
 				[
 					'num'    => $request->get_param( 'n' ),
 					'size'   => $request->get_param( 'size' ),


### PR DESCRIPTION
### Description of the Change

Not sure if I missed this when adding in the image generation feature or if this is a new change on the OpenAI side, but looking at their [API docs](https://platform.openai.com/docs/api-reference/images/create) today, noticed that the prompts you send to generate images must be 1000 characters or less.

This PR handles that in three different locations:

1. Adds a `maxlength` attribute of 1000 to our prompt textarea. This will limit the amount of text that can be entered when building a prompt
2. Add validation within our REST endpoint to throw an error if the prompt length exceeds 1000 characters. This will solve use cases where someone is hitting this endpoint directly instead of going through the admin UI
3. Add validation within our callback function to throw an error if the prompt length exceeds 1000 characters. This will solve use cases where someone is using this method directly or someone uses the `classifai_dalle_prompt` filter to modify the prompt and exceed 1000 characters

### How to test the Change

1. Within the `Generate images` tab in the media modal, inspect the HTML and ensure the `textarea` has a `maxlength` attribute set to 1000
2. Try entering in more than 1000 characters into this `textarea` and notice it won't allow you to
3. If desired, try making direct requests to our image generation endpoint (`/wp-json/classifai/v1/openai/generate-image?prompt=`) with a prompt longer than 1000 characters. Note you'll need proper authentication to get passed auth checks first

### Changelog Entry

> Fixed - Ensure the prompt we send to DALL·E never exceeds 1000 characters

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
