### PR TITLE
Ensure all custom hooks have proper docblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 [![E2E Testing](https://github.com/10up/classifai/actions/workflows/cypress.yml/badge.svg)](https://github.com/10up/classifai/actions/workflows/cypress.yml) [![PHPUnit Testing](https://github.com/10up/classifai/actions/workflows/test.yml/badge.svg)](https://github.com/10up/classifai/actions/workflows/test.yml) [![Linting](https://github.com/10up/classifai/actions/workflows/lint.yml/badge.svg)](https://github.com/10up/classifai/actions/workflows/lint.yml) [![CodeQL](https://github.com/10up/classifai/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/10up/classifai/actions/workflows/codeql-analysis.yml) [![Dependency Review](https://github.com/10up/classifai/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/classifai/actions/workflows/dependency-review.yml)
 
+*You can learn more about ClassifAI's features at [ClassifAIPlugin.com](https://classifaiplugin.com/) and documentation at the [ClassifAI documentation site](https://10up.github.io/classifai/).*
+
 ## Table of Contents
 * [Overview](#overview)
 * [Features](#features)

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -659,11 +659,11 @@ class ComputerVision extends Provider {
 		 * @since 1.6.0
 		 * @hook classifai_should_ocr_scan_image
 		 *
-		 * @param bool  $should_ocr_scan Whether to run OCR scanning. The default value is set in ComputerVision settings.
-		 * @param array $metadata        Image metadata.
-		 * @param int   $attachment_id   The attachment ID.
+		 * @param {bool}  $should_ocr_scan Whether to run OCR scanning. The default value is set in ComputerVision settings.
+		 * @param {array} $metadata        Image metadata.
+		 * @param {int}   $attachment_id   The attachment ID.
 		 *
-		 * @return bool Whether to run OCR scanning.
+		 * @return {bool} Whether to run OCR scanning.
 		 */
 		if ( ! $force && ! apply_filters( 'classifai_should_ocr_scan_image', $should_ocr_scan, $metadata, $attachment_id ) ) {
 			return $metadata;

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -815,8 +815,8 @@ class ComputerVision extends Provider {
 				 * @since 1.5.0
 				 * @hook classifai_computer_vision_caption_failed
 				 *
-				 * @param array $tags      The caption data.
-				 * @param int   $threshold The caption_threshold setting.
+				 * @param {array} $tags      The caption data.
+				 * @param {int}   $threshold The caption_threshold setting.
 				 */
 				do_action( 'classifai_computer_vision_caption_failed', $captions, $threshold );
 			}
@@ -928,8 +928,8 @@ class ComputerVision extends Provider {
 				 * @since 1.5.0
 				 * @hook classifai_computer_vision_image_tag_failed
 				 *
-				 * @param array $tags      The image tag data.
-				 * @param int   $threshold The tag_threshold setting.
+				 * @param {array} $tags      The image tag data.
+				 * @param {int}   $threshold The tag_threshold setting.
 				 */
 				do_action( 'classifai_computer_vision_image_tag_failed', $tags, $threshold );
 			}

--- a/includes/Classifai/Providers/Azure/OCR.php
+++ b/includes/Classifai/Providers/Azure/OCR.php
@@ -326,8 +326,8 @@ class OCR {
 		 * @since 1.6.0
 		 * @hook classifai_ocr_after_request
 		 *
-		 * @param array|WP_Error Response data or a WP_Error if the request failed.
-		 * @param string The attachment URL.
+		 * @param {array|WP_Error} Response data or a WP_Error if the request failed.
+		 * @param {string} The attachment URL.
 		 */
 		do_action( 'classifai_ocr_after_request', $response, $url );
 
@@ -349,8 +349,8 @@ class OCR {
 				 * @since 1.6.0
 				 * @hook classifai_ocr_unsuccessful_response
 				 *
-				 * @param array|WP_Error Response data or a WP_Error if the request failed.
-				 * @param string The attachment URL.
+				 * @param {array|WP_Error} Response data or a WP_Error if the request failed.
+				 * @param {string} The attachment URL.
 				 */
 				do_action( 'classifai_ocr_unsuccessful_response', $response, $url );
 

--- a/includes/Classifai/Providers/Azure/OCR.php
+++ b/includes/Classifai/Providers/Azure/OCR.php
@@ -122,10 +122,10 @@ class OCR {
 		 * @since 1.6.0
 		 * @hook classifai_ocr_approved_media_types
 		 *
-		 * @param array $media_types   The media types to process.
-		 * @param int   $attachment_id The attachment ID.
+		 * @param {array} $media_types   The media types to process.
+		 * @param {int}   $attachment_id The attachment ID.
 		 *
-		 * @return array Filtered media types.
+		 * @return {array} Filtered media types.
 		 */
 		$approved_media_types = apply_filters( 'classifai_ocr_approved_media_types', $this->media_to_process, $attachment_id );
 
@@ -145,11 +145,11 @@ class OCR {
 			 * @since 1.6.0
 			 * @hook classifai_ocr_tags
 			 *
-			 * @param array       $tags          Tags to look for. Default handwriting and text.
-			 * @param int         $attachment_id The attachment ID.
-			 * @param bool|object $scan          Previosly run scan.
+			 * @param {array}       $tags          Tags to look for. Default handwriting and text.
+			 * @param {int}         $attachment_id The attachment ID.
+			 * @param {bool|object} $scan          Previously run scan.
 			 *
-			 * @return array Filtered tags.
+			 * @return {array} Filtered tags.
 			 */
 			$tags = apply_filters( 'classifai_ocr_tags', [ 'handwriting', 'text' ], $attachment_id, $this->scan );
 
@@ -159,11 +159,11 @@ class OCR {
 			 * @since 1.6.0
 			 * @hook classifai_ocr_tag_confidence
 			 *
-			 * @param int         $confidence    The mininum confidence level. Default 90.
-			 * @param int         $attachment_id The attachment ID.
-			 * @param bool|object $scan          Previosly run scan.
+			 * @param {int}         $confidence    The minimum confidence level. Default 90.
+			 * @param {int}         $attachment_id The attachment ID.
+			 * @param {bool|object} $scan          Previously run scan.
 			 *
-			 * @return int Confidence level.
+			 * @return {int} Confidence level.
 			 */
 			$tag_confidence = apply_filters( 'classifai_ocr_tag_confidence', 90, $attachment_id, $this->scan );
 
@@ -181,11 +181,11 @@ class OCR {
 		 * @since 1.6.0
 		 * @hook classifai_ocr_should_process
 		 *
-		 * @param bool        $process       Whether to run OCR processing or not.
-		 * @param int         $attachment_id The attachment ID.
-		 * @param bool|object $scan          Previosly run scan.
+		 * @param {bool}        $process       Whether to run OCR processing or not.
+		 * @param {int}         $attachment_id The attachment ID.
+		 * @param {bool|object} $scan          Previously run scan.
 		 *
-		 * @return bool Whether this attachment should have OCR processing.
+		 * @return {bool} Whether this attachment should have OCR processing.
 		 */
 		return apply_filters( 'classifai_ocr_should_process', $process, $attachment_id, $this->scan );
 	}
@@ -246,10 +246,10 @@ class OCR {
 				 * @since 1.6.0
 				 * @hook classifai_ocr_text
 				 *
-				 * @param string $text The returned text data.
-				 * @param object $scan The full scan results from the API.
+				 * @param {string} $text The returned text data.
+				 * @param {object} $scan The full scan results from the API.
 				 *
-				 * @return string The filtered text data.
+				 * @return {string} The filtered text data.
 				 */
 				$text = apply_filters( 'classifai_ocr_text', implode( ' ', $text ), $scan );
 
@@ -267,13 +267,13 @@ class OCR {
 				 * @since 1.6.0
 				 * @hook classifai_ocr_text_post_args
 				 *
-				 * @param string $post_args     Array of post data for the attachment post update. Defaults to `ID` and `post_content`.
-				 * @param int    $attachment_id ID of the attachment post.
-				 * @param object $scan          The full scan results from the API.
-				 * @param string $text          The text data to be saved.
-				 * @param object $scan          The full scan results from the API.
+				 * @param {string} $post_args     Array of post data for the attachment post update. Defaults to `ID` and `post_content`.
+				 * @param {int}    $attachment_id ID of the attachment post.
+				 * @param {object} $scan          The full scan results from the API.
+				 * @param {string} $text          The text data to be saved.
+				 * @param {object} $scan          The full scan results from the API.
 				 *
-				 * @return string The filtered text data.
+				 * @return {string} The filtered text data.
 				 */
 				$post_args = apply_filters( 'classifai_ocr_text_post_args', $post_args, $attachment_id, $text, $scan );
 

--- a/includes/Classifai/Providers/Azure/Read.php
+++ b/includes/Classifai/Providers/Azure/Read.php
@@ -188,10 +188,10 @@ class Read {
 		 * @since 1.5.0
 		 * @hook classifai_azure_read_after_request
 		 *
-		 * @param array|WP_Error Response data or a WP_Error if the request failed.
-		 * @param string The request URL with query args added.
-		 * @param int The document ID.
-		 * @param string The document URL.
+		 * @param {array|WP_Error} Response data or a WP_Error if the request failed.
+		 * @param {string} The request URL with query args added.
+		 * @param {int} The document ID.
+		 * @param {string} The document URL.
 		 */
 		do_action( 'classifai_azure_read_after_request', $response, $url, $this->attachment_id, $document_url );
 

--- a/includes/Classifai/Providers/Azure/Read.php
+++ b/includes/Classifai/Providers/Azure/Read.php
@@ -98,12 +98,13 @@ class Read {
 		/**
 		 * Filters whether to run Read processing on this attachment item
 		 *
+		 * @since 1.7.0
 		 * @hook classifai_azure_read_should_process
 		 *
-		 * @param bool        $process       Whether to run OCR processing or not.
-		 * @param int         $attachment_id The attachment ID.
+		 * @param {bool} $process       Whether to run OCR processing or not.
+		 * @param {int}  $attachment_id The attachment ID.
 		 *
-		 * @return bool Whether this attachment should have OCR processing.
+		 * @return {bool} Whether this attachment should have OCR processing.
 		 */
 		return apply_filters( 'classifai_azure_read_should_process', $process, $this->attachment_id );
 	}
@@ -145,12 +146,13 @@ class Read {
 		/**
 		 * Filters the request arguments sent to Read endpoint.
 		 *
+		 * @since 1.7.0
 		 * @hook classifai_azure_read_should_process
 		 *
-		 * @param array $args       Whether to run OCR processing or not.
-		 * @param int   $attachment_id The attachment ID.
+		 * @param {array} $args       Whether to run OCR processing or not.
+		 * @param {int}   $attachment_id The attachment ID.
 		 *
-		 * @return array Filtered request arguments.
+		 * @return {array} Filtered request arguments.
 		 */
 		$request_args = apply_filters( 'classifai_azure_read_request_args', [], $this->attachment_id );
 
@@ -251,6 +253,16 @@ class Read {
 				case 'notStarted':
 				case 'running':
 					$this->update_status( $body );
+					/**
+					 * Filters the Read retry interval.
+					 *
+					 * @since 1.7.0
+					 * @hook classifai_azure_read_retry_interval
+					 *
+					 * @param {int} $seconds How many seconds should the interval be? Default 60.
+					 *
+					 * @return {int} Filtered interval.
+					 */
 					$retry_interval = apply_filters( 'classifai_azure_read_retry_interval', MINUTE_IN_SECONDS );
 					wp_schedule_single_event( time() + $retry_interval, 'classifai_retry_get_read_result', [ $operation_url, $this->attachment_id ] );
 					break;
@@ -280,13 +292,14 @@ class Read {
 		}
 
 		/**
-		 * Filter the text max pages can be processed.
+		 * Filter the max pages that can be processed.
 		 *
+		 * @since 1.7.0
 		 * @hook classifai_azure_read_result_max_page
 		 *
-		 * @param int $max_page The attachment ID.
+		 * @param {int} $max_page The maximum pages that are read.
 		 *
-		 * @return int
+		 * @return {int} Filtered max pages.
 		 */
 		$max_page = min( apply_filters( 'classifai_azure_read_result_max_page', 2 ), count( $data['analyzeResult']['readResults'] ) );
 
@@ -301,13 +314,14 @@ class Read {
 		/**
 		 * Filter the text result returned from Read API.
 		 *
+		 * @since 1.7.0
 		 * @hook classifai_azure_read_text_result
 		 *
-		 * @param array       $lines_of_text Array of text extracted from the response.
-		 * @param int         $attachment_id The attachment ID.
-		 * @param array       $data          Read result.
+		 * @param {array} $lines_of_text Array of text extracted from the response.
+		 * @param {int}   $attachment_id The attachment ID.
+		 * @param {array} $data          Read result.
 		 *
-		 * @return array
+		 * @return {array} Filtered array of text.
 		 */
 		$lines_of_text = apply_filters( 'classifai_azure_read_text_result', $lines_of_text, $this->attachment_id, $data );
 

--- a/includes/Classifai/Providers/Azure/SmartCropping.php
+++ b/includes/Classifai/Providers/Azure/SmartCropping.php
@@ -103,7 +103,7 @@ class SmartCropping {
 		 * @since 1.5.0
 		 * @hook classifai_smart_crop_max_pixel_dimension
 		 *
-		 * @param {int} max The max width/height in pixels.
+		 * @param {int} $max The max width/height in pixels. Default 1024.
 		 *
 		 * @return {int} Filtered max dimension in pixels.
 		 */
@@ -264,10 +264,13 @@ class SmartCropping {
 		 * the original file in the file system.
 		 *
 		 * @since 1.5.0
+		 * @hook classifai_smart_cropping_thumb_file_name
 		 *
-		 * @param string Default file name.
-		 * @param int    The ID of the attachment being processed.
-		 * @param array  Width and height data for the image.
+		 * @param {string} Default file name.
+		 * @param {int}    The ID of the attachment being processed.
+		 * @param {array}  Width and height data for the image.
+		 *
+		 * @return {string} Filtered file name.
 		 */
 		$new_thumb_file_name = apply_filters(
 			'classifai_smart_cropping_thumb_file_name',

--- a/includes/Classifai/Providers/Azure/SmartCropping.php
+++ b/includes/Classifai/Providers/Azure/SmartCropping.php
@@ -337,9 +337,9 @@ class SmartCropping {
 		 * @since 1.5.0
 		 * @hook classifai_smart_cropping_after_request
 		 *
-		 * @param array|WP_Error Response data or a WP_Error if the request failed.
-		 * @param string The request URL with query args added.
-		 * @param array  Array containing the image height and width.
+		 * @param {array|WP_Error} Response data or a WP_Error if the request failed.
+		 * @param {string} The request URL with query args added.
+		 * @param {array}  Array containing the image height and width.
 		 */
 		do_action( 'classifai_smart_cropping_after_request', $response, $url, $data );
 
@@ -361,9 +361,9 @@ class SmartCropping {
 		 * @since 1.5.0
 		 * @hook classifai_smart_cropping_unsuccessful_response
 		 *
-		 * @param array|WP_Error Response data or a WP_Error if the request failed.
-		 * @param string The request URL with query args added.
-		 * @param array  Array containing the image height and width.
+		 * @param {array|WP_Error} Response data or a WP_Error if the request failed.
+		 * @param {string} The request URL with query args added.
+		 * @param {array}  Array containing the image height and width.
 		 */
 		do_action( 'classifai_smart_cropping_unsuccessful_response', $response, $url, $data );
 

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -502,10 +502,15 @@ class TextToSpeech extends Provider {
 		}
 
 		/**
-		 * Filter to disable Text to Speech synthesis for a post by post ID.
+		 * Filter to disable the rendering of the Text to Speech block.
 		 *
-		 * @param boolean 'is_disabled' Boolean to toggle the service. By default - false.
-		 * @param boolean 'post_id'     Post ID.
+		 * @since 2.2.0
+		 * @hook classifai_disable_post_to_audio_block
+		 *
+		 * @param {bool} $is_disabled Whether to disable the display or not. By default - false.
+		 * @param {bool} $post_id     Post ID.
+		 *
+		 * @return {bool} Whether the audio block should be shown.
 		 */
 		if ( apply_filters( 'classifai_disable_post_to_audio_block', false, $post->ID ) ) {
 			return $content;
@@ -555,10 +560,13 @@ class TextToSpeech extends Provider {
 								/**
 								 * Hook to filter the text next to the audio controls on the frontend.
 								 *
-								 * @param string  The text to filter.
-								 * @param integer The Post ID.
+								 * @since 2.2.0
+								 * @hook classifai_listen_to_this_post_text
 								 *
-								 * @return string
+								 * @param {string} The text to filter.
+								 * @param {int}    Post ID.
+								 *
+								 * @return {string} Filtered text.
 								 */
 								apply_filters( 'classifai_listen_to_this_post_text', '%s %s', $post->ID ),
 								esc_html__( 'Listen to this', 'classifai' ),

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,8 @@ Supercharge WordPress Content Workflows and Engagement with Artificial Intellige
 
 Tap into leading cloud-based services like [OpenAI](https://openai.com/), [Microsoft Azure AI](https://azure.microsoft.com/en-us/overview/ai-platform/), and [IBM Watson](https://www.ibm.com/watson) to augment your WordPress-powered websites.  Publish content faster while improving SEO performance and increasing audience engagement.  ClassifAI integrates Artificial Intelligence and Machine Learning technologies to lighten your workload and eliminate tedious tasks, giving you more time to create original content that matters.
 
+*You can learn more about ClassifAI's features at [ClassifAIPlugin.com](https://classifaiplugin.com/) and documentation at the [ClassifAI documentation site](https://10up.github.io/classifai/).*
+
 **Features**
 
 * Generate a summary of post content and store it as an excerpt using [OpenAI's ChatGPT API](https://platform.openai.com/docs/guides/chat)


### PR DESCRIPTION
### Description of the Change

I noticed that we introduced a few new filters in the last release but those filters did not have proper docblocks. This means they aren't showing within our automated documentation site: https://10up.github.io/classifai/

I did a scan of our codebase and found similar issues with a handful of our existing actions and filters as well, so this PR cleans all of those up. I've also added a link to this doc site at the top of our readmes.

### How to test the Change

If desired, you can build the doc site locally by running `npm run build:docs` and ensuring all hooks show properly there

### Changelog Entry

> Fixed - Add proper docblocks to all custom hooks to ensure those show properly in our documentation site

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
