### PR TITLE
Change the prompt we send for generating titles to use a `system` message

### DIFF
--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -649,7 +649,7 @@ class ChatGPT extends Provider {
 		 *
 		 * @return {string} Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_chatgpt_title_prompt', 'Write an SEO-friendly title for the following content that will encourage readers to clickthrough, staying within a range of 40 to 60 characters', $post_id, $args );
+		$prompt = apply_filters( 'classifai_chatgpt_title_prompt', 'Write an SEO-friendly title for the following content that will encourage readers to clickthrough, staying within a range of 40 to 60 characters.', $post_id, $args );
 
 		/**
 		 * Filter the request body before sending to ChatGPT.
@@ -668,8 +668,12 @@ class ChatGPT extends Provider {
 				'model'       => $this->chatgpt_model,
 				'messages'    => [
 					[
+						'role'    => 'system',
+						'content' => $prompt,
+					],
+					[
 						'role'    => 'user',
-						'content' => esc_html( $prompt ) . ': ' . $this->get_content( $post_id, absint( $args['num'] ) * 15, false, $args['content'] ) . '',
+						'content' => $this->get_content( $post_id, absint( $args['num'] ) * 15, false, $args['content'] ) . '',
 					],
 				],
 				'temperature' => 0.9,


### PR DESCRIPTION
### Description of the Change

Similar to point 1 in #544, this PR updates the request we send to OpenAI to add our prompt as a `system` message instead of a `user` message, and leave the `user` message to just contain the content.

I don't think this should change anything about the titles that are returned but does seem like best practice and provides more flexibility in the future.

### How to test the Change

1. Ensure you have the title generation feature on and configured
2. Try generating some titles and ensure content is returned
3. If desired, try the same test on the latest released version of the plugin to see how titles may differ

### Changelog Entry

> Changed - Update our title generation prompt to use a `system` message.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
