### PR TITLE
Update our excerpt prompt

### DIFF
--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -558,7 +558,7 @@ class ChatGPT extends Provider {
 		 *
 		 * @return {string} Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_chatgpt_excerpt_prompt', sprintf( 'Summarize the following message using a maximum of %d words. Ensure this summary pairs well with the following text: %s.', $excerpt_length, get_the_title( $post_id ) ), $post_id, $excerpt_length );
+		$prompt = apply_filters( 'classifai_chatgpt_excerpt_prompt', sprintf( 'Summarize the following message using a maximum of %d words. Ensure this summary pairs well with the following text: %s.', $excerpt_length, $args['title'] ), $post_id, $excerpt_length );
 
 		/**
 		 * Filter the request body before sending to ChatGPT.

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -532,6 +532,7 @@ class ChatGPT extends Provider {
 			array_filter( $args ),
 			[
 				'content' => '',
+				'title'   => get_the_title( $post_id ),
 			]
 		);
 

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -557,7 +557,7 @@ class ChatGPT extends Provider {
 		 *
 		 * @return {string} Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_chatgpt_excerpt_prompt', 'Provide a teaser for the following text using a maximum of ' . $excerpt_length . ' words', $post_id, $excerpt_length );
+		$prompt = apply_filters( 'classifai_chatgpt_excerpt_prompt', sprintf( 'Summarize the following message using a maximum of %d words. Ensure this summary pairs well with the following text: %s.', $excerpt_length, get_the_title( $post_id ) ), $post_id, $excerpt_length );
 
 		/**
 		 * Filter the request body before sending to ChatGPT.
@@ -576,11 +576,15 @@ class ChatGPT extends Provider {
 				'model'       => $this->chatgpt_model,
 				'messages'    => [
 					[
+						'role'    => 'system',
+						'content' => $prompt,
+					],
+					[
 						'role'    => 'user',
-						'content' => $prompt . ': ' . $this->get_content( $post_id, $excerpt_length, true, $args['content'] ) . '',
+						'content' => $this->get_content( $post_id, $excerpt_length, false, $args['content'] ) . '',
 					],
 				],
-				'temperature' => 0,
+				'temperature' => 0.9,
 			],
 			$post_id
 		);
@@ -731,10 +735,10 @@ class ChatGPT extends Provider {
 		/**
 		 * We then subtract those tokens from the max number of tokens ChatGPT allows
 		 * in a single request, as well as subtracting out the number of tokens in our
-		 * prompt (13). ChatGPT counts both the tokens in the request and in
+		 * prompt (~50). ChatGPT counts both the tokens in the request and in
 		 * the response towards the max.
 		 */
-		$max_content_tokens = $this->max_tokens - $return_tokens - 13;
+		$max_content_tokens = $this->max_tokens - $return_tokens - 50;
 
 		if ( empty( $post_content ) ) {
 			$post         = get_post( $post_id );

--- a/includes/Classifai/Services/LanguageProcessing.php
+++ b/includes/Classifai/Services/LanguageProcessing.php
@@ -89,7 +89,13 @@ class LanguageProcessing extends Service {
 							'type'              => 'string',
 							'sanitize_callback' => 'sanitize_text_field',
 							'validate_callback' => 'rest_validate_request_arg',
-							'description'       => esc_html__( 'Content to generate a title for', 'classifai' ),
+							'description'       => esc_html__( 'Content to summarize into an excerpt.', 'classifai' ),
+						],
+						'title'   => [
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+							'validate_callback' => 'rest_validate_request_arg',
+							'description'       => esc_html__( 'Title of content we want a summary for.', 'classifai' ),
 						],
 					],
 					'permission_callback' => [ $this, 'generate_post_excerpt_permissions_check' ],
@@ -275,6 +281,7 @@ class LanguageProcessing extends Service {
 	public function generate_post_excerpt( WP_REST_Request $request ) {
 		$post_id = $request->get_param( 'id' );
 		$content = $request->get_param( 'content' );
+		$title   = $request->get_param( 'title' );
 
 		// Find the right provider class.
 		$provider = find_provider_class( $this->provider_classes ?? [], 'ChatGPT' );
@@ -284,7 +291,16 @@ class LanguageProcessing extends Service {
 			return $provider;
 		}
 
-		return rest_ensure_response( $provider->rest_endpoint_callback( $post_id, 'excerpt', [ 'content' => $content ] ) );
+		return rest_ensure_response(
+			$provider->rest_endpoint_callback(
+				$post_id,
+				'excerpt',
+				[
+					'content' => $content,
+					'title'   => $title,
+				]
+			)
+		);
 	}
 
 	/**

--- a/src/js/post-excerpt/panel.js
+++ b/src/js/post-excerpt/panel.js
@@ -27,6 +27,7 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	const postId = select( 'core/editor' ).getCurrentPostId();
 	const postContent =
 		select( 'core/editor' ).getEditedPostAttribute( 'content' );
+	const postTitle = select( 'core/editor' ).getEditedPostAttribute( 'title' );
 	const buttonText =
 		'' === excerpt
 			? __( 'Generate excerpt', 'classifai' )
@@ -39,7 +40,7 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 		apiFetch( {
 			path,
 			method: 'POST',
-			data: { id: postId, content: postContent },
+			data: { id: postId, content: postContent, title: postTitle },
 		} ).then(
 			( res ) => {
 				onUpdateExcerpt( res );


### PR DESCRIPTION
### Description of the Change

We recently received some feedback about our excerpt generation feature. While it seems to provide a decent summary of the content, excerpts are often meant to be used alongside the title of the content. For instance, a common design pattern is to display a featured image with the title below and the excerpt below that. In this case, ideally the excerpt pairs well with this title and doesn't just repeat the same thing.

In testing, often the generated excerpts include the title, sometime verbatim, sometimes with a word or two changed. The generated excerpt will contain more than that but often it will start with the same title. In the above mentioned scenario, this isn't ideal as you end up with the same (or close to the same) text shown back to back (first in the title, then in the excerpt).

This PR does a few things to try and help with this:

1. We move our prompt into a `system` message instead of a `user` message. From OpenAI's docs:

> The system message helps set the behavior of the assistant. ... However note that the system message is optional and the model’s behavior without a system message is likely to be similar to using a generic message such as "You are a helpful assistant."

Not sure how much this helps but feels like best practice to set our prompt in the `system` message and the actual content we want summarized into a separate `user` message.

2. We've modified the prompt some and have included a bit in there that asks it to provide a summary that pairs well with the title:
```
Summarize the following message using a maximum of %d words. Ensure this summary pairs well with the following text: %s.
```

Not sure if that last part actually helps or not. Seems like the next change is the one that helped the most.

3. We've removed the title from the content we are summarizing. Previously we took the title and the post content, combined those together, and sent that along to OpenAI to summarize. Now we just send the post content.
4. We allow the title to be passed into our endpoint so we have the most up-to-date title (instead of pulling this from the database)

### How to test the Change

1. Setup the OpenAI ChatGPT functionality, in particular the Generate excerpt functionality
2. Generate an excerpt for a piece of content and ensure text is returned
3. This gets more into opinion territory but use your best judgement to determine if the generated excerpt seems to pair well with the title. Can also run these same tests with the current released plugin to see how the generated excerpts differ

### Changelog Entry

> Changed - Update the prompt we send to OpenAI that is used to generate excerpts to try and ensure the excerpts generated pair well with the title of the content.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
