### PR TITLE
Remove quotes from generated excerpts and modify prompt slightly

### DIFF
--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -443,7 +443,7 @@ class ChatGPT extends Provider {
 		 *
 		 * @return {string} Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_chatgpt_excerpt_prompt', 'Provide a kicker for the following text in ' . $excerpt_length . ' words', $post_id, $excerpt_length );
+		$prompt = apply_filters( 'classifai_chatgpt_excerpt_prompt', 'Provide a teaser for the following text using a maximum of ' . $excerpt_length . ' words', $post_id, $excerpt_length );
 
 		/**
 		 * Filter the request body before sending to ChatGPT.
@@ -485,7 +485,8 @@ class ChatGPT extends Provider {
 		if ( ! is_wp_error( $response ) && ! empty( $response['choices'] ) ) {
 			foreach ( $response['choices'] as $choice ) {
 				if ( isset( $choice['message'], $choice['message']['content'] ) ) {
-					$response = sanitize_text_field( $choice['message']['content'] );
+					// ChatGPT often adds quotes to strings, so remove those as well as extra spaces.
+					$response = sanitize_text_field( trim( $choice['message']['content'], ' "\'' ) );
 				}
 			}
 		}


### PR DESCRIPTION
### Description of the Change

ChatGPT tends to add quotes around things, which is not needed when generating an excerpt. This was caught and fixed while working on the generate titles feature, so adding that same functionality to excerpts.

This PR also slightly tweaks the prompt we use to generate excerpts to try and get better summaries.

### How to test the Change

Test out the excerpt generation and ensure excerpts are generated and no quotes are added around the excerpts

### Changelog Entry

> Changed - Tweak the prompt that is used to generate excerpts
> Fixed - Ensure quotes aren't added around generated excerpts

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
