### PR TITLE
Support the Text-to-Speech feature in the Classic Editor

### DIFF
--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -550,7 +550,7 @@ class TextToSpeech extends Provider {
 		</p>
 
 		<?php
-		if ( $audio_id && wp_get_attachment_url( $audio_id ) ) {
+		if ( 'yes' === $process_content && $audio_id && wp_get_attachment_url( $audio_id ) ) {
 			$cache_busting_url = add_query_arg(
 				[
 					'ver' => time(),

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -5,6 +5,7 @@
 
 namespace Classifai\Providers\Azure;
 
+use Classifai\Admin\SavePostHandler;
 use Classifai\Providers\Provider;
 use stdClass;
 use WP_Http;
@@ -587,14 +588,13 @@ class TextToSpeech extends Provider {
 		}
 
 		if ( isset( $_POST['classifai_synthesize_speech'] ) && 'yes' === sanitize_text_field( wp_unslash( $_POST['classifai_synthesize_speech'] ) ) ) {
-			$process_content = 'yes';
+			update_post_meta( $post_id, self::SYNTHESIZE_SPEECH_KEY, 'yes' );
+
+			$save_post_handler = new SavePostHandler();
+			$save_post_handler->synthesize_speech( $post_id );
 		} else {
-			$process_content = 'no';
+			update_post_meta( $post_id, self::SYNTHESIZE_SPEECH_KEY, 'no' );
 		}
-
-		update_post_meta( $post_id, self::SYNTHESIZE_SPEECH_KEY, sanitize_text_field( $process_content ) );
-
-		// TODO: synthesize speech here if needed
 	}
 
 	/**

--- a/src/js/language-processing.js
+++ b/src/js/language-processing.js
@@ -346,8 +346,8 @@ import '../scss/language-processing.scss';
 	}
 } )();
 
-// Display "Classify Post" button only when "Process content on update" is unchecked (Classic Editor).
 document.addEventListener( 'DOMContentLoaded', function () {
+	// Display "Classify Post" button only when "Process content on update" is unchecked (Classic Editor).
 	const classifaiNLUCheckbox = document.getElementById(
 		'_classifai_process_content'
 	);
@@ -363,5 +363,25 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			}
 		} );
 		classifaiNLUCheckbox.dispatchEvent( new Event( 'change' ) );
+	}
+
+	// Display audio preview only when "Enable audio generation" is checked (Classic Editor).
+	const classifaiAudioGenerationCheckbox = document.getElementById(
+		'classifai_synthesize_speech'
+	);
+	const classifaiAudioPreview = document.getElementById(
+		'classifai-audio-preview'
+	);
+	if ( classifaiAudioGenerationCheckbox && classifaiAudioPreview ) {
+		classifaiAudioGenerationCheckbox.addEventListener(
+			'change',
+			function () {
+				if ( this.checked === true ) {
+					classifaiAudioPreview.style.display = 'block';
+				} else {
+					classifaiAudioPreview.style.display = 'none';
+				}
+			}
+		);
 	}
 } );

--- a/src/scss/language-processing.scss
+++ b/src/scss/language-processing.scss
@@ -168,3 +168,12 @@
 		}
 	}
 }
+
+#classifai-text-to-speech-meta-box {
+	.description {
+		display: block;
+		margin-top: 8px;
+		font-size: 12px;
+		color: rgb(117, 117, 117);
+	}
+}

--- a/tests/cypress/integration/text-to-speech.test.js
+++ b/tests/cypress/integration/text-to-speech.test.js
@@ -1,27 +1,30 @@
 describe( 'Microsoft Azure - Text to Speech', () => {
 	before( () => {
 		cy.login();
-		cy.visit( '/wp-admin/tools.php?page=classifai&tab=language_processing&provider=azure_text_to_speech' );
+		cy.visit(
+			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=azure_text_to_speech'
+		);
 		cy.get( '#azure_text_to_speech_post_types_post' ).check( 'post' );
 		cy.get( '#url' ).clear();
 		cy.get( '#url' ).type( 'https://service.com' );
 		cy.get( '#api_key' ).type( 'password' );
-		cy.get('#submit').click();
+		cy.get( '#submit' ).click();
 
 		cy.get( '#voice' ).select( 'en-AU-AnnetteNeural|Female' );
-		cy.get('#submit').click();
+		cy.get( '#submit' ).click();
 	} );
 
 	it( 'Generates audio from text', () => {
 		cy.createPost( {
 			title: 'Text to Speech test',
-			content: "This feature uses Microsoft's Text to Speech capabilities.",
+			content:
+				"This feature uses Microsoft's Text to Speech capabilities.",
 		} );
 
 		cy.get( 'button[aria-label="Close panel"]' ).click();
 		cy.get( 'button[data-label="Post"]' ).click();
 		cy.get( '.classifai-panel' ).click();
-		cy.get( '#classifai-audio-controls__preview-btn' ).should( 'exist' )
+		cy.get( '#classifai-audio-controls__preview-btn' ).should( 'exist' );
 	} );
 
 	it( 'Audio controls are visible if supported by post type', () => {
@@ -32,33 +35,80 @@ describe( 'Microsoft Azure - Text to Speech', () => {
 	it( 'a11y - aria-labels', () => {
 		cy.visit( '/text-to-speech-test/' );
 		cy.get( '.dashicons-controls-play' ).should( 'be.visible' );
-		cy.get( '.class-post-audio-controls' ).should( 'have.attr', 'aria-label', 'Play audio' );
+		cy.get( '.class-post-audio-controls' ).should(
+			'have.attr',
+			'aria-label',
+			'Play audio'
+		);
 
 		cy.get( '.class-post-audio-controls' ).click();
 
 		cy.get( '.dashicons-controls-play' ).should( 'not.be.visible' );
-		cy.get( '.class-post-audio-controls' ).should( 'have.attr', 'aria-label', 'Pause audio' );
+		cy.get( '.class-post-audio-controls' ).should(
+			'have.attr',
+			'aria-label',
+			'Pause audio'
+		);
 
 		cy.get( '.class-post-audio-controls' ).click();
 		cy.get( '.dashicons-controls-play' ).should( 'be.visible' );
-		cy.get( '.class-post-audio-controls' ).should( 'have.attr', 'aria-label', 'Play audio' );
+		cy.get( '.class-post-audio-controls' ).should(
+			'have.attr',
+			'aria-label',
+			'Play audio'
+		);
 	} );
 
 	it( 'a11y - keyboard accessibility', () => {
 		cy.visit( '/text-to-speech-test/' );
-		cy.get( '.class-post-audio-controls' ).tab( { shift: true } ).tab().type( '{enter}' );
+		cy.get( '.class-post-audio-controls' )
+			.tab( { shift: true } )
+			.tab()
+			.type( '{enter}' );
 		cy.get( '.dashicons-controls-pause' ).should( 'be.visible' );
-		cy.get( '.class-post-audio-controls' ).should( 'have.attr', 'aria-label', 'Pause audio' );
+		cy.get( '.class-post-audio-controls' ).should(
+			'have.attr',
+			'aria-label',
+			'Pause audio'
+		);
 
 		cy.get( '.class-post-audio-controls' ).type( '{enter}' );
 		cy.get( '.dashicons-controls-play' ).should( 'be.visible' );
-		cy.get( '.class-post-audio-controls' ).should( 'have.attr', 'aria-label', 'Play audio' );
+		cy.get( '.class-post-audio-controls' ).should(
+			'have.attr',
+			'aria-label',
+			'Play audio'
+		);
+	} );
+
+	it( 'Can see the enable button in a post (Classic Editor)', () => {
+		cy.visit( '/wp-admin/plugins.php' );
+		cy.get( '#activate-classic-editor' ).click();
+
+		cy.classicCreatePost( {
+			title: 'Text to Speech test classic',
+			content:
+				"This feature uses Microsoft's Text to Speech capabilities.",
+			postType: 'post',
+		} );
+
+		cy.get( '#classifai-text-to-speech-meta-box' ).should( 'exist' );
+		cy.get( '#classifai_synthesize_speech' ).check();
+		cy.get( '#classifai-audio-preview' ).should( 'exist' );
+
+		cy.visit( '/text-to-speech-test/' );
+		cy.get( '.class-post-audio-controls' ).should( 'be.visible' );
+
+		cy.visit( '/wp-admin/plugins.php' );
+		cy.get( '#deactivate-classic-editor' ).click();
 	} );
 
 	it( 'Disable support for post type Post', () => {
-		cy.visit( '/wp-admin/tools.php?page=classifai&tab=language_processing&provider=azure_text_to_speech' );
+		cy.visit(
+			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=azure_text_to_speech'
+		);
 		cy.get( '#azure_text_to_speech_post_types_post' ).uncheck( 'post' );
-		cy.get('#submit').click();
+		cy.get( '#submit' ).click();
 
 		cy.visit( '/text-to-speech-test/' );
 		cy.get( '.class-post-audio-controls' ).should( 'not.exist' );


### PR DESCRIPTION
### Description of the Change

In #403 we introduced a feature that can convert your content into speech using the Microsoft Azure's Text to Speech API. This only worked in the Block Editor so this PR brings the same feature over to the Classic Editor.

There's a new meta box that shows in the Classic Editor that allows you to toggle audio generation on or off:

<img width="302" alt="Classic Editor meta box to toggle speech generation" src="https://github.com/10up/classifai/assets/916738/6bd9b9b9-baac-478d-b1ed-58cc765d881a">

The text here mirrors what we show in the Block Editor. If this toggle is turned on, when the item is saved, we will generate an audio file for this item and connect the two.

We then show an audio preview in the same meta box:

<img width="327" alt="Audio preview in meta box" src="https://github.com/10up/classifai/assets/916738/4294e8c3-1e58-4e3c-a325-d3a0e2ae3a04">

Behind the scenes we use the same meta keys as are used in the Block Editor so things should all function the same. For example, if the toggle is turned off, we don't render the audio element on the front-end.

Closes #499

### How to test the Change

1. Install the Classic Editor plugin
2. Ensure you have Text to Speech configured in ClassifAI
3. Create a new item in whatever post type you have supported
4. With the toggle off, save the item. Make sure audio isn't generated
5. Turn the toggle on and save again. Ensure audio is generated and shows on the front-end
6. Turn the toggle back off and ensure the audio file stays but doesn't show on the front-end
7. Disable the Classic Editor plugin and repeat the steps to ensure Block Editor content still works as well

### Changelog Entry

> Added - Support our Text to Speech capability using Microsoft Azura Text to Speech in the Classic Editor

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
