### PR TITLE
Add `WP-CLI` command to bulk process audio transcriptions

### DIFF
--- a/hookdocs/wp-cli.md
+++ b/hookdocs/wp-cli.md
@@ -109,6 +109,40 @@ The following WP-CLI commands are supported by ClassifAI:
     * `true` to run in dry-run mode
     * `false` to run in normal mode
 
+* `wp classifai transcribe_audio <attachment_ids> [--per_page=<per_page>] [--force=<bool>] [--dry-run=<bool>]`
+
+  Batch generation of audio transcriptions using OpenAI's Whisper API.
+
+  * `<attachment_ids>`: A comma-delimited list of attachment IDs to generate transcriptions for. If not set, will instead run a query to get all audio attachments to process.
+
+    default: `null`
+
+  * `[--per_page=<int>]`: How many items should be processed at a time. Will still process all items but will do it in batches matching this number. Defaults to 100.
+
+    default: `100`
+
+    options:
+
+    * N, max number of items to process at a time
+
+  * `[--force=<bool>]`: Whether to process audio files that already have a transcription set. Defaults to `false`.
+
+    default: `false`
+
+    options:
+
+    * `true` to process all items
+    * `false` to only process items that don't have transcriptions set
+
+  * `[--dry-run=<bool>]`: Whether to run as a dry-run. Defaults to `true`, so will run in dry-run mode unless this is set to `false`.
+
+    default: `true`
+
+    options:
+
+    * `true` to run in dry-run mode
+    * `false` to run in normal mode
+
 ### Image Processing Commands
 
 * `wp classifai image <attachment_ids> [--limit=<int>] [--skip=<skip>] [--force]`

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -429,30 +429,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 				$attachment = get_post( $attachment_id );
 				$transcribe = new Transcribe( $attachment_id, $settings );
 
-				// Ensure we have a valid ID.
-				if ( ! $attachment ) {
-					\WP_CLI::log( sprintf( 'Item ID %d does not exist', $attachment_id ) );
-					$errors ++;
-					continue;
-				}
-
-				// Ensure we have a valid post type.
-				if ( 'attachment' !== $attachment->post_type ) {
-					\WP_CLI::log( sprintf( 'The "%s" post type is not supported for audio transcription processing', $attachment->post_type ) );
-					$errors ++;
-					continue;
-				}
-
-				// Ensure the attachment meets the requirements for processing.
-				if ( ! $transcribe->should_process( $attachment_id ) ) {
-					\WP_CLI::log( 'Attachment does not meet processing requirements. Ensure the file type and size meet requirements.' );
-					$errors ++;
-					continue;
-				}
-
-				// Don't process if the attachment already has a transcription, unless force is set.
-				if ( '' !== trim( $attachment->post_content ) && ! $opts['force'] ) {
-					\WP_CLI::log( sprintf( 'Item ID %d already has a transcription and the force option hasn\'t been set. Skipping...', $attachment_id ) );
+				if ( ! $this->should_transcribe_attachment( $attachment, $attachment_id, $transcribe, (bool) $opts['force'] ) ) {
 					$errors ++;
 					continue;
 				}
@@ -471,6 +448,64 @@ class ClassifaiCommand extends \WP_CLI_Command {
 			}
 
 			$progress_bar->finish();
+		} else {
+			\WP_CLI::log( sprintf( 'Starting processing of attachment items in batches of %d', $opts['per_page'] ) );
+
+			$paged      = 1;
+			$mime_types = [];
+			$transcribe = new Transcribe( 1, [] );
+
+			// Get all the mime types for the file formats we support.
+			foreach ( wp_get_mime_types() as $extensions => $mime ) {
+				foreach ( explode( '|', $extensions ) as $ext ) {
+					if ( in_array( $ext, $transcribe->file_formats, true ) ) {
+						$mime_types[] = $mime;
+					}
+				}
+			}
+
+			do {
+				$attachments = get_posts(
+					array(
+						'post_type'        => 'attachment',
+						'posts_per_page'   => $opts['per_page'],
+						'post_mime_type'   => array_unique( $mime_types ),
+						'paged'            => $paged,
+						'suppress_filters' => 'false',
+						'fields'           => 'ids',
+					)
+				);
+				$total       = count( $attachments );
+
+				foreach ( $attachments as $attachment_id ) {
+					$attachment = get_post( $attachment_id );
+					$transcribe = new Transcribe( $attachment_id, $settings );
+
+					if ( ! $this->should_transcribe_attachment( $attachment, (int) $attachment_id, $transcribe, (bool) $opts['force'] ) ) {
+						$errors ++;
+						continue;
+					}
+
+					if ( ! $dry_run ) {
+						$result = $transcribe->process();
+
+						if ( is_wp_error( $result ) ) {
+							\WP_CLI::log( sprintf( 'Error while processing item ID %s: %s', $attachment_id, $result->get_error_message() ) );
+							$errors ++;
+						}
+					}
+
+					$count ++;
+				}
+
+				$this->inmemory_cleanup();
+
+				if ( $total ) {
+					\WP_CLI::log( sprintf( 'Batch %d is done, proceeding to next batch', $paged ) );
+				}
+
+				$paged ++;
+			} while ( $total );
 		}
 
 		if ( ! $dry_run ) {
@@ -480,6 +515,43 @@ class ClassifaiCommand extends \WP_CLI_Command {
 		}
 
 		\WP_CLI::log( sprintf( '%d items had errors', $errors ) );
+	}
+
+	/**
+	 * Determine if an attachment should be transcribed.
+	 *
+	 * @param \WP_Post|null $attachment Attachment we are processing.
+	 * @param int           $attachment_id Attachment ID.
+	 * @param Transcribe    $transcribe Transcribe instance.
+	 * @param boolean       $force Whether to force processing.
+	 * @return boolean
+	 */
+	private function should_transcribe_attachment( $attachment, int $attachment_id, Transcribe $transcribe, bool $force = false ) {
+		// Ensure we have a valid ID.
+		if ( ! $attachment ) {
+			\WP_CLI::log( sprintf( 'Item ID %d does not exist', $attachment_id ) );
+			return false;
+		}
+
+		// Ensure we have a valid post type.
+		if ( 'attachment' !== $attachment->post_type ) {
+			\WP_CLI::log( sprintf( 'The "%s" post type is not supported for audio transcription processing', $attachment->post_type ) );
+			return false;
+		}
+
+		// Ensure the attachment meets the requirements for processing.
+		if ( ! $transcribe->should_process( $attachment_id ) ) {
+			\WP_CLI::log( sprintf( 'Item ID %d does not meet processing requirements. Ensure the file type and size meet requirements.', $attachment_id ) );
+			return false;
+		}
+
+		// Don't process if the attachment already has a transcription, unless force is set.
+		if ( '' !== trim( $attachment->post_content ) && ! $force ) {
+			\WP_CLI::log( sprintf( 'Item ID %d already has a transcription and the force option hasn\'t been set. Skipping...', $attachment_id ) );
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -10,6 +10,8 @@ use Classifai\PostClassifier;
 use Classifai\Providers\Azure\ComputerVision;
 use Classifai\Providers\Azure\SmartCropping;
 use Classifai\Providers\Azure\TextToSpeech;
+use Classifai\Providers\OpenAI\Whisper;
+use Classifai\Providers\OpenAI\Whisper\Transcribe;
 
 /**
  * ClassifaiCommand is the command line interface of the ClassifAI plugin.
@@ -360,6 +362,121 @@ class ClassifaiCommand extends \WP_CLI_Command {
 			\WP_CLI::success( sprintf( '%d items have been processed', $count ) );
 		} else {
 			\WP_CLI::success( sprintf( '%d items would have been processed', $count ) );
+		}
+
+		\WP_CLI::log( sprintf( '%d items had errors', $errors ) );
+	}
+
+	/**
+	 * Batch trigger generation of audio transcriptions depending on passed-in settings.
+	 *
+	 * ## Options
+	 *
+	 * [<attachment_ids>]
+	 * : Comma-delimited list of attachments IDs to generate transcriptions for
+	 *
+	 * [--per_page=<int>]
+	 * : How many items should be processed at a time. Default 100
+	 *
+	 * [--force=<bool>]
+	 * : Whether to process audio files that already have a transcription set. Default false
+	 *
+	 * [--dry-run=<bool>]
+	 * : Whether to run as a dry-run. Default true
+	 *
+	 * @param array $args Arguments.
+	 * @param array $opts Options.
+	 */
+	public function transcribe_audio( $args = [], $opts = [] ) {
+		$defaults = [
+			'per_page' => 100,
+			'force'    => false,
+		];
+
+		$opts             = wp_parse_args( $opts, $defaults );
+		$opts['per_page'] = (int) $opts['per_page'] > 0 ? $opts['per_page'] : 100;
+
+		$count  = 0;
+		$errors = 0;
+
+		$whisper  = new Whisper( false );
+		$settings = $whisper->get_settings();
+
+		// Determine if this is a dry run or not.
+		if ( isset( $opts['dry-run'] ) ) {
+			if ( 'false' === $opts['dry-run'] ) {
+				$dry_run = false;
+			} else {
+				$dry_run = (bool) $opts['dry-run'];
+			}
+		} else {
+			$dry_run = true;
+		}
+
+		if ( $dry_run ) {
+			\WP_CLI::line( '--- Running command in dry-run mode ---' );
+		}
+
+		// Process the passed in attachment IDs.
+		if ( ! empty( $args[0] ) ) {
+			$attachment_ids = array_map( 'absint', explode( ',', $args[0] ) );
+
+			\WP_CLI::log( sprintf( 'Starting processing of %s items', count( $attachment_ids ) ) );
+
+			$progress_bar = \WP_CLI\Utils\make_progress_bar( 'Processing ...', count( $attachment_ids ) );
+
+			foreach ( $attachment_ids as $attachment_id ) {
+				$attachment = get_post( $attachment_id );
+				$transcribe = new Transcribe( $attachment_id, $settings );
+
+				// Ensure we have a valid ID.
+				if ( ! $attachment ) {
+					\WP_CLI::log( sprintf( 'Item ID %d does not exist', $attachment_id ) );
+					$errors ++;
+					continue;
+				}
+
+				// Ensure we have a valid post type.
+				if ( 'attachment' !== $attachment->post_type ) {
+					\WP_CLI::log( sprintf( 'The "%s" post type is not supported for audio transcription processing', $attachment->post_type ) );
+					$errors ++;
+					continue;
+				}
+
+				// Ensure the attachment meets the requirements for processing.
+				if ( ! $transcribe->should_process( $attachment_id ) ) {
+					\WP_CLI::log( 'Attachment does not meet processing requirements. Ensure the file type and size meet requirements.' );
+					$errors ++;
+					continue;
+				}
+
+				// Don't process if the attachment already has a transcription, unless force is set.
+				if ( '' !== trim( $attachment->post_content ) && ! $opts['force'] ) {
+					\WP_CLI::log( sprintf( 'Item ID %d already has a transcription and the force option hasn\'t been set. Skipping...', $attachment_id ) );
+					$errors ++;
+					continue;
+				}
+
+				if ( ! $dry_run ) {
+					$result = $transcribe->process();
+
+					if ( is_wp_error( $result ) ) {
+						\WP_CLI::log( sprintf( 'Error while processing item ID %s: %s', $attachment_id, $result->get_error_message() ) );
+						$errors ++;
+					}
+				}
+
+				$progress_bar->tick();
+				$count ++;
+			}
+
+			$progress_bar->finish();
+		}
+
+		if ( ! $dry_run ) {
+			\WP_CLI::success( sprintf( '%d items had transcriptions added', $count ) );
+		} else {
+			\WP_CLI::success( sprintf( '%d items would have had transcriptions added', $count ) );
 		}
 
 		\WP_CLI::log( sprintf( '%d items had errors', $errors ) );

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -438,7 +438,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 					$result = $transcribe->process();
 
 					if ( is_wp_error( $result ) ) {
-						\WP_CLI::log( sprintf( 'Error while processing item ID %s: %s', $attachment_id, $result->get_error_message() ) );
+						\WP_CLI::error( sprintf( 'Error while processing item ID %s: %s', $attachment_id, $result->get_error_message() ), false );
 						$errors ++;
 					}
 				}
@@ -490,7 +490,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 						$result = $transcribe->process();
 
 						if ( is_wp_error( $result ) ) {
-							\WP_CLI::log( sprintf( 'Error while processing item ID %s: %s', $attachment_id, $result->get_error_message() ) );
+							\WP_CLI::error( sprintf( 'Error while processing item ID %s: %s', $attachment_id, $result->get_error_message() ), false );
 							$errors ++;
 						}
 					}
@@ -529,25 +529,25 @@ class ClassifaiCommand extends \WP_CLI_Command {
 	private function should_transcribe_attachment( $attachment, int $attachment_id, Transcribe $transcribe, bool $force = false ) {
 		// Ensure we have a valid ID.
 		if ( ! $attachment ) {
-			\WP_CLI::log( sprintf( 'Item ID %d does not exist', $attachment_id ) );
+			\WP_CLI::error( sprintf( 'Item ID %d does not exist', $attachment_id ), false );
 			return false;
 		}
 
 		// Ensure we have a valid post type.
 		if ( 'attachment' !== $attachment->post_type ) {
-			\WP_CLI::log( sprintf( 'The "%s" post type is not supported for audio transcription processing', $attachment->post_type ) );
+			\WP_CLI::error( sprintf( 'The "%s" post type is not supported for audio transcription processing', $attachment->post_type ), false );
 			return false;
 		}
 
 		// Ensure the attachment meets the requirements for processing.
 		if ( ! $transcribe->should_process( $attachment_id ) ) {
-			\WP_CLI::log( sprintf( 'Item ID %d does not meet processing requirements. Ensure the file type is one of %s and file size is under %d bytes.', $attachment_id, implode( ', ', $transcribe->file_formats ), $transcribe->max_file_size ) );
+			\WP_CLI::error( sprintf( 'Item ID %d does not meet processing requirements. Ensure the file type is one of %s and file size is under %d bytes.', $attachment_id, implode( ', ', $transcribe->file_formats ), $transcribe->max_file_size ), false );
 			return false;
 		}
 
 		// Don't process if the attachment already has a transcription, unless force is set.
 		if ( '' !== trim( $attachment->post_content ) && ! $force ) {
-			\WP_CLI::log( sprintf( 'Item ID %d already has a transcription and the force option hasn\'t been set. Skipping...', $attachment_id ) );
+			\WP_CLI::error( sprintf( 'Item ID %d already has a transcription and the force option hasn\'t been set. Skipping...', $attachment_id ), false );
 			return false;
 		}
 

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -511,12 +511,16 @@ class ClassifaiCommand extends \WP_CLI_Command {
 		}
 
 		if ( ! $dry_run ) {
-			\WP_CLI::success( sprintf( '%d items had transcriptions added', $count ) );
+			\WP_CLI::log( '-------- Finished! --------' );
+			\WP_CLI::log( sprintf( '%d items had transcriptions added', $count ) );
 		} else {
-			\WP_CLI::success( sprintf( '%d items would have had transcriptions added', $count ) );
+			\WP_CLI::log( '-------- Finished! --------' );
+			\WP_CLI::log( sprintf( '%d items would have had transcriptions added', $count ) );
 		}
 
-		\WP_CLI::log( sprintf( '%d items had errors', $errors ) );
+		if ( $errors > 0 ) {
+			\WP_CLI::error( sprintf( '%d items had errors', $errors ), false );
+		}
 	}
 
 	/**

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -541,7 +541,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 		// Ensure the attachment meets the requirements for processing.
 		if ( ! $transcribe->should_process( $attachment_id ) ) {
-			\WP_CLI::log( sprintf( 'Item ID %d does not meet processing requirements. Ensure the file type and size meet requirements.', $attachment_id ) );
+			\WP_CLI::log( sprintf( 'Item ID %d does not meet processing requirements. Ensure the file type is one of %s and file size is under %d bytes.', $attachment_id, implode( ', ', $transcribe->file_formats ), $transcribe->max_file_size ) );
 			return false;
 		}
 

--- a/includes/Classifai/Providers/OpenAI/Whisper/Whisper.php
+++ b/includes/Classifai/Providers/OpenAI/Whisper/Whisper.php
@@ -26,7 +26,7 @@ trait Whisper {
 	 *
 	 * @var array
 	 */
-	protected $file_formats = [
+	public $file_formats = [
 		'mp3',
 		'mp4',
 		'mpeg',

--- a/includes/Classifai/Providers/OpenAI/Whisper/Whisper.php
+++ b/includes/Classifai/Providers/OpenAI/Whisper/Whisper.php
@@ -41,7 +41,7 @@ trait Whisper {
 	 *
 	 * @var int
 	 */
-	protected $max_file_size = 25 * MB_IN_BYTES;
+	public $max_file_size = 25 * MB_IN_BYTES;
 
 	/**
 	 * Builds the API url.


### PR DESCRIPTION
### Description of the Change

In #451 we added the ability to generate a transcription from an audio file. This PR is a follow-up to that and adds a `WP-CLI` command that can be used to do the same thing. This is perfect for processing a large amount of audio files or having more control over which files are processed.

The new command looks like:
```
wp classifai transcribe_audio
```

and has the following options:

- A comma-delimited list of attachment IDs to process
- A `per_page` argument. This controls how many items we process in each batch. Defaults to 100. As an example, if you have 1000 items to process, all of these will be processed but will be done in batches of 100 for performance reasons
- A `force` argument that defaults to `false`. Will only process items that don't have data saved in `post_content` if set to `false` (basically won't re-process items that already have a transcription saved)
- A `dry-run` argument that defaults to `true`. You must pass `false` to actually run the command

Here are some example commands that can be run:
```
wp classifai transcribe_audio 1,2,3 --dry-run=false
```

```
wp classifai transcribe_audio --dry-run=false
```

```
wp classifai transcribe_audio --per_page=5 --force=true --dry-run=false
```

Closes #498 

### How to test the Change

Try running some of the `WP-CLI` commands as described above and ensure they all work as expected

### Changelog Entry

> Added - Custom `WP-CLI` command that can be used to generate audio transcriptions in bulk 

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
