### PR TITLE
Add sample copy that can be used to alert site visitor's that AI tools are in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Whatever options you have selected in the Category, Keyword, Entity, and Concept
 
 We recommend that you are transparent with your users that AI tools are being used.  This can be done by adding a notice to your site's Privacy Policy or similar page. Sample copy is provided below:
 
-> This site makes use of Artificial Intelligence tools that may include image generation, post title and excerpt generation, image alt text generation, post and media tagging, text-to-speech audio generation, speech-to-text transcript generation, image smart focal point cropping, media text recognition, and recommended content.
+> This site makes use of Artificial Intelligence tools to help with tasks like language processing, image processing, and content recommendations.
 
 ## Support Level
 

--- a/README.md
+++ b/README.md
@@ -406,6 +406,12 @@ ClassifAI connects your WordPress site directly to your account with specific se
 
 Whatever options you have selected in the Category, Keyword, Entity, and Concept taxonomy dropdowns in the NLU Language Processing settings can be viewed within Classic Editor metaboxes and the Block Editor side panel.  They can also be viewed in the All Posts and All Pages table list views by utilizing the Screen Options to enable those columns if they're not already appearing in your table list view.
 
+### Should I alert my site's users that AI tools are being used?
+
+We recommend that you are transparent with your users that AI tools are being used.  This can be done by adding a notice to your site's Privacy Policy or similar page. Sample copy is provided below:
+
+> This site makes use of Artificial Intelligence tools that may include image generation, post title and excerpt generation, image alt text generation, post and media tagging, text-to-speech audio generation, speech-to-text transcript generation, image smart focal point cropping, media text recognition, and recommended content.
+
 ## Support Level
 
 **Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress.  Bug reports, feature requests, questions, and pull requests are welcome.

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -149,9 +149,9 @@ class Plugin {
 	 * Adds information to the privacy policy.
 	 */
 	public function add_privacy_policy_content() {
-		$content  = '<p class="privacy-policy-tutorial">' . esc_html__( 'ClassifAI provides integrations with various AI providers. We recommend that you are transparent with your users that these AI tools are being used.', 'classifai' ) . '</p>';
+		$content  = '<p class="privacy-policy-tutorial">' . esc_html__( 'ClassifAI integrates with various AI service providers. We recommend that you are transparent with your users that these AI integrations are in use.', 'classifai' ) . '</p>';
 		$content .= '<strong class="privacy-policy-tutorial">' . esc_html__( 'Suggested text:', 'classifai' ) . '</strong> ';
-		$content .= esc_html__( 'This site makes use of Artificial Intelligence tools that may include image generation, post title and excerpt generation, image alt text generation, post and media tagging, text-to-speech audio generation, speech-to-text transcript generation, image smart focal point cropping, media text recognition, and recommended content.', 'classifai' );
+		$content .= esc_html__( 'This site makes use of Artificial Intelligence tools to help with tasks like language processing, image processing, and content recommendations.', 'classifai' );
 
 		wp_add_privacy_policy_content( 'ClassifAI', wp_kses_post( wpautop( $content, false ) ) );
 	}

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -36,6 +36,7 @@ class Plugin {
 		add_action( 'init', [ $this, 'init' ], 20 );
 		add_action( 'init', [ $this, 'i18n' ] );
 		add_action( 'admin_init', [ $this, 'init_admin_helpers' ] );
+		add_action( 'admin_init', [ $this, 'add_privacy_policy_content' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 		add_filter( 'plugin_action_links_' . CLASSIFAI_PLUGIN_BASENAME, array( $this, 'filter_plugin_action_links' ) );
 	}
@@ -142,6 +143,17 @@ class Plugin {
 				$instance->register();
 			}
 		}
+	}
+
+	/**
+	 * Adds information to the privacy policy.
+	 */
+	public function add_privacy_policy_content() {
+		$content  = '<p class="privacy-policy-tutorial">' . __( 'ClassifAI provides integrations with various AI providers. We recommend that you are transparent with your users that these AI tools are being used.', 'classifai' ) . '</p>';
+		$content .= '<strong class="privacy-policy-tutorial">' . __( 'Suggested text:', 'classifai' ) . '</strong> ';
+		$content .= esc_html__( 'This site makes use of Artificial Intelligence tools that may include image generation, post title and excerpt generation, image alt text generation, post and media tagging, text-to-speech audio generation, speech-to-text transcript generation, image smart focal point cropping, media text recognition, and recommended content.', 'classifai' );
+
+		wp_add_privacy_policy_content( 'ClassifAI', wp_kses_post( wpautop( $content, false ) ) );
 	}
 
 	/**

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -149,8 +149,8 @@ class Plugin {
 	 * Adds information to the privacy policy.
 	 */
 	public function add_privacy_policy_content() {
-		$content  = '<p class="privacy-policy-tutorial">' . __( 'ClassifAI provides integrations with various AI providers. We recommend that you are transparent with your users that these AI tools are being used.', 'classifai' ) . '</p>';
-		$content .= '<strong class="privacy-policy-tutorial">' . __( 'Suggested text:', 'classifai' ) . '</strong> ';
+		$content  = '<p class="privacy-policy-tutorial">' . esc_html__( 'ClassifAI provides integrations with various AI providers. We recommend that you are transparent with your users that these AI tools are being used.', 'classifai' ) . '</p>';
+		$content .= '<strong class="privacy-policy-tutorial">' . esc_html__( 'Suggested text:', 'classifai' ) . '</strong> ';
 		$content .= esc_html__( 'This site makes use of Artificial Intelligence tools that may include image generation, post title and excerpt generation, image alt text generation, post and media tagging, text-to-speech audio generation, speech-to-text transcript generation, image smart focal point cropping, media text recognition, and recommended content.', 'classifai' );
 
 		wp_add_privacy_policy_content( 'ClassifAI', wp_kses_post( wpautop( $content, false ) ) );


### PR DESCRIPTION
### Description of the Change

It's ideal to let site visitor's know when AI tools may be in use. This can be fairly straightforward if using AI to write content or to generate images but if used to do things like generate an excerpt, add `alt` text or classify content there's not necessarily a great place to put these alerts.

The easiest answer is to add a section in your site's Privacy Policy / Terms of Use / similar type of page that let's visitors know that AI tools may be in use. This PR adds sample copy to our `README.md` file that can be used for this purpose. In addition, it utilizes the core `wp_add_privacy_policy_content` function to add the same copy to the Privacy admin settings page, allowing users to copy/paste from there:

<img width="842" alt="ClassifAI privacy policy" src="https://github.com/10up/classifai/assets/916738/d7505bb3-dd4b-4eb7-ae5f-2e4c0b242457">


Closes #480

### How to test the Change

1. Verify the changes to the `README.md` file look correct
2. Verify the changes show in the WordPress Privacy admin page

### Changelog Entry

> Added - Provide sample copy that can be added to a site's Privacy Policy, letting site visitors know AI tools are in use

### Credits

Props @jeffpaul, @dkotter 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
