### PR TITLE
Update to the most recent version of the IBM Watson NLU API

### DIFF
--- a/config.php
+++ b/config.php
@@ -16,8 +16,9 @@ classifai_define( 'CLASSIFAI_PLUGIN_VERSION', $plugin_version );
 classifai_define( 'CLASSIFAI_PLUGIN_DIR', __DIR__ );
 classifai_define( 'CLASSIFAI_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
-// API
-classifai_define( 'WATSON_NLU_VERSION', '2018-03-19' );
+// API - https://cloud.ibm.com/docs/natural-language-understanding?topic=natural-language-understanding-release-notes#active-version-dates
+classifai_define( 'WATSON_NLU_VERSION', '2022-08-10' );
+
 // Taxonomies
 classifai_define( 'WATSON_CATEGORY_TAXONOMY', 'watson-category' );
 classifai_define( 'WATSON_KEYWORD_TAXONOMY', 'watson-keyword' );

--- a/includes/Classifai/Watson/Classifier.php
+++ b/includes/Classifai/Watson/Classifier.php
@@ -44,7 +44,7 @@ class Classifier {
 	/**
 	 * Classifies the text specified using IBM Watson NLU API.
 	 *
-	 * https://www.ibm.com/watson/developercloud/natural-language-understanding/api/v1/#post-analyze
+	 * https://cloud.ibm.com/apidocs/natural-language-understanding#analyze
 	 *
 	 * @param string $text The plain text to classify
 	 * @param array  $options NLU classification options


### PR DESCRIPTION
### Description of the Change

We've been running the `2018-03-19` version of the IBM Watson NLU API for a number of years. According to their [documentation](https://cloud.ibm.com/docs/natural-language-understanding?topic=natural-language-understanding-release-notes#active-version-dates), the latest version is `2022-08-10`.

Ideally we should be running the latest versions of the various APIs we integrate with (where possible) so this PR updates the API version we make requests to. As far as I can tell in my testing, things still work as expected, no breaking changes were found. The actual results returned are different but that is expected with running a newer API version.

### How to test the Change

1. Ensure you have IBM Watson setup and configured properly
2. Ensure classification works with all four features
3. If desired, downgrade the API version back to `2018-03-19` and compare results to see what differences there are

### Changelog Entry

> Changed - Update the IBM Watson NLU API to the `2022-08-10` version.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
