### PR TITLE
#526 - Provide ability to override Audio Player Controls via filter.

### DIFF
--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -607,7 +607,7 @@ class TextToSpeech extends Provider {
 
 		$_post = get_post();
 
-		if ( ! $_post instanceof \WP_Post) {
+		if ( ! $_post instanceof \WP_Post ) {
 			return $content;
 		}
 
@@ -654,22 +654,30 @@ class TextToSpeech extends Provider {
 		}
 
 		/**
-		 * Filters the audio player markup / styles / scripts before display.
+		 * Filters the audio player markup before display.
 		 *
-		 * Returning a non-false value from the filter will effectively short-circuit retrieval
-		 * and return the passed value appended to the current state of content.
+		 * Returning a non-false value from the filter will short-circuit building
+		 * the block markup and instead will return the custom markup appended to
+		 * the post content.
 		 *
-		 * @since 2.2.1
+		 * Note that by using this filter, the custom CSS and JS files will no longer
+		 * be enqueued, so you'll be responsible for either loading them yourself or
+		 * loading custom ones.
 		 *
+		 * @since 2.2.3
+		 *
+		 * @param {bool}     $markup                Audio markup to use. By default false.
 		 * @param {string}   $content               Content of the current post.
-		 * @param {WP_Post}  $_post                 The Post Object.
-		 * @param {int}      $audio_attachment_id   The ID to audio attachment.
+		 * @param {WP_Post}  $_post                 The Post object.
+		 * @param {int}      $audio_attachment_id   The audio attachment ID.
 		 * @param {string}   $audio_attachment_url  The URL to the audio attachment file.
+		 *
+		 * @return {bool|string} Custom audio block markup. Will be appended to the post content.
 		 */
-		$audio = apply_filters( 'classifai_pre_render_post_audio_controls', false, $content, $post, $audio_attachment_id, $audio_attachment_url );
+		$markup = apply_filters( 'classifai_pre_render_post_audio_controls', false, $content, $_post, $audio_attachment_id, $audio_attachment_url );
 
-		if ( false !== $audio ) {
-			return (string) $audio . $content;
+		if ( false !== $markup ) {
+			return (string) $markup . $content;
 		}
 
 		wp_enqueue_script(

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -604,18 +604,14 @@ class TextToSpeech extends Provider {
 	 * @return string
 	 */
 	public function render_post_audio_controls( $content ) {
-		global $post;
 
-		if ( ! $post ) {
+		$_post = get_post();
+
+		if ( ! $_post instanceof \WP_Post) {
 			return $content;
 		}
 
-		if ( ! in_array( $post->post_type, self::get_supported_post_types(), true ) ) {
-			return $content;
-		}
-
-		$is_audio_enabled = get_post_meta( $post->ID, self::SYNTHESIZE_SPEECH_KEY, true );
-		if ( 'no' === $is_audio_enabled ) {
+		if ( ! in_array( $_post->post_type, self::get_supported_post_types(), true ) ) {
 			return $content;
 		}
 
@@ -625,16 +621,21 @@ class TextToSpeech extends Provider {
 		 * @since 2.2.0
 		 * @hook classifai_disable_post_to_audio_block
 		 *
-		 * @param {bool} $is_disabled Whether to disable the display or not. By default - false.
-		 * @param {bool} $post_id     Post ID.
+		 * @param  {bool}    $is_disabled  Whether to disable the display or not. By default - false.
+		 * @param  {WP_Post} $_post        The Post Object.
 		 *
-		 * @return {bool} Whether the audio block should be shown.
+		 * @return {bool}                  Whether the audio block should be shown.
 		 */
-		if ( apply_filters( 'classifai_disable_post_to_audio_block', false, $post->ID ) ) {
+		if ( apply_filters( 'classifai_disable_post_to_audio_block', false, $_post ) ) {
 			return $content;
 		}
 
-		$audio_attachment_id = (int) get_post_meta( $post->ID, self::AUDIO_ID_KEY, true );
+		$is_audio_enabled = get_post_meta( $_post->ID, self::SYNTHESIZE_SPEECH_KEY, true );
+		if ( 'no' === $is_audio_enabled ) {
+			return $content;
+		}
+
+		$audio_attachment_id = (int) get_post_meta( $_post->ID, self::AUDIO_ID_KEY, true );
 
 		if ( ! $audio_attachment_id ) {
 			return $content;
@@ -644,6 +645,31 @@ class TextToSpeech extends Provider {
 
 		if ( ! $audio_attachment_url ) {
 			return $content;
+		}
+
+		$audio_timestamp = (int) get_post_meta( $_post->ID, self::AUDIO_TIMESTAMP_KEY, true );
+
+		if ( $audio_timestamp ) {
+			$audio_attachment_url = add_query_arg( 'ver', filter_var( $audio_timestamp, FILTER_SANITIZE_NUMBER_INT ), $audio_attachment_url );
+		}
+
+		/**
+		 * Filters the audio player markup / styles / scripts before display.
+		 *
+		 * Returning a non-false value from the filter will effectively short-circuit retrieval
+		 * and return the passed value appended to the current state of content.
+		 *
+		 * @since 2.2.1
+		 *
+		 * @param {string}   $content               Content of the current post.
+		 * @param {WP_Post}  $_post                 The Post Object.
+		 * @param {int}      $audio_attachment_id   The ID to audio attachment.
+		 * @param {string}   $audio_attachment_url  The URL to the audio attachment file.
+		 */
+		$audio = apply_filters( 'classifai_pre_render_post_audio_controls', false, $content, $post, $audio_attachment_id, $audio_attachment_url );
+
+		if ( false !== $audio ) {
+			return (string) $audio . $content;
 		}
 
 		wp_enqueue_script(
@@ -661,12 +687,6 @@ class TextToSpeech extends Provider {
 			get_asset_info( 'post-audio-controls', 'version' ),
 			'all'
 		);
-
-		$audio_timestamp = (int) get_post_meta( $post->ID, self::AUDIO_TIMESTAMP_KEY, true );
-
-		if ( $audio_timestamp ) {
-			$audio_attachment_url = add_query_arg( 'ver', filter_var( $audio_timestamp, FILTER_SANITIZE_NUMBER_INT ), $audio_attachment_url );
-		}
 
 		ob_start();
 
@@ -691,9 +711,9 @@ class TextToSpeech extends Provider {
 								 *
 								 * @return {string} Filtered text.
 								 */
-								apply_filters( 'classifai_listen_to_this_post_text', '%s %s', $post->ID ),
+								apply_filters( 'classifai_listen_to_this_post_text', '%s %s', $_post->ID ),
 								esc_html__( 'Listen to this', 'classifai' ),
-								esc_html( $post->post_type )
+								esc_html( $_post->post_type )
 							);
 
 							echo wp_kses_post( $listen_to_post_text );

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -621,10 +621,10 @@ class TextToSpeech extends Provider {
 		 * @since 2.2.0
 		 * @hook classifai_disable_post_to_audio_block
 		 *
-		 * @param  {bool}    $is_disabled  Whether to disable the display or not. By default - false.
-		 * @param  {WP_Post} $_post        The Post Object.
+		 * @param  {bool}    $is_disabled Whether to disable the display or not. By default - false.
+		 * @param  {WP_Post} $_post       The Post object.
 		 *
-		 * @return {bool}                  Whether the audio block should be shown.
+		 * @return {bool} Whether the audio block should be shown.
 		 */
 		if ( apply_filters( 'classifai_disable_post_to_audio_block', false, $_post ) ) {
 			return $content;
@@ -656,23 +656,24 @@ class TextToSpeech extends Provider {
 		/**
 		 * Filters the audio player markup before display.
 		 *
-		 * Returning a non-false value from the filter will short-circuit building
-		 * the block markup and instead will return the custom markup appended to
-		 * the post content.
+		 * Returning a non-false value from this filter will short-circuit building
+		 * the block markup and instead will return your custom markup prepended to
+		 * the post_content.
 		 *
 		 * Note that by using this filter, the custom CSS and JS files will no longer
 		 * be enqueued, so you'll be responsible for either loading them yourself or
 		 * loading custom ones.
 		 *
+		 * @hook classifai_pre_render_post_audio_controls
 		 * @since 2.2.3
 		 *
-		 * @param {bool}     $markup                Audio markup to use. By default false.
-		 * @param {string}   $content               Content of the current post.
-		 * @param {WP_Post}  $_post                 The Post object.
-		 * @param {int}      $audio_attachment_id   The audio attachment ID.
-		 * @param {string}   $audio_attachment_url  The URL to the audio attachment file.
+		 * @param {bool|string} $markup               Audio markup to use. Defaults to false.
+		 * @param {string}      $content              Content of the current post.
+		 * @param {WP_Post}     $_post                The Post object.
+		 * @param {int}         $audio_attachment_id  The audio attachment ID.
+		 * @param {string}      $audio_attachment_url The URL to the audio attachment file.
 		 *
-		 * @return {bool|string} Custom audio block markup. Will be appended to the post content.
+		 * @return {bool|string} Custom audio block markup. Will be prepended to the post content.
 		 */
 		$markup = apply_filters( 'classifai_pre_render_post_audio_controls', false, $content, $_post, $audio_attachment_id, $audio_attachment_url );
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #526 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Use the newly added `classifai_pre_render_post_audio_controls` filter to return audio player markup, and enqueue its related styles and scripts.
2. Check to see if the default ClassifAI plugin output for the TTS audio player is overridden as expected.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Ability to override Audio Player Controls.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @joshuaabenazer 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
