### PR TITLE
#538 - Add setting to toggle the default behaviour of audio generation on a post.

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -62,7 +62,7 @@ class ComputerVision extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'valid'                 => false,
 			'url'                   => '',

--- a/includes/Classifai/Providers/Azure/Personalizer.php
+++ b/includes/Classifai/Providers/Azure/Personalizer.php
@@ -62,7 +62,7 @@ class Personalizer extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'authenticated' => false,
 			'url'           => '',

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -454,7 +454,7 @@ class TextToSpeech extends Provider {
 	/**
 	 * Returns the default settings.
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'credentials'   => array(
 				'url'     => '',
@@ -466,25 +466,6 @@ class TextToSpeech extends Provider {
 			'default'       => true,
 			'post-types'    => array(),
 		];
-	}
-
-	/**
-	 * Helper to get the settings and allow for settings default values.
-	 *
-	 * @param string|bool|mixed $index Optional. Name of the settings option index.
-	 *
-	 * @return string|array|mixed
-	 */
-	public function get_settings( $index = false ) {
-		$defaults = $this->get_default_settings();
-		$settings = get_option( $this->get_option_name(), [] );
-		$settings = wp_parse_args( $settings, $defaults );
-
-		if ( $index && isset( $settings[ $index ] ) ) {
-			return $settings[ $index ];
-		}
-
-		return $settings;
 	}
 
 	/**

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -201,10 +201,10 @@ class TextToSpeech extends Provider {
 			$this->get_option_name(),
 			$this->get_option_name(),
 			[
-				'label_for'      => 'default',
-				'input_type'     => 'checkbox',
-				'default_value'  => $default_settings['default'],
-				'description'    => esc_html__( 'Enables the toggle to generate audio on posts by default.', 'classifai' ),
+				'label_for'     => 'default',
+				'input_type'    => 'checkbox',
+				'default_value' => $default_settings['default'],
+				'description'   => esc_html__( 'Enables the toggle to generate audio on posts by default.', 'classifai' ),
 			]
 		);
 
@@ -513,8 +513,8 @@ class TextToSpeech extends Provider {
 			array(
 				'get_callback'    => function( $object ) use ( $settings ) {
 					$process_content = get_post_meta( $object['id'], self::SYNTHESIZE_SPEECH_KEY, true );
-					if ( empty( $process_content ) || ! in_array( $process_content, [ 'no', 'yes'], true ) ) {
-						$process_content =  ( 'no' === $settings['default'] ) ? 'no' : 'yes';
+					if ( empty( $process_content ) || ! in_array( $process_content, [ 'no', 'yes' ], true ) ) {
+						$process_content = ( 'no' === $settings['default'] ) ? 'no' : 'yes';
 					}
 					return $process_content;
 				},
@@ -575,9 +575,9 @@ class TextToSpeech extends Provider {
 		wp_nonce_field( 'classifai_text_to_speech_meta_action', 'classifai_text_to_speech_meta' );
 
 		$process_content = get_post_meta( $post->ID, self::SYNTHESIZE_SPEECH_KEY, true );
-		if ( empty( $process_content ) || ! in_array( $process_content, [ 'no', 'yes'], true ) ) {
+		if ( empty( $process_content ) || ! in_array( $process_content, [ 'no', 'yes' ], true ) ) {
 			$default         = $this->get_settings( 'default' );
-			$process_content =  ( 'no' === $default ) ? 'no' : 'yes';
+			$process_content = ( 'no' === $default ) ? 'no' : 'yes';
 		}
 
 		$post_type       = get_post_type_object( get_post_type( $post ) );

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -204,7 +204,7 @@ class TextToSpeech extends Provider {
 				'label_for'     => 'default',
 				'input_type'    => 'checkbox',
 				'default_value' => $default_settings['default'],
-				'description'   => esc_html__( 'Enables the toggle to generate audio on posts by default.', 'classifai' ),
+				'description'   => esc_html__( 'Determines if audio generation is on by default for individual items.', 'classifai' ),
 			]
 		);
 

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -398,7 +398,10 @@ class ChatGPT extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
+		if ( ! function_exists( 'get_editable_roles' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/user.php' );
+		}
 		$editable_roles = get_editable_roles() ?? [];
 
 		return [

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -374,7 +374,7 @@ class DallE extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'authenticated'    => false,
 			'api_key'          => '',

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -282,7 +282,7 @@ class Embeddings extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'authenticated'         => false,
 			'api_key'               => '',

--- a/includes/Classifai/Providers/OpenAI/Whisper.php
+++ b/includes/Classifai/Providers/OpenAI/Whisper.php
@@ -300,7 +300,7 @@ class Whisper extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'authenticated'      => false,
 			'api_key'            => '',

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -153,7 +153,7 @@ abstract class Provider {
 	 * @return string|array|mixed
 	 */
 	public function get_settings( $index = false ) {
-		$defaults = [];
+		$defaults = $this->get_default_settings();
 		$settings = get_option( $this->get_option_name(), [] );
 		$settings = wp_parse_args( $settings, $defaults );
 
@@ -162,6 +162,13 @@ abstract class Provider {
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Returns the default settings.
+	 */
+	public function get_default_settings() {
+		return [];
 	}
 
 	/**

--- a/tests/Classifai/Providers/Azure/ComputerVisionTest.php
+++ b/tests/Classifai/Providers/Azure/ComputerVisionTest.php
@@ -81,14 +81,30 @@ class ComputerVisionTest extends WP_UnitTestCase {
 
 
 	/**
-	 * Ensure that settings returns empty array of the `classifai_computer_vision` is not set.
+	 * Ensure that settings returns default settings array if the `classifai_computer_vision` is not set.
 	 */
 	public function test_no_computer_vision_option_set() {
 		delete_option( 'classifai_computer_vision' );
 
 		$settings = $this->get_computer_vision()->get_settings();
 
-		$this->assertSame( $settings, array() );
+		$this->assertSame( $settings, [
+			'valid'                 => false,
+			'url'                   => '',
+			'api_key'               => '',
+			'enable_image_captions' => array(
+				'alt'         => 0,
+				'caption'     => 0,
+				'description' => 0,
+			),
+			'enable_image_tagging'  => true,
+			'enable_smart_cropping' => false,
+			'enable_ocr'            => false,
+			'enable_read_pdf'       => false,
+			'caption_threshold'     => 75,
+			'tag_threshold'         => 70,
+			'image_tag_taxonomy'    => 'classifai-image-tags',
+		] );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Provides an extra setting for TTS to change the default behaviour of the the toggle to generate audio on posts.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #538

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Go to Tools -> ClassifAI -> Language Processing -> Microsoft Azure
2. A new setting "Enabled by default" should be present and should be checked by default.
    1. Review that the "Enable audio generation" sidebar Gutenberg setting on new post or posts that do not have audio generated is enabled.
    2. Review to make sure this update to the code does not change the way new posts behave in terms of audio generation and adheres to how it was before the code change.
3. Now uncheck the setting from point#2 
    1. Review that  the "Enable audio generation" sidebar Gutenberg setting on new post or posts that do not have audio generated is disabled.
    2. Review to make sure this toggle is adhered to and upon update the toggle the audio is generated if it does not exists.
    3. Review to make sure if the audio is available for a post and this toggle is then disabled it does not show up on the frontend.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Setting to toggle the default behaviour of audio generation on a post.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @joshuaabenazer 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
