### PR TITLE
Make sure media scripts are loaded before we load our custom image generation JS

### DIFF
--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -83,6 +83,8 @@ class DallE extends Provider {
 			return;
 		}
 
+		wp_enqueue_media();
+
 		wp_enqueue_style(
 			'classifai-image-processing-style',
 			CLASSIFAI_PLUGIN_URL . 'dist/media-modal.css',


### PR DESCRIPTION
### Description of the Change

As reported in #520, on some screens we get a JS console error from our custom Media Modal code. This JS file is only loaded if we're on either `post.php` or `post-new.php`, which is good, but this does mean it loads on custom post creation/edit screens, which may not have any media handling (like the External Connection flow that Distributor uses).

It seems like the easy fix is to use the `wp_enqueue_media` function before loading our custom Media Modal JS file. In testing this, it fixed the reported issue and didn't cause any regressions from what I could see either in the Block Editor or Classic Editor image generation processes.

Closes #520 

### How to test the Change

1. Check out this PR and run `npm install && npm run build`
2. Go to a custom post screen, like the Distributor Add External Connection flow
3. Ensure no JS errors show in the console
4. Ensure you can still generate images in normal flows (Image block, featured image, inline images in the Classic Editor)

### Changelog Entry

> Fixed - Ensure we don't throw any JS errors in our image generation file

### Credits

Props @dkotter, @ravinderk 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
