### PR TITLE
Add bulk actions to trigger text to speech generation

### DIFF
--- a/includes/Classifai/Admin/BulkActions.php
+++ b/includes/Classifai/Admin/BulkActions.php
@@ -268,7 +268,7 @@ class BulkActions {
 
 		$classified     = ! empty( $_GET['bulk_classified'] ) ? intval( wp_unslash( $_GET['bulk_classified'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$text_to_speech = ! empty( $_GET['bulk_text_to_speech'] ) ? intval( wp_unslash( $_GET['bulk_text_to_speech'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$post_type      = ! empty( $_GET['post_type'] ) ? wp_unslash( $_GET['post_type'] ) : 'post'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$post_type      = ! empty( $_GET['post_type'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) : 'post'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$scanned        = ! empty( $_GET['bulk_scanned'] ) ? intval( wp_unslash( $_GET['bulk_scanned'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$cropped        = ! empty( $_GET['bulk_cropped'] ) ? intval( wp_unslash( $_GET['bulk_cropped'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$transcribed    = ! empty( $_GET['bulk_transcribed'] ) ? intval( wp_unslash( $_GET['bulk_transcribed'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/includes/Classifai/Admin/BulkActions.php
+++ b/includes/Classifai/Admin/BulkActions.php
@@ -126,11 +126,17 @@ class BulkActions {
 	public function register_bulk_actions( $bulk_actions ) {
 		$nlu_post_types = get_supported_post_types();
 
-		if ( ! empty( $nlu_post_types ) || is_a( $this->embeddings, '\Classifai\Providers\OpenAI\Embeddings' ) ) {
+		if (
+			! empty( $nlu_post_types ) ||
+			( is_a( $this->embeddings, '\Classifai\Providers\OpenAI\Embeddings' ) && ! empty( $this->embeddings->supported_post_types() ) )
+		) {
 			$bulk_actions['classify'] = __( 'Classify', 'classifai' );
 		}
 
-		if ( is_a( $this->text_to_speech, '\Classifai\Providers\Azure\TextToSpeech' ) ) {
+		if (
+			is_a( $this->text_to_speech, '\Classifai\Providers\Azure\TextToSpeech' ) &&
+			in_array( get_current_screen()->post_type, $this->text_to_speech->get_supported_post_types(), true )
+		) {
 			$bulk_actions['text_to_speech'] = __( 'Text to speech', 'classifai' );
 		}
 

--- a/includes/Classifai/Admin/BulkActions.php
+++ b/includes/Classifai/Admin/BulkActions.php
@@ -2,6 +2,7 @@
 namespace Classifai\Admin;
 
 use Classifai\Providers\Azure\ComputerVision;
+use Classifai\Providers\Azure\TextToSpeech;
 use Classifai\Providers\OpenAI\Embeddings;
 use Classifai\Providers\OpenAI\Whisper;
 use Classifai\Providers\OpenAI\Whisper\Transcribe;
@@ -42,6 +43,11 @@ class BulkActions {
 	private $whisper;
 
 	/**
+	 * @var \Classifai\Providers\Azure\TextToSpeech
+	 */
+	private $text_to_speech;
+
+	/**
 	 * Register the actions needed.
 	 */
 	public function register() {
@@ -55,25 +61,32 @@ class BulkActions {
 	 * Register bulk actions for language processing.
 	 */
 	public function register_language_processing_hooks() {
-		$this->embeddings      = new Embeddings( false );
-		$settings              = $this->embeddings->get_settings();
-		$embeddings_post_types = [];
-		$nlu_post_types        = get_supported_post_types();
+		$this->embeddings          = new Embeddings( false );
+		$embedding_settings        = $this->embeddings->get_settings();
+		$embeddings_post_types     = [];
+		$nlu_post_types            = get_supported_post_types();
+		$this->text_to_speech      = new TextToSpeech( false );
+		$text_to_speech_post_types = $this->text_to_speech->get_supported_post_types();
 
-		// Set up the save post handler if we have any post types for NLU.
-		if ( ! empty( $nlu_post_types ) ) {
+		// Set up the save post handler if we have any post types.
+		if ( ! empty( $nlu_post_types ) || ! empty( $text_to_speech_post_types ) ) {
 			$this->save_post_handler = new SavePostHandler();
 		}
 
 		// Set up the embeddings post types if the feature is enabled. Otherwise clear our embeddings handler.
-		if ( isset( $settings['enable_classification'] ) && 1 === (int) $settings['enable_classification'] ) {
+		if ( isset( $embedding_settings['enable_classification'] ) && 1 === (int) $embedding_settings['enable_classification'] ) {
 			$embeddings_post_types = $this->embeddings->supported_post_types();
 		} else {
 			$this->embeddings = null;
 		}
 
+		// Clear our TextToSpeech handler if no post types are set up.
+		if ( empty( $text_to_speech_post_types ) ) {
+			$this->text_to_speech = null;
+		}
+
 		// Merge our post types together and make them unique.
-		$post_types = array_unique( array_merge( $embeddings_post_types, $nlu_post_types ) );
+		$post_types = array_unique( array_merge( $embeddings_post_types, $nlu_post_types, $text_to_speech_post_types ) );
 
 		if ( empty( $post_types ) ) {
 			return;
@@ -104,14 +117,23 @@ class BulkActions {
 	}
 
 	/**
-	 * Register Classifai bulk action.
+	 * Register language processing bulk actions.
 	 *
 	 * @param array $bulk_actions Current bulk actions.
 	 *
 	 * @return array
 	 */
 	public function register_bulk_actions( $bulk_actions ) {
-		$bulk_actions['classify'] = __( 'Classify', 'classifai' );
+		$nlu_post_types = get_supported_post_types();
+
+		if ( ! empty( $nlu_post_types ) || is_a( $this->embeddings, '\Classifai\Providers\OpenAI\Embeddings' ) ) {
+			$bulk_actions['classify'] = __( 'Classify', 'classifai' );
+		}
+
+		if ( is_a( $this->text_to_speech, '\Classifai\Providers\Azure\TextToSpeech' ) ) {
+			$bulk_actions['text_to_speech'] = __( 'Text to speech', 'classifai' );
+		}
+
 		return $bulk_actions;
 	}
 
@@ -145,7 +167,7 @@ class BulkActions {
 	}
 
 	/**
-	 * Handle bulk actions.
+	 * Handle language processing bulk actions.
 	 *
 	 * @param string $redirect_to Redirect URL after bulk actions.
 	 * @param string $doaction    Action ID.
@@ -154,24 +176,44 @@ class BulkActions {
 	 * @return string
 	 */
 	public function bulk_action_handler( $redirect_to, $doaction, $post_ids ) {
-		if ( 'classify' !== $doaction ) {
+		if (
+			empty( $post_ids ) ||
+			! in_array( $doaction, [ 'classify', 'text_to_speech' ], true )
+		) {
 			return $redirect_to;
 		}
 
+		$action = '';
+
 		foreach ( $post_ids as $post_id ) {
-			// Handle NLU classification.
-			if ( is_a( $this->save_post_handler, '\Classifai\Admin\SavePostHandler' ) ) {
-				$this->save_post_handler->classify( $post_id );
+			if ( 'classify' === $doaction ) {
+				// Handle NLU classification.
+				if ( is_a( $this->save_post_handler, '\Classifai\Admin\SavePostHandler' ) ) {
+					$action = 'classified';
+					$this->save_post_handler->classify( $post_id );
+				}
+
+				// Handle OpenAI Embeddings classification.
+				if ( is_a( $this->embeddings, '\Classifai\Providers\OpenAI\Embeddings' ) ) {
+					$action = 'classified';
+					$this->embeddings->generate_embeddings_for_post( $post_id );
+				}
 			}
 
-			// Handle OpenAI Embeddings classification.
-			if ( is_a( $this->embeddings, '\Classifai\Providers\OpenAI\Embeddings' ) ) {
-				$this->embeddings->generate_embeddings_for_post( $post_id );
+			if ( 'text_to_speech' === $doaction ) {
+				// Handle Azure Text to Speech generation.
+				if (
+					is_a( $this->text_to_speech, '\Classifai\Providers\Azure\TextToSpeech' ) &&
+					is_a( $this->save_post_handler, '\Classifai\Admin\SavePostHandler' )
+				) {
+					$action = 'text_to_speech';
+					$this->save_post_handler->synthesize_speech( $post_id );
+				}
 			}
 		}
 
-		$redirect_to = remove_query_arg( [ 'bulk_classified', 'bulk_scanned', 'bulk_cropped', 'bulk_transcribed' ], $redirect_to );
-		$redirect_to = add_query_arg( 'bulk_classified', count( $post_ids ), $redirect_to );
+		$redirect_to = remove_query_arg( [ 'bulk_classified', 'bulk_text_to_speech', 'bulk_scanned', 'bulk_cropped', 'bulk_transcribed' ], $redirect_to );
+		$redirect_to = add_query_arg( rawurlencode( "bulk_{$action}" ), count( $post_ids ), $redirect_to );
 
 		return esc_url_raw( $redirect_to );
 	}
@@ -213,7 +255,7 @@ class BulkActions {
 			}
 		}
 
-		$redirect_to = remove_query_arg( [ 'bulk_classified', 'bulk_scanned', 'bulk_cropped', 'bulk_transcribed' ], $redirect_to );
+		$redirect_to = remove_query_arg( [ 'bulk_classified', 'bulk_text_to_speech', 'bulk_scanned', 'bulk_cropped', 'bulk_transcribed' ], $redirect_to );
 		$redirect_to = add_query_arg( rawurlencode( "bulk_{$action}" ), count( $attachment_ids ), $redirect_to );
 
 		return esc_url_raw( $redirect_to );
@@ -224,12 +266,13 @@ class BulkActions {
 	 */
 	public function bulk_action_admin_notice() {
 
-		$classified  = ! empty( $_GET['bulk_classified'] ) ? intval( wp_unslash( $_GET['bulk_classified'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$scanned     = ! empty( $_GET['bulk_scanned'] ) ? intval( wp_unslash( $_GET['bulk_scanned'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$cropped     = ! empty( $_GET['bulk_cropped'] ) ? intval( wp_unslash( $_GET['bulk_cropped'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$transcribed = ! empty( $_GET['bulk_transcribed'] ) ? intval( wp_unslash( $_GET['bulk_transcribed'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$classified     = ! empty( $_GET['bulk_classified'] ) ? intval( wp_unslash( $_GET['bulk_classified'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$text_to_speech = ! empty( $_GET['bulk_text_to_speech'] ) ? intval( wp_unslash( $_GET['bulk_text_to_speech'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$scanned        = ! empty( $_GET['bulk_scanned'] ) ? intval( wp_unslash( $_GET['bulk_scanned'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$cropped        = ! empty( $_GET['bulk_cropped'] ) ? intval( wp_unslash( $_GET['bulk_cropped'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$transcribed    = ! empty( $_GET['bulk_transcribed'] ) ? intval( wp_unslash( $_GET['bulk_transcribed'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		if ( ! $classified && ! $scanned && ! $cropped && ! $transcribed ) {
+		if ( ! $classified && ! $text_to_speech && ! $scanned && ! $cropped && ! $transcribed ) {
 			return;
 		}
 
@@ -237,6 +280,10 @@ class BulkActions {
 			$classified_posts_count = $classified;
 			$post_type              = 'post';
 			$action                 = __( 'Classified', 'classifai' );
+		} elseif ( $text_to_speech ) {
+			$classified_posts_count = $text_to_speech;
+			$post_type              = 'post';
+			$action                 = __( 'Text to speech conversion done for', 'classifai' );
 		} elseif ( $scanned ) {
 			$classified_posts_count = $scanned;
 			$post_type              = 'image';


### PR DESCRIPTION
### Description of the Change

A text-to-speech feature was added in #403. We missed adding bulk action support for that, so this PR adds that, matching how we've done this for other features.

If the text-to-speech feature is enabled for a post type, you'll now see two new options to trigger this:

1. In the `Bulk actions` dropdown, there is a new `Text to speech` option. This will run the text-to-speech generation on whichever items you have selected
<img width="285" alt="Bulk action support" src="https://github.com/10up/classifai/assets/916738/1a699343-7a75-46ba-8963-4a4914126801">

2. Hovering over an individual item in the post lists table, there's a new `Text to speech` link that will trigger the text-to-speech generation for that individual item
<img width="416" alt="Inline support" src="https://github.com/10up/classifai/assets/916738/5692b820-1b77-4f21-b3ba-3dde8915289e">


Partially closes #460. A separate PR is coming to add `WP-CLI` support

### How to test the Change

1. With this branch checked out, enable the Text to Speech feature for a specific post type
2. Go to that post types edit screen
3. Select one or more items and then choose the `Text to speech` option in the `Bulk actions` dropdown and then hit `Apply`
4. Ensure a success message shows and that the generation of audio files worked as expected
5. Hover over a single item and click on the `Text to speech` link
6. Ensure a success message shows and that the generation of the audio file worked
7. There was some refactoring on our bulk action handling to make it more generic so if desired, test bulk classification features with Watson and OpenAI Embeddings

### Changelog Entry

> Added - Ability to trigger text-to-speech generation in bulk
> Added - Ability to trigger text-to-speech generation on an individual item from the post lists screen

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
