### PR TITLE
Add WP-CLI command to bulk process OpenAI Embeddings

### DIFF
--- a/hookdocs/wp-cli.md
+++ b/hookdocs/wp-cli.md
@@ -109,6 +109,47 @@ The following WP-CLI commands are supported by ClassifAI:
     * `true` to run in dry-run mode
     * `false` to run in normal mode
 
+* `wp classifai embeddings <post_ids> [--post_type=<post_type>] [--post_status=<post_status>] [--per_page=<per_page>] [--dry-run=<bool>]`
+
+  Batch classification of items using the OpenAI Embeddings API.
+
+  * `<post_ids>`: A comma-delimited list of post IDs to classify. Used if `post_type` is `false` or absent.
+
+    default: `null`
+
+  * `[--post_type=<post_type>]`: Batch process items belonging to this post type. If `false` or absent, will rely on `post_ids`.
+
+    default: `false`
+
+    options:
+
+    * any post type name
+
+  * `[--post_status=<post_status>]`: Batch process items that have this post status. Defaults to `publish`.
+
+    default: `publish`
+
+    options:
+
+    * any post status name
+
+  * `[--per_page=<int>]`: How many items should be processed at a time. Will still process all items but will do it in batches matching this number. Defaults to 100.
+
+    default: `100`
+
+    options:
+
+    * N, max number of items to process at a time
+
+  * `[--dry-run=<bool>]`: Whether to run as a dry-run. Defaults to `true`, so will run in dry-run mode unless this is set to `false`.
+
+    default: `true`
+
+    options:
+
+    * `true` to run in dry-run mode
+    * `false` to run in normal mode
+
 ### Image Processing Commands
 
 * `wp classifai image <attachment_ids> [--limit=<int>] [--skip=<skip>] [--force]`
@@ -152,46 +193,3 @@ The following WP-CLI commands are supported by ClassifAI:
 * `wp classifai reset`
 
   Restores the plugin configuration to factory defaults. Any API credentials will need to be re-entered after this is ran.
-
-### OpenAI Embeddings Commands
-
-* `wp classifai embeddings <post_ids> [--post_type=<post_type>] [--post_status=<post_status>] [--per_page=<per_page>] [--dry-run=<bool>]`
-
-  Batch post OpenAI embeddings.
-
-  * `<post_ids>`: A comma-delimited list of post IDs to generate text-to-speech for. Used if post_type is `false` or absent.
-
-    default: `null`
-
-  * `[--post_type=<post_type>]`: Batch process items belonging to this post type. If `false` or absent, will rely on `post_ids`.
-
-    default: `false`
-
-    options:
-
-    * any post type name
-
-  * `[--post_status=<post_status>]`: Batch process items that have this post status. Defaults to `publish`.
-
-    default: `publish`
-
-    options:
-
-    * any post status name
-
-  * `[--per_page=<int>]`: How many items should be processed at a time. Will still process all items but will do it in batches matching this number. Defaults to 100.
-
-    default: `100`
-
-    options:
-
-    * N, max number of items to process at a time
-
-  * `[--dry-run=<bool>]`: Whether to run as a dry-run. Defaults to `true`, so will run in dry-run mode unless this is set to `false`.
-
-    default: `true`
-
-    options:
-
-    * `true` to run in dry-run mode
-    * `false` to run in normal mode

--- a/hookdocs/wp-cli.md
+++ b/hookdocs/wp-cli.md
@@ -152,3 +152,46 @@ The following WP-CLI commands are supported by ClassifAI:
 * `wp classifai reset`
 
   Restores the plugin configuration to factory defaults. Any API credentials will need to be re-entered after this is ran.
+
+### OpenAI Embeddings Commands
+
+* `wp classifai embeddings <post_ids> [--post_type=<post_type>] [--post_status=<post_status>] [--per_page=<per_page>] [--dry-run=<bool>]`
+
+  Batch post OpenAI embeddings.
+
+  * `<post_ids>`: A comma-delimited list of post IDs to generate text-to-speech for. Used if post_type is `false` or absent.
+
+    default: `null`
+
+  * `[--post_type=<post_type>]`: Batch process items belonging to this post type. If `false` or absent, will rely on `post_ids`.
+
+    default: `false`
+
+    options:
+
+    * any post type name
+
+  * `[--post_status=<post_status>]`: Batch process items that have this post status. Defaults to `publish`.
+
+    default: `publish`
+
+    options:
+
+    * any post status name
+
+  * `[--per_page=<int>]`: How many items should be processed at a time. Will still process all items but will do it in batches matching this number. Defaults to 100.
+
+    default: `100`
+
+    options:
+
+    * N, max number of items to process at a time
+
+  * `[--dry-run=<bool>]`: Whether to run as a dry-run. Defaults to `true`, so will run in dry-run mode unless this is set to `false`.
+
+    default: `true`
+
+    options:
+
+    * `true` to run in dry-run mode
+    * `false` to run in normal mode

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -539,12 +539,12 @@ class ClassifaiCommand extends \WP_CLI_Command {
 	}
 
 	/**
-	 * Batch trigger generation of OpenAI embeddings depending on passed-in settings.
+	 * Batch classify content using the OpenAI Embeddings API depending on passed-in settings.
 	 *
 	 * ## Options
 	 *
 	 * [<post_ids>]
-	 * : Comma-delimited list of post IDs to generate for
+	 * : Comma-delimited list of post IDs to classify
 	 *
 	 * [--post_type=<post_type>]
 	 * : Batch process items belonging to this post type. If not used, relies on post_ids in args
@@ -626,7 +626,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 						$result = $embeddings->generate_embeddings_for_post( $post_id );
 
 						if ( is_wp_error( $result ) ) {
-							\WP_CLI::log( sprintf( 'Error while processing item ID %s', $post_id ) );
+							\WP_CLI::error( sprintf( 'Error while processing item ID %s', $post_id ), false );
 							$errors ++;
 						}
 					}
@@ -657,7 +657,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 			foreach ( $post_ids as $post_id ) {
 				// Ensure we have a valid post ID.
 				if ( ! get_post( $post_id ) ) {
-					\WP_CLI::log( sprintf( 'Item ID %d does not exist', $post_id ) );
+					\WP_CLI::error( sprintf( 'Item ID %d does not exist', $post_id ), false );
 					$errors ++;
 					continue;
 				}
@@ -665,7 +665,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 				// Ensure we have a valid post type.
 				$post_type = get_post_type( $post_id );
 				if ( ! $post_type || ! in_array( $post_type, $allowed_post_types, true ) ) {
-					\WP_CLI::log( sprintf( 'The "%s" post type is not enabled for OpenAI Embeddings processing', $post_type ) );
+					\WP_CLI::error( sprintf( 'The "%s" post type is not enabled for OpenAI Embeddings processing', $post_type ), false );
 					$errors ++;
 					continue;
 				}
@@ -674,7 +674,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 					$result = $embeddings->generate_embeddings_for_post( $post_id );
 
 					if ( is_wp_error( $result ) ) {
-						\WP_CLI::log( sprintf( 'Error while processing item ID %s', $post_id ) );
+						\WP_CLI::error( sprintf( 'Error while processing item ID %s', $post_id ), false );
 						$errors ++;
 					}
 				}

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -10,6 +10,7 @@ use Classifai\PostClassifier;
 use Classifai\Providers\Azure\ComputerVision;
 use Classifai\Providers\Azure\SmartCropping;
 use Classifai\Providers\Azure\TextToSpeech;
+use Classifai\Providers\OpenAI\Embeddings;
 
 /**
  * ClassifaiCommand is the command line interface of the ClassifAI plugin.
@@ -535,6 +536,162 @@ class ClassifaiCommand extends \WP_CLI_Command {
 			\WP_CLI::error( "Cropped $total_success images, $total_errors errors." );
 		}
 
+	}
+
+	/**
+	 * Batch trigger generation of OpenAI embeddings depending on passed-in settings.
+	 *
+	 * ## Options
+	 *
+	 * [<post_ids>]
+	 * : Comma-delimited list of post IDs to generate for
+	 *
+	 * [--post_type=<post_type>]
+	 * : Batch process items belonging to this post type. If not used, relies on post_ids in args
+	 *
+	 * [--post_status=<post_status>]
+	 * : Batch process items that have this post status. Default publish
+
+	 * [--per_page=<int>]
+	 * : How many items should be processed at a time. Default 100
+	 *
+	 * [--dry-run=<bool>]
+	 * : Whether to run as a dry-run. Default true
+	 *
+	 * @param array $args Arguments.
+	 * @param array $opts Options.
+	 */
+	public function embeddings( $args = [], $opts = [] ) {
+		$defaults = [
+			'post_type'   => false,
+			'post_status' => 'publish',
+			'per_page'    => 100,
+		];
+
+		$embeddings         = new Embeddings( false );
+		$opts               = wp_parse_args( $opts, $defaults );
+		$opts['per_page']   = (int) $opts['per_page'] > 0 ? $opts['per_page'] : 100;
+		$allowed_post_types = $embeddings->supported_post_types();
+
+		$count  = 0;
+		$errors = 0;
+
+		// Determine if this is a dry run or not.
+		if ( isset( $opts['dry-run'] ) ) {
+			if ( 'false' === $opts['dry-run'] ) {
+				$dry_run = false;
+			} else {
+				$dry_run = (bool) $opts['dry-run'];
+			}
+		} else {
+			$dry_run = true;
+		}
+
+		if ( $dry_run ) {
+			\WP_CLI::line( '--- Running command in dry-run mode ---' );
+		}
+
+		// If we have a post type specified, process all items in that type.
+		if ( ! empty( $opts['post_type'] ) ) {
+			// Only allow processing post types that are enabled in settings.
+			if ( $opts['post_type'] && ! in_array( $opts['post_type'], $allowed_post_types, true ) ) {
+				\WP_CLI::error( sprintf( 'The "%s" post type is not enabled for OpenAI Embeddings processing', $opts['post_type'] ) );
+			}
+
+			// Only allow processing post statuses that are valid for a particular post type.
+			if ( ! in_array( $opts['post_status'], get_available_post_statuses( $opts['post_type'] ), true ) ) {
+				\WP_CLI::error( sprintf( 'The "%s" post status is not valid for the "%s" post type', $opts['post_status'], $opts['post_type'] ) );
+			}
+
+			\WP_CLI::log( sprintf( 'Starting processing of "%s" post type items that have the "%s" status in batches of %d', $opts['post_type'], $opts['post_status'], $opts['per_page'] ) );
+
+			$paged = 1;
+
+			do {
+				$posts = get_posts(
+					array(
+						'post_type'        => $opts['post_type'],
+						'posts_per_page'   => $opts['per_page'],
+						'paged'            => $paged,
+						'post_status'      => $opts['post_status'],
+						'suppress_filters' => 'false',
+						'fields'           => 'ids',
+					)
+				);
+				$total = count( $posts );
+
+				foreach ( $posts as $post_id ) {
+					if ( ! $dry_run ) {
+						$result = $embeddings->generate_embeddings_for_post( $post_id );
+
+						if ( is_wp_error( $result ) ) {
+							\WP_CLI::log( sprintf( 'Error while processing item ID %s', $post_id ) );
+							$errors ++;
+						}
+					}
+
+					$count ++;
+				}
+
+				$this->inmemory_cleanup();
+
+				if ( $total ) {
+					\WP_CLI::log( sprintf( 'Batch %d is done, proceeding to next batch', $paged ) );
+				}
+
+				$paged ++;
+			} while ( $total );
+		} else {
+			// If no post type is specified, we have to have a list of post IDs.
+			if ( ! isset( $args[0] ) ) {
+				\WP_CLI::error( 'Please specify a comma-delimited list of post IDs to process' );
+			}
+
+			$post_ids = array_map( 'absint', explode( ',', $args[0] ) );
+
+			\WP_CLI::log( sprintf( 'Starting processing of %s items', count( $post_ids ) ) );
+
+			$progress_bar = \WP_CLI\Utils\make_progress_bar( 'Processing ...', count( $post_ids ) );
+
+			foreach ( $post_ids as $post_id ) {
+				// Ensure we have a valid post ID.
+				if ( ! get_post( $post_id ) ) {
+					\WP_CLI::log( sprintf( 'Item ID %d does not exist', $post_id ) );
+					$errors ++;
+					continue;
+				}
+
+				// Ensure we have a valid post type.
+				$post_type = get_post_type( $post_id );
+				if ( ! $post_type || ! in_array( $post_type, $allowed_post_types, true ) ) {
+					\WP_CLI::log( sprintf( 'The "%s" post type is not enabled for OpenAI Embeddings processing', $post_type ) );
+					$errors ++;
+					continue;
+				}
+
+				if ( ! $dry_run ) {
+					$result = $embeddings->generate_embeddings_for_post( $post_id );
+
+					if ( is_wp_error( $result ) ) {
+						\WP_CLI::log( sprintf( 'Error while processing item ID %s', $post_id ) );
+						$errors ++;
+					}
+				}
+
+				$progress_bar->tick();
+				$count ++;
+			}
+
+			$progress_bar->finish();
+		}
+
+		if ( ! $dry_run ) {
+			\WP_CLI::success( sprintf( '%d items have been processed', $count ) );
+		} else {
+			\WP_CLI::success( sprintf( '%d items would have been processed', $count ) );
+		}
+
+		\WP_CLI::log( sprintf( '%d items had errors', $errors ) );
 	}
 
 	/**

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -568,10 +568,11 @@ class ClassifaiCommand extends \WP_CLI_Command {
 			'per_page'    => 100,
 		];
 
-		$embeddings         = new Embeddings( false );
-		$opts               = wp_parse_args( $opts, $defaults );
-		$opts['per_page']   = (int) $opts['per_page'] > 0 ? $opts['per_page'] : 100;
-		$allowed_post_types = $embeddings->supported_post_types();
+		$embeddings          = new Embeddings( false );
+		$opts                = wp_parse_args( $opts, $defaults );
+		$opts['per_page']    = (int) $opts['per_page'] > 0 ? $opts['per_page'] : 100;
+		$allowed_post_types  = $embeddings->supported_post_types();
+		$allowed_post_status = $embeddings->supported_post_statuses();
 
 		$count  = 0;
 		$errors = 0;
@@ -599,7 +600,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 			}
 
 			// Only allow processing post statuses that are valid for a particular post type.
-			if ( ! in_array( $opts['post_status'], get_available_post_statuses( $opts['post_type'] ), true ) ) {
+			if ( ! in_array( $opts['post_status'], get_available_post_statuses( $opts['post_type'] ), true ) || ! in_array( $opts['post_status'], $allowed_post_status, true ) ) {
 				\WP_CLI::error( sprintf( 'The "%s" post status is not valid for the "%s" post type', $opts['post_status'], $opts['post_type'] ) );
 			}
 

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -387,7 +387,7 @@ class Embeddings extends Provider {
 		}
 
 		// Ensure the user has permissions to edit.
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) && ( ! defined( 'WP_CLI' ) || ! WP_CLI ) ) {
 			return;
 		}
 
@@ -453,7 +453,7 @@ class Embeddings extends Provider {
 
 			// Get embedding similarity for each term.
 			foreach ( $terms as $term_id ) {
-				if ( ! current_user_can( 'assign_term', $term_id ) ) {
+				if ( ! current_user_can( 'assign_term', $term_id ) && ( ! defined( 'WP_CLI' ) || ! WP_CLI ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
### Description of the Change
In [437](https://github.com/10up/classifai/pull/437) we added a feature to classify content within your existing content structure using the OpenAI Embeddings API. This PR adds the WP CLI script to do bulk embeddings using the command below:

`wp classifai embeddings`

and has the following options:

- A comma-delimited list of post IDs to process
- A `per_page` argument. This controls how many items we process in each batch. Defaults to 100. As an example, if you have 1000 items to process, all of these will be processed but will be done in batches of 100 for performance reasons
- A `post_type` argument that defaults to `post`. Will only process items that belong to the defined value.
- - A `post_status` argument that defaults to `publish`. Will only process items that belong to the defined value.
- A `dry-run` argument that defaults to `true`. You must pass false to actually run the command

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Custom WP-CLI command that can be used to run Embeddings processing

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @phpbits 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
