### PR TITLE
replace get_post_statuses() with get_post_stati()

### DIFF
--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -711,7 +711,7 @@ function get_all_post_statuses() {
 	/*
 	 * We unset the following because we want to limit the post
 	 * statuses to the ones returned by `get_post_statuses()` and
-	 * any custom post statuses registered using `register_post_type()`
+	 * any custom post statuses registered using `register_post_status()`
 	 */
 	unset(
 		$all_statuses['future'],
@@ -723,9 +723,6 @@ function get_all_post_statuses() {
 		$all_statuses['request-failed'],
 		$all_statuses['request-completed']
 	);
-
-	// Some labels don't begin with upper case.
-	$all_statuses = array_map( 'ucwords', $all_statuses );
 
 	/*
 	 * There is a minor difference in the label for 'pending' status between

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -225,7 +225,7 @@ function get_post_types_for_language_settings() {
  * @return array
  */
 function get_post_statuses_for_language_settings() {
-	$post_statuses = get_post_statuses();
+	$post_statuses = get_all_post_statuses();
 
 	/**
 	 * Filter post statuses shown in language processing settings.
@@ -692,4 +692,58 @@ function find_provider_class( array $provider_classes = [], string $service_name
 	}
 
 	return $provider;
+}
+
+/**
+ * Returns core and custom post types.
+ *
+ * @return array
+ */
+function get_all_post_statuses() {
+	$all_statuses = wp_list_pluck(
+		get_post_stati(
+			[],
+			'objects'
+		),
+		'label'
+	);
+
+	/*
+	 * We unset the following because we want to limit the post
+	 * statuses to the ones returned by `get_post_statuses()` and
+	 * any custom post statuses registered using `register_post_type()`
+	 */
+	unset(
+		$all_statuses['future'],
+		$all_statuses['trash'],
+		$all_statuses['auto-draft'],
+		$all_statuses['inherit'],
+		$all_statuses['request-pending'],
+		$all_statuses['request-confirmed'],
+		$all_statuses['request-failed'],
+		$all_statuses['request-completed']
+	);
+
+	// Some labels don't begin with upper case.
+	$all_statuses = array_map( 'ucwords', $all_statuses );
+
+	/*
+	 * There is a minor difference in the label for 'pending' status between
+	 * `get_post_statuses()` and `get_post_stati()`.
+	 *
+	 * `get_post_stati()` has the label as `Pending` whereas
+	 * `get_post_statuses()` has the label as `Pending Review`.
+	 *
+	 * So we normalise it here.
+	 */
+	if ( isset( $all_statuses['pending'] ) ) {
+		$all_statuses['pending'] = esc_html__( 'Pending Review', 'classifai' );
+	}
+
+	/**
+	 * Hook to filter post statuses.
+	 *
+	 * @param array $all_statuses Array of post statuses.
+	 */
+	return apply_filters( 'get_all_post_statuses', $all_statuses );
 }

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -695,7 +695,7 @@ function find_provider_class( array $provider_classes = [], string $service_name
 }
 
 /**
- * Returns core and custom post types.
+ * Get core and custom post statuses.
  *
  * @return array
  */
@@ -740,7 +740,12 @@ function get_all_post_statuses() {
 	/**
 	 * Hook to filter post statuses.
 	 *
-	 * @param array $all_statuses Array of post statuses.
+	 * @since 2.2.2
+	 * @hook classifai_all_post_statuses
+	 *
+	 * @param {array} $all_statuses Array of post statuses.
+	 *
+	 * @return {array} Array of post statuses.
 	 */
-	return apply_filters( 'get_all_post_statuses', $all_statuses );
+	return apply_filters( 'classifai_all_post_statuses', $all_statuses );
 }

--- a/includes/Classifai/Providers/OpenAI/OpenAI.php
+++ b/includes/Classifai/Providers/OpenAI/OpenAI.php
@@ -8,6 +8,8 @@ namespace Classifai\Providers\OpenAI;
 use Classifai\Providers\OpenAI\APIRequest;
 use WP_Error;
 
+use function Classifai\get_all_post_statuses;
+
 trait OpenAI {
 
 	/**
@@ -188,7 +190,7 @@ trait OpenAI {
 	 * @return array
 	 */
 	public function get_post_statuses_for_settings() {
-		$post_statuses = get_post_statuses();
+		$post_statuses = get_all_post_statuses();
 
 		/**
 		 * Filter post statuses shown in settings.

--- a/tests/Classifai/HelpersTest.php
+++ b/tests/Classifai/HelpersTest.php
@@ -269,6 +269,9 @@ class HelpersTest extends \WP_UnitTestCase {
 	public function test_get_post_statuses() {
 		$all_statuses  = get_all_post_statuses();
 		$core_statuses = get_post_statuses();
+
+		// This tells that $all_status contains all statuses that
+		// are present in $core_statuses.
 		$statuses_diff = array_diff( $core_statuses, $all_statuses );
 		$this->assertEquals( 0, count( $statuses_diff ) );
 		$this->assertArrayHasKey( 'unread', $all_statuses );

--- a/tests/Classifai/HelpersTest.php
+++ b/tests/Classifai/HelpersTest.php
@@ -6,6 +6,23 @@ namespace Classifai;
  * @group helpers
  */
 class HelpersTest extends \WP_UnitTestCase {
+
+	/**
+	 * Set up method.
+	 */
+	public function set_up() {
+		register_post_status( 'unread', array(
+			'label'                     => _x( 'Unread', 'post' ),
+			'public'                    => true,
+			'exclude_from_search'       => false,
+			'show_in_admin_all_list'    => true,
+			'show_in_admin_status_list' => true,
+			'label_count'               => _n_noop( 'Unread <span class="count">(%s)</span>', 'Unread <span class="count">(%s)</span>' ),
+		) );
+
+		parent::set_up();
+	}
+
 	/**
 	 * Tear down method.
 	 */
@@ -244,5 +261,16 @@ class HelpersTest extends \WP_UnitTestCase {
 
 		$sanitized_int = clean_input( 'classify_test_int', true, 'absint' );
 		$this->assertEquals( $sanitized_int, 2 );
+	}
+
+	/**
+	 * Tests for the get_post_statuses method.
+	 */
+	public function test_get_post_statuses() {
+		$all_statuses  = get_all_post_statuses();
+		$core_statuses = get_post_statuses();
+		$statuses_diff = array_diff( $core_statuses, $all_statuses );
+		$this->assertEquals( 0, count( $statuses_diff ) );
+		$this->assertArrayHasKey( 'unread', $all_statuses );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR adds a new function `get_all_post_statuses()` that returns the core post statuses + custom post statuses registered using `register_post_status()`.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #500 

### How to test the Change

Verify post statuses settings under ClassifAI

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Added utility method to retrieve custom post statuses in addition to the core post statuses.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dkotter @Sidsector9 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
