### PR TITLE
Add `WP-CLI` command to bulk process excerpts

### DIFF
--- a/hookdocs/wp-cli.md
+++ b/hookdocs/wp-cli.md
@@ -109,6 +109,56 @@ The following WP-CLI commands are supported by ClassifAI:
     * `true` to run in dry-run mode
     * `false` to run in normal mode
 
+* `wp classifai generate_excerpt <post_ids> [--post_type=<post_type>] [--post_status=<post_status>] [--per_page=<per_page>] [--force=<bool>] [--dry-run=<bool>]`
+
+  Batch generation of excerpts using OpenAI's ChatGPT API.
+
+  * `<post_ids>`: A comma-delimited list of post IDs to generate excerpts for. Used if post_type is `false` or absent.
+
+    default: `null`
+
+  * `[--post_type=<post_type>]`: Batch process items belonging to this post type. If `false` or absent, will rely on `post_ids`.
+
+    default: `false`
+
+    options:
+
+    * any post type name
+
+  * `[--post_status=<post_status>]`: Batch process items that have this post status. Defaults to `publish`.
+
+    default: `publish`
+
+    options:
+
+    * any post status name
+
+  * `[--per_page=<int>]`: How many items should be processed at a time. Will still process all items but will do it in batches matching this number. Defaults to 100.
+
+    default: `100`
+
+    options:
+
+    * N, max number of items to process at a time
+
+  * `[--force=<bool>]`: Whether to process items that already have an excerpt set. Defaults to `false`.
+
+    default: `false`
+
+    options:
+
+    * `true` to process all items
+    * `false` to only process items that don't have an excerpt set
+
+  * `[--dry-run=<bool>]`: Whether to run as a dry-run. Defaults to `true`, so will run in dry-run mode unless this is set to `false`.
+
+    default: `true`
+
+    options:
+
+    * `true` to run in dry-run mode
+    * `false` to run in normal mode
+
 ### Image Processing Commands
 
 * `wp classifai image <attachment_ids> [--limit=<int>] [--skip=<skip>] [--force]`

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -10,6 +10,7 @@ use Classifai\PostClassifier;
 use Classifai\Providers\Azure\ComputerVision;
 use Classifai\Providers\Azure\SmartCropping;
 use Classifai\Providers\Azure\TextToSpeech;
+use Classifai\Providers\OpenAI\ChatGPT;
 
 /**
  * ClassifaiCommand is the command line interface of the ClassifAI plugin.
@@ -347,6 +348,157 @@ class ClassifaiCommand extends \WP_CLI_Command {
 						\WP_CLI::log( sprintf( 'Error while processing item ID %s: %s', $post_id, $result->get_error_message() ) );
 						$errors ++;
 					}
+				}
+
+				$progress_bar->tick();
+				$count ++;
+			}
+
+			$progress_bar->finish();
+		}
+
+		if ( ! $dry_run ) {
+			\WP_CLI::success( sprintf( '%d items have been processed', $count ) );
+		} else {
+			\WP_CLI::success( sprintf( '%d items would have been processed', $count ) );
+		}
+
+		\WP_CLI::log( sprintf( '%d items had errors', $errors ) );
+	}
+
+	/**
+	 * Batch trigger generation of excerpts depending on passed-in settings.
+	 *
+	 * ## Options
+	 *
+	 * [<post_ids>]
+	 * : Comma-delimited list of post IDs to generate excerpts for
+	 *
+	 * [--post_type=<post_type>]
+	 * : Batch process items belonging to this post type. If not used, relies on post_ids in args
+	 *
+	 * [--post_status=<post_status>]
+	 * : Batch process items that have this post status. Default publish
+
+	 * [--per_page=<int>]
+	 * : How many items should be processed at a time. Default 100
+	 *
+	 * [--dry-run=<bool>]
+	 * : Whether to run as a dry-run. Default true
+	 *
+	 * @param array $args Arguments.
+	 * @param array $opts Options.
+	 */
+	public function generate_excerpt( $args = [], $opts = [] ) {
+		$defaults = [
+			'post_type'   => false,
+			'post_status' => 'publish',
+			'per_page'    => 100,
+		];
+
+		$opts             = wp_parse_args( $opts, $defaults );
+		$opts['per_page'] = (int) $opts['per_page'] > 0 ? $opts['per_page'] : 100;
+
+		$count  = 0;
+		$errors = 0;
+
+		$chat_gpt = new ChatGPT( false );
+
+		// Determine if this is a dry run or not.
+		if ( isset( $opts['dry-run'] ) ) {
+			if ( 'false' === $opts['dry-run'] ) {
+				$dry_run = false;
+			} else {
+				$dry_run = (bool) $opts['dry-run'];
+			}
+		} else {
+			$dry_run = true;
+		}
+
+		if ( $dry_run ) {
+			\WP_CLI::line( '--- Running command in dry-run mode ---' );
+		}
+
+		// If we have a post type specified, process all items in that type.
+		if ( ! empty( $opts['post_type'] ) ) {
+			\WP_CLI::log( sprintf( 'Starting processing of "%s" post type items that have the "%s" status in batches of %d', $opts['post_type'], $opts['post_status'], $opts['per_page'] ) );
+
+			$paged = 1;
+
+			do {
+				$posts = get_posts(
+					array(
+						'post_type'        => $opts['post_type'],
+						'posts_per_page'   => $opts['per_page'],
+						'paged'            => $paged,
+						'post_status'      => $opts['post_status'],
+						'suppress_filters' => 'false',
+						'fields'           => 'ids',
+					)
+				);
+				$total = count( $posts );
+
+				foreach ( $posts as $post_id ) {
+					$result = $chat_gpt->generate_excerpt( (int) $post_id );
+
+					\WP_CLI::log( sprintf( 'Excerpt returned for item ID %d: %s', $post_id, $result ) );
+
+					if ( is_wp_error( $result ) ) {
+						\WP_CLI::log( sprintf( 'Error while processing item ID %s: %s', $post_id, $result->get_error_message() ) );
+						$errors ++;
+					}
+
+					// Update excerpt if not doing a dry run and we have a valid result.
+					if ( ! $dry_run && ! is_wp_error( $result ) ) {
+						wp_update_post(
+							array(
+								'ID'           => $post_id,
+								'post_excerpt' => $result,
+							)
+						);
+					}
+
+					$count ++;
+				}
+
+				$this->inmemory_cleanup();
+
+				if ( $total ) {
+					\WP_CLI::log( sprintf( 'Batch %d is done, proceeding to next batch', $paged ) );
+				}
+
+				$paged ++;
+			} while ( $total );
+		} else {
+			// If no post type is specified, we have to have a list of post IDs.
+			if ( ! isset( $args[0] ) ) {
+				\WP_CLI::error( 'Please specify a comma-delimited list of post IDs to process' );
+			}
+
+			$post_ids = array_map( 'absint', explode( ',', $args[0] ) );
+
+			\WP_CLI::log( sprintf( 'Starting processing of %s items', count( $post_ids ) ) );
+
+			$progress_bar = \WP_CLI\Utils\make_progress_bar( 'Processing ...', count( $post_ids ) );
+
+			foreach ( $post_ids as $post_id ) {
+				$result = $chat_gpt->generate_excerpt( (int) $post_id );
+
+				\WP_CLI::log( sprintf( 'Excerpt returned for item ID %d: %s', $post_id, $result ) );
+
+				if ( is_wp_error( $result ) ) {
+					\WP_CLI::log( sprintf( 'Error while processing item ID %s: %s', $post_id, $result->get_error_message() ) );
+					$errors ++;
+				}
+
+				// Update excerpt if not doing a dry run and we have a valid result.
+				if ( ! $dry_run && ! is_wp_error( $result ) ) {
+					wp_update_post(
+						array(
+							'ID'           => $post_id,
+							'post_excerpt' => $result,
+						)
+					);
 				}
 
 				$progress_bar->tick();

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -425,6 +425,16 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 		// If we have a post type specified, process all items in that type.
 		if ( ! empty( $opts['post_type'] ) ) {
+			// Only allow processing post types that are enabled in settings.
+			if ( ! in_array( $opts['post_type'], get_post_types(), true ) ) {
+				\WP_CLI::error( sprintf( 'The "%s" post type is not a valid post type', $opts['post_type'] ) );
+			}
+
+			// Only allow processing post statuses that are valid for a particular post type.
+			if ( ! in_array( $opts['post_status'], get_available_post_statuses( $opts['post_type'] ), true ) ) {
+				\WP_CLI::error( sprintf( 'The "%s" post status is not valid for the "%s" post type', $opts['post_status'], $opts['post_type'] ) );
+			}
+
 			\WP_CLI::log( sprintf( 'Starting processing of "%s" post type items that have the "%s" status in batches of %d', $opts['post_type'], $opts['post_status'], $opts['per_page'] ) );
 
 			$paged = 1;

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -474,19 +474,19 @@ class ChatGPT extends Provider {
 	/**
 	 * Generate an excerpt using ChatGPT.
 	 *
-	 * @param int $post_id The Post Id we're processing
+	 * @param int $post_id The Post ID we're processing
 	 * @return string|WP_Error
 	 */
 	public function generate_excerpt( int $post_id = 0 ) {
 		if ( ! $post_id || ! get_post( $post_id ) ) {
-			return new WP_Error( 'post_id_required', esc_html__( 'Post ID is required to generate an excerpt.', 'classifai' ) );
+			return new WP_Error( 'post_id_required', esc_html__( 'A valid post ID is required to generate an excerpt.', 'classifai' ) );
 		}
 
 		$settings = $this->get_settings();
 
 		// These checks (and the one above) happen in the REST permission_callback,
 		// but we run them again here in case this method is called directly.
-		if ( empty( $settings ) || ( isset( $settings['authenticated'] ) && false === $settings['authenticated'] ) || ( isset( $settings['enable_excerpt'] ) && 'no' === $settings['enable_excerpt'] ) ) {
+		if ( empty( $settings ) || ( isset( $settings['authenticated'] ) && false === $settings['authenticated'] ) || ( isset( $settings['enable_excerpt'] ) && 'no' === $settings['enable_excerpt'] && ( ! defined( 'WP_CLI' ) || ! WP_CLI ) ) ) {
 			return new WP_Error( 'not_enabled', esc_html__( 'Excerpt generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 


### PR DESCRIPTION
### Description of the Change

In #405 we added the ability to manually generate excerpts on individual items. This is a follow up that adds a `WP-CLI` command that can be used to process items in bulk, adding generated excerpts to those items.

One thing to note is that OpenAI has [rate limits](https://platform.openai.com/docs/guides/rate-limits/what-are-the-rate-limits-for-our-api) on their APIs, so you may run into that if processing too many items at a time. For instance, free accounts only get 3 requests per minute on the ChatGPT API, so very easy to hit that. Paid accounts go up to 3500 requests per minute, so unlikely to run into issues. We may want to explore adding rate limiting into ClassifAI at some point to ensure these limits aren't hit.

The new command looks like:
```
wp classifai generate_excerpt
```

and has the following options:

- A comma-delimited list of post IDs to process
- A `post_type` argument that will be used if no post IDs are passed in
- A `post_status` argument that will be used along with the `post_type` argument. Defaults to `publish`
- A `per_page` argument. This controls how many items we process in each batch. Defaults to 100. As an example, if you have 1000 items to process, all of these will be processed but will be done in batches of 100 for performance reasons
- A `force` argument that defaults to `false`. Will only process items that don't have an excerpt set if set to `false`
- A `dry-run` argument that defaults to `true`. You must pass `false` to actually run the command

Here are some example commands that can be run:
```
wp classifai generate_excerpt 1,2,3 --dry-run=false
```

```
wp classifai generate_excerpt --post_type=post --dry-run=false
```

```
wp classifai generate_excerpt --post_type=page --per_page=5 --force=true --dry-run=false
```

Closes #416 

### How to test the Change

Try running some of the `WP-CLI` commands as described above and ensure they all work as expected

### Changelog Entry

> Added - Custom WP-CLI command that can be used to generate excerpts in bulk

### Credits

Props @dkotter

### Checklist:

- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
