### PR TITLE
Remove extra slash from asset URLs

### DIFF
--- a/includes/Classifai/Blocks.php
+++ b/includes/Classifai/Blocks.php
@@ -46,7 +46,7 @@ function register_blocks() {
 function blocks_styles() {
 	wp_enqueue_style(
 		'recommended-content-block-style',
-		CLASSIFAI_PLUGIN_URL . '/dist/recommended-content-block-frontend.css',
+		CLASSIFAI_PLUGIN_URL . 'dist/recommended-content-block-frontend.css',
 		[],
 		CLASSIFAI_PLUGIN_VERSION
 	);

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -519,7 +519,7 @@ class TextToSpeech extends Provider {
 
 		wp_enqueue_script(
 			'classifai-post-audio-player-js',
-			CLASSIFAI_PLUGIN_URL . '/dist/post-audio-controls.js',
+			CLASSIFAI_PLUGIN_URL . 'dist/post-audio-controls.js',
 			get_asset_info( 'post-audio-controls', 'dependencies' ),
 			get_asset_info( 'post-audio-controls', 'version' ),
 			true
@@ -527,7 +527,7 @@ class TextToSpeech extends Provider {
 
 		wp_enqueue_style(
 			'classifai-post-audio-player-css',
-			CLASSIFAI_PLUGIN_URL . '/dist/post-audio-controls.css',
+			CLASSIFAI_PLUGIN_URL . 'dist/post-audio-controls.css',
 			array(),
 			get_asset_info( 'post-audio-controls', 'version' ),
 			'all'


### PR DESCRIPTION
### Description of the Change

Found we had a few assets that we were loading that included an extra slash in the URL. This PR removes those

### How to test the Change

Not much to test here other than ensuring these assets still load properly

### Changelog Entry

> Fixed - Remove extra slash from asset URLs

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
