### PR TITLE
Add `WP-CLI` command that can be used to bulk process Text to Speech data

### DIFF
--- a/hookdocs/wp-cli.md
+++ b/hookdocs/wp-cli.md
@@ -68,7 +68,7 @@ The following WP-CLI commands are supported by ClassifAI:
 
     default: `false`
 
-* `wp classifai text_to_speech <post_ids> [--post_type=<post_type>] [--post_status=<post_status>] [--per_page=<per_page>]`
+* `wp classifai text_to_speech <post_ids> [--post_type=<post_type>] [--post_status=<post_status>] [--per_page=<per_page>] [--dry-run=<bool>]`
 
   Batch generation of text-to-speech data using Microsoft Azure's Text to Speech API.
 

--- a/hookdocs/wp-cli.md
+++ b/hookdocs/wp-cli.md
@@ -68,6 +68,38 @@ The following WP-CLI commands are supported by ClassifAI:
 
     default: `false`
 
+* `wp classifai text_to_speech <post_ids> [--post_type=<post_type>] [--post_status=<post_status>] [--per_page=<per_page>]`
+
+  Batch generation of text-to-speech data using Microsoft Azure's Text to Speech API.
+
+  * `<post_ids>`: A comma-delimited list of post IDs to generate text-to-speech for. Used if post_type is `false` or absent.
+
+    default: `null`
+
+  * `[--post_type=<post_type>]`: Batch process items belonging to this post type. If `false` or absent, will rely on `post_ids`.
+
+    default: `false`
+
+    options:
+
+    * any post type name
+
+  * `[--post_status=<post_status>]`: Batch process items that have this post status. Defaults to `publish`.
+
+    default: `publish`
+
+    options:
+
+    * any post status name
+
+  * `[--per_page=<per_page>]`: How many items should be processed at a time. Will still process all items but will do it in batches matching this number. Defaults to 100.
+
+    default: `100`
+
+    options:
+
+    * N, max number of items to process at a time
+
 ### Image Processing Commands
 
 * `wp classifai image <attachment_ids> [--limit=<int>] [--skip=<skip>] [--force]`

--- a/hookdocs/wp-cli.md
+++ b/hookdocs/wp-cli.md
@@ -92,13 +92,22 @@ The following WP-CLI commands are supported by ClassifAI:
 
     * any post status name
 
-  * `[--per_page=<per_page>]`: How many items should be processed at a time. Will still process all items but will do it in batches matching this number. Defaults to 100.
+  * `[--per_page=<int>]`: How many items should be processed at a time. Will still process all items but will do it in batches matching this number. Defaults to 100.
 
     default: `100`
 
     options:
 
     * N, max number of items to process at a time
+
+  * `[--dry-run=<bool>]`: Whether to run as a dry-run. Defaults to `true`, so will run in dry-run mode unless this is set to `false`.
+
+    default: `true`
+
+    options:
+
+    * `true` to run in dry-run mode
+    * `false` to run in normal mode
 
 ### Image Processing Commands
 

--- a/includes/Classifai/Admin/SavePostHandler.php
+++ b/includes/Classifai/Admin/SavePostHandler.php
@@ -184,7 +184,8 @@ class SavePostHandler {
 			);
 		}
 
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		// We skip the user cap check if running under WP-CLI.
+		if ( ! current_user_can( 'edit_post', $post_id ) && ( ! defined( 'WP_CLI' ) || ! WP_CLI ) ) {
 			return new \WP_Error(
 				'azure_text_to_speech_user_not_authorized',
 				esc_html__( 'Unauthorized user.', 'classifai' )

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -250,7 +250,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 		// If we have a post type specified, process all items in that type.
 		if ( ! empty( $opts['post_type'] ) ) {
-			\WP_CLI::log( sprintf( 'Starting processing of %s items in batches of %d', $opts['post_type'], $opts['per_page'] ) );
+			\WP_CLI::log( sprintf( 'Starting processing of "%s" post types that have the "%s" status in batches of %d', $opts['post_type'], $opts['post_status'], $opts['per_page'] ) );
 
 			$paged = 1;
 
@@ -260,7 +260,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 						'post_type'        => $opts['post_type'],
 						'posts_per_page'   => $opts['per_page'],
 						'paged'            => $paged,
-						'post_status'      => 'publish',
+						'post_status'      => $opts['post_status'],
 						'suppress_filters' => 'false',
 						'fields'           => 'ids',
 					)

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -299,8 +299,17 @@ class ClassifaiCommand extends \WP_CLI_Command {
 			$progress_bar = \WP_CLI\Utils\make_progress_bar( 'Processing ...', count( $post_ids ) );
 
 			foreach ( $post_ids as $post_id ) {
+				// Ensure we have a valid post ID.
 				if ( ! get_post( $post_id ) ) {
 					\WP_CLI::log( sprintf( 'Item ID %d does not exist', $post_id ) );
+					$errors ++;
+					continue;
+				}
+
+				// Ensure we have a valid post type.
+				$post_type = get_post_type( $post_id );
+				if ( ! $post_type || ! in_array( $post_type, $allowed_post_types, true ) ) {
+					\WP_CLI::log( sprintf( 'The "%s" post type is not enabled for Text to Speech processing', $post_type ) );
 					$errors ++;
 					continue;
 				}

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -274,7 +274,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 				\WP_CLI::error( sprintf( 'The "%s" post status is not valid for the "%s" post type', $opts['post_status'], $opts['post_type'] ) );
 			}
 
-			\WP_CLI::log( sprintf( 'Starting processing of "%s" post types that have the "%s" status in batches of %d', $opts['post_type'], $opts['post_status'], $opts['per_page'] ) );
+			\WP_CLI::log( sprintf( 'Starting processing of "%s" post type items that have the "%s" status in batches of %d', $opts['post_type'], $opts['post_status'], $opts['per_page'] ) );
 
 			$paged = 1;
 

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -235,13 +235,8 @@ class ClassifaiCommand extends \WP_CLI_Command {
 			'per_page'    => 100,
 		];
 
-		$opts = wp_parse_args( $opts, $defaults );
-
-		// Only allow processing post types that are enabled in settings.
+		$opts               = wp_parse_args( $opts, $defaults );
 		$allowed_post_types = TextToSpeech::get_supported_post_types();
-		if ( $opts['post_type'] && ! in_array( $opts['post_type'], $allowed_post_types, true ) ) {
-			\WP_CLI::error( sprintf( 'The "%s" post type is not enabled for Text to Speech processing', $opts['post_type'] ) );
-		}
 
 		$count  = 0;
 		$errors = 0;
@@ -250,6 +245,16 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 		// If we have a post type specified, process all items in that type.
 		if ( ! empty( $opts['post_type'] ) ) {
+			// Only allow processing post types that are enabled in settings.
+			if ( $opts['post_type'] && ! in_array( $opts['post_type'], $allowed_post_types, true ) ) {
+				\WP_CLI::error( sprintf( 'The "%s" post type is not enabled for Text to Speech processing', $opts['post_type'] ) );
+			}
+
+			// Only allow processing post statuses that are valid for a particular post type.
+			if ( ! in_array( $opts['post_status'], get_available_post_statuses( $opts['post_status'] ), true ) ) {
+				\WP_CLI::error( sprintf( 'The "%s" post status is not valid for the "%s" post type', $opts['post_status'], $opts['post_type'] ) );
+			}
+
 			\WP_CLI::log( sprintf( 'Starting processing of "%s" post types that have the "%s" status in batches of %d', $opts['post_type'], $opts['post_status'], $opts['per_page'] ) );
 
 			$paged = 1;

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -292,13 +292,19 @@ class ClassifaiCommand extends \WP_CLI_Command {
 				\WP_CLI::error( 'Please specify a comma-delimited list of post IDs to process' );
 			}
 
-			$post_ids = explode( ',', $args[0] );
+			$post_ids = array_map( 'absint', explode( ',', $args[0] ) );
 
 			\WP_CLI::log( sprintf( 'Starting processing of %s items', count( $post_ids ) ) );
 
 			$progress_bar = \WP_CLI\Utils\make_progress_bar( 'Processing ...', count( $post_ids ) );
 
 			foreach ( $post_ids as $post_id ) {
+				if ( ! get_post( $post_id ) ) {
+					\WP_CLI::log( sprintf( 'Item ID %d does not exist', $post_id ) );
+					$errors ++;
+					continue;
+				}
+
 				$result = $save_post_handler->synthesize_speech( $post_id );
 
 				if ( is_wp_error( $result ) ) {
@@ -314,7 +320,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 		}
 
 		\WP_CLI::success( sprintf( '%d items have been processed', $count ) );
-		\WP_CLI::success( sprintf( '%d items had errors', $errors ) );
+		\WP_CLI::log( sprintf( '%d items had errors', $errors ) );
 	}
 
 	/**

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -236,6 +236,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 		];
 
 		$opts               = wp_parse_args( $opts, $defaults );
+		$opts['per_page']   = (int) $opts['per_page'] > 0 ? $opts['per_page'] : 100;
 		$allowed_post_types = TextToSpeech::get_supported_post_types();
 
 		$count  = 0;
@@ -251,7 +252,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 			}
 
 			// Only allow processing post statuses that are valid for a particular post type.
-			if ( ! in_array( $opts['post_status'], get_available_post_statuses( $opts['post_status'] ), true ) ) {
+			if ( ! in_array( $opts['post_status'], get_available_post_statuses( $opts['post_type'] ), true ) ) {
 				\WP_CLI::error( sprintf( 'The "%s" post status is not valid for the "%s" post type', $opts['post_status'], $opts['post_type'] ) );
 			}
 

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -280,7 +280,9 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 				$this->inmemory_cleanup();
 
-				\WP_CLI::log( sprintf( 'Batch %d is done, proceeding to next batch', $paged ) );
+				if ( $total ) {
+					\WP_CLI::log( sprintf( 'Batch %d is done, proceeding to next batch', $paged ) );
+				}
 
 				$paged ++;
 			} while ( $total );


### PR DESCRIPTION
### Description of the Change

Following on from #477, this PR adds a custom `WP-CLI` command that can be used to generate Text to Speech data in bulk.

The new command looks like:
```
wp classifai text_to_speech
```

and has the following options:

- A comma-delimited list of post IDs to process
- A `post_type` to process. This will override the post IDs if both happen to be passed. We check this value against the list of supported post types that are set in settings. If it's not found, it stops processing
- A `post_status` to process. This will only be used if the `post_type` is passed. Defaults to `publish`
- A `per_page` argument. This controls how many items we process in each batch. Defaults to 100. As an example, if you have 1000 items to process, all of these will be processed but will be done in batches of 100 for performance reasons
- A `dry-run` argument that defaults to `true`. You must pass `false` to actually run the command

Here are some example commands that can be run:
```
wp classifai text_to_speech 1,2,3 --dry-run=false
```

```
wp classifai text_to_speech --post_type=post --dry-run=false
```

```
wp classifai text_to_speech --post_type=page --post_status=draft --dry-run=false
```

Here's some sample output from me running a command:
```
➜ wp classifai text_to_speech --post_type=page --per_page=1 --dry-run=false
Starting processing of "page" post types that have the "publish" status in batches of 1
Batch 1 is done, proceeding to next batch
Batch 2 is done, proceeding to next batch
Batch 3 is done, proceeding to next batch
Batch 4 is done, proceeding to next batch
Success: 4 items have been processed
0 items had errors
```

Partially closes #460 

### How to test the Change

Try running some of the `WP-CLI` commands as described above and ensure they all work as expected

### Changelog Entry

> Added - Custom `WP-CLI` command that can be used to generate Text to Speech data in bulk 

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
