### PR TITLE
Ensure we define the class property before using it

### DIFF
--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -28,6 +28,11 @@ class NLU extends Provider {
 	public $save_post_handler;
 
 	/**
+	 * @var $nlu_features array The list of NLU features
+	 */
+	protected $nlu_features = [];
+
+	/**
 	 * Watson NLU constructor.
 	 *
 	 * @param string $service The service this class belongs to.


### PR DESCRIPTION
### Description of the Change

As reported, in newer versions of PHP (seems like 8.2+) a PHP deprecation is shown because of our NLU class. We have a class property `nlu_features`, that we use but never define. This PR fixes that by ensuring that property is defined.

Closes #547 

### How to test the Change

1. In an environment running PHP 8.2 and with this PR checked out, ensure no deprecation notices are shown
2. Ensure all NLU functionality still works
3. Downgrade to PHP 7.4 and ensure things still work as well

### Changelog Entry

> Fixed - Ensure we define a class property before using it to avoid PHP deprecation notices

### Credits

Props @ankitguptaindia, @dkotter 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
