### PR TITLE
Add image generation support to the classic editor

### DIFF
--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -87,7 +87,7 @@ class DallE extends Provider {
 		wp_enqueue_script(
 			'classifai-generate-images',
 			CLASSIFAI_PLUGIN_URL . 'dist/media-modal.js',
-			[ 'jquery', 'wp-api' ],
+			[ 'jquery', 'wp-api', 'wp-media-utils', 'wp-url' ],
 			get_asset_info( 'media-modal', 'version' ),
 			true
 		);

--- a/src/js/media-modal/index.js
+++ b/src/js/media-modal/index.js
@@ -10,7 +10,7 @@ const currentPostFrame = wp.media.view.MediaFrame.Post;
  * Extend the core MediaFrame.Select view.
  *
  * We do this in order to add our new tab and
- * the content for that tab.
+ * the content for that tab in the block editor.
  */
 wp.media.view.MediaFrame.Select = currentMediaSelectFrame.extend( {
 	/**

--- a/src/js/media-modal/index.js
+++ b/src/js/media-modal/index.js
@@ -3,7 +3,8 @@
 import Prompt from './views/prompt';
 import '../../scss/media-modal.scss';
 
-const currentMediaFrame = wp.media.view.MediaFrame.Select;
+const currentMediaSelectFrame = wp.media.view.MediaFrame.Select;
+const currentPostFrame = wp.media.view.MediaFrame.Post;
 
 /**
  * Extend the core MediaFrame.Select view.
@@ -11,14 +12,14 @@ const currentMediaFrame = wp.media.view.MediaFrame.Select;
  * We do this in order to add our new tab and
  * the content for that tab.
  */
-wp.media.view.MediaFrame.Select = currentMediaFrame.extend( {
+wp.media.view.MediaFrame.Select = currentMediaSelectFrame.extend( {
 	/**
 	 * Bind region mode event callbacks.
 	 *
 	 * @see media.controller.Region.render
 	 */
 	bindHandlers: function () {
-		currentMediaFrame.prototype.bindHandlers.apply( this, arguments );
+		currentMediaSelectFrame.prototype.bindHandlers.apply( this, arguments );
 
 		this.on( 'content:render:generate', this.generateContent, this );
 	},
@@ -29,7 +30,50 @@ wp.media.view.MediaFrame.Select = currentMediaFrame.extend( {
 	 * @param {wp.media.view.Router} routerView
 	 */
 	browseRouter: function ( routerView ) {
-		currentMediaFrame.prototype.browseRouter.apply( this, arguments );
+		currentMediaSelectFrame.prototype.browseRouter.apply( this, arguments );
+
+		routerView.set( {
+			generate: {
+				text: classifaiDalleData.tabText,
+				priority: 30,
+			},
+		} );
+	},
+
+	/**
+	 * Render callback for the content region in the `generate` mode.
+	 */
+	generateContent: function () {
+		this.content.set( new Prompt().render() );
+	},
+} );
+
+/**
+ * Extend the core MediaFrame.Post view.
+ *
+ * We do this in order to add our new tab and
+ * the content for that tab within the media
+ * modal used in the Classic Editor.
+ */
+wp.media.view.MediaFrame.Post = currentPostFrame.extend( {
+	/**
+	 * Bind region mode event callbacks.
+	 *
+	 * @see media.controller.Region.render
+	 */
+	bindHandlers: function () {
+		currentPostFrame.prototype.bindHandlers.apply( this, arguments );
+
+		this.on( 'content:render:generate', this.generateContent, this );
+	},
+
+	/**
+	 * Render callback for the router region in the `browse` mode.
+	 *
+	 * @param {wp.media.view.Router} routerView
+	 */
+	browseRouter: function ( routerView ) {
+		currentPostFrame.prototype.browseRouter.apply( this, arguments );
 
 		routerView.set( {
 			generate: {

--- a/src/js/media-modal/views/generated-image.js
+++ b/src/js/media-modal/views/generated-image.js
@@ -1,7 +1,7 @@
 /* eslint object-shorthand: 0 */
 
-const { uploadMedia } = wp.mediaUtils;
-const { cleanForSlug } = wp.url;
+import { uploadMedia } from '@wordpress/media-utils';
+import { cleanForSlug } from '@wordpress/url';
 
 /**
  * View to render a single generated image.

--- a/src/scss/media-modal.scss
+++ b/src/scss/media-modal.scss
@@ -35,6 +35,27 @@
 				display: block;
 				float: left;
 				margin-right: 10px;
+
+				&.is-tertiary {
+					padding: 6px;
+					background: transparent;
+					border: 0;
+					color: #007cba;
+					cursor: pointer;
+					white-space: nowrap;
+					outline: 1px solid transparent;
+
+					&:hover:not(:disabled) {
+						box-shadow: inset 0 0 0 1px #006ba1;
+						color: #006ba1;
+					}
+
+					&:active:not(:disabled) {
+						background: #ddd;
+						box-shadow: none;
+						color: #006ba1;
+					}
+				}
 			}
 
 			.spinner {


### PR DESCRIPTION
### Description of the Change

When we added the image generation feature, we didn't add support for that in the Classic Editor. In looking into this, it was pretty easy to add this for the Featured Image section and after some testing, I was able to get it working for in-content media as well.

The Featured Image experience is basically the exact same as what we have in the Block Editor. For in-content images, the modal itself is slightly different (it has a left-hand sidebar) and the process of selecting and inserting an image slightly differs as well, but generating and inserting does work, so I think this is an okay compromise.

Closes #465 

### How to test the Change

1. Install the Classic Editor plugin
2. Create a new classic post
3. Click to add a featured image and notice the `Generate images` tab shows up
4. Ensure generating images work and inserting one of those images as a featured image works as well
5. Click on the `Add Media` button above the editor
6. Ensure the `Generate images` tab shows in this modal
7. Ensuring generating and inserting images works from here

### Changelog Entry

> Added - Ability to generate images in the Classic Editor

### Credits

Props @dkotter, @mattbbs

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
