### PR TITLE
Replace the word `REGION` with `LOCATION`

### DIFF
--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -159,7 +159,7 @@ class TextToSpeech extends Provider {
 				'label_for'     => 'url',
 				'input_type'    => 'text',
 				'default_value' => $default_settings['credentials']['url'],
-				'description'   => __( 'Text to Speech region endpoint, e.g., <code>https://LOCATION.tts.speech.microsoft.com/</code>. Replace <code>REGION</code> with the region you selected for the resource in Azure.', 'classifai' ),
+				'description'   => __( 'Text to Speech region endpoint, e.g., <code>https://LOCATION.tts.speech.microsoft.com/</code>. Replace <code>LOCATION</code> with the Location/Region you selected for the resource in Azure.', 'classifai' ),
 			]
 		);
 


### PR DESCRIPTION
### Description of the Change

Update the helper text we show when setting up the Text to Speech feature to be more clear. On the Azure side, this setting is labeled as `Location/Region`, so I've used `LOCATION` as the placeholder (both in the admin and in our README) but I also reference `Location/Region` since that's what a user will see when getting this value from Azure.

<img width="638" alt="Text to Speech settings" src="https://github.com/10up/classifai/assets/916738/d961e70a-20f9-45f1-bd85-f4cd1cc4c7a5">


Closes #517

### How to test the Change

Go to the Text to Speech settings page (`wp-admin/tools.php?page=classifai&tab=language_processing&provider=azure_text_to_speech`) and ensure the text looks correct

### Changelog Entry

None

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
