### PR TITLE
#540 - Audio Generation Cleanup / Optimization / Display

### DIFF
--- a/includes/Classifai/Admin/BulkActions.php
+++ b/includes/Classifai/Admin/BulkActions.php
@@ -9,6 +9,7 @@ use Classifai\Providers\OpenAI\Whisper;
 use Classifai\Providers\OpenAI\Whisper\Transcribe;
 use function Classifai\get_post_types_for_language_settings;
 use function Classifai\get_supported_post_types;
+use function Classifai\get_tts_supported_post_types;
 
 /**
  * Handle bulk actions.
@@ -68,15 +69,14 @@ class BulkActions {
 	 * Register bulk actions for language processing.
 	 */
 	public function register_language_processing_hooks() {
-		$this->chat_gpt       = new ChatGPT( false );
-		$this->embeddings     = new Embeddings( false );
-		$this->text_to_speech = new TextToSpeech( false );
+		$this->chat_gpt   = new ChatGPT( false );
+		$this->embeddings = new Embeddings( false );
 
 		$user_roles                = wp_get_current_user()->roles ?? [];
 		$embedding_settings        = $this->embeddings->get_settings();
 		$embeddings_post_types     = [];
 		$nlu_post_types            = get_supported_post_types();
-		$text_to_speech_post_types = $this->text_to_speech->get_supported_post_types();
+		$text_to_speech_post_types = get_tts_supported_post_types();
 		$chat_gpt_post_types       = [];
 		$chat_gpt_settings         = $this->chat_gpt->get_settings();
 
@@ -102,11 +102,6 @@ class BulkActions {
 			$embeddings_post_types = $this->embeddings->supported_post_types();
 		} else {
 			$this->embeddings = null;
-		}
-
-		// Clear our TextToSpeech handler if no post types are set up.
-		if ( empty( $text_to_speech_post_types ) ) {
-			$this->text_to_speech = null;
 		}
 
 		// Merge our post types together and make them unique.

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -279,7 +279,7 @@ function get_supported_post_types() {
 /**
  * The list of post types that TTS supports.
  *
- * return array Supported Post Types.
+ * @return array Supported Post Types.
  */
 function get_tts_supported_post_types() {
 	$classifai_settings = get_plugin_settings( 'language_processing', Azure\TextToSpeech::FEATURE_NAME );

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -279,7 +279,7 @@ function get_supported_post_types() {
 /**
  * The list of post types that TTS supports.
  *
- * return {array} Supported Post Types.
+ * return array Supported Post Types.
  */
 function get_tts_supported_post_types() {
 	$classifai_settings = get_plugin_settings( 'language_processing', Azure\TextToSpeech::FEATURE_NAME );

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -3,6 +3,7 @@
 namespace Classifai;
 
 use Classifai\Providers\Provider;
+use Classifai\Providers\Azure;
 use Classifai\Services\Service;
 use Classifai\Services\ServicesManager;
 use WP_Error;
@@ -271,6 +272,28 @@ function get_supported_post_types() {
 	 * @return {array} Array of post types.
 	 */
 	$post_types = apply_filters( 'classifai_post_types', $post_types );
+
+	return $post_types;
+}
+
+/**
+ * The list of post types that TTS supports.
+ *
+ * return {array} Supported Post Types.
+ */
+function get_tts_supported_post_types() {
+	$classifai_settings = get_plugin_settings( 'language_processing', Azure\TextToSpeech::FEATURE_NAME );
+
+	if ( empty( $classifai_settings ) ) {
+		$post_types = [];
+	} else {
+		$post_types = [];
+		foreach ( $classifai_settings['post_types'] as $post_type => $enabled ) {
+			if ( ! empty( $enabled ) ) {
+				$post_types[] = $post_type;
+			}
+		}
+	}
 
 	return $post_types;
 }

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -62,7 +62,7 @@ class ComputerVision extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'valid'                 => false,
 			'url'                   => '',

--- a/includes/Classifai/Providers/Azure/Personalizer.php
+++ b/includes/Classifai/Providers/Azure/Personalizer.php
@@ -62,7 +62,7 @@ class Personalizer extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'authenticated' => false,
 			'url'           => '',

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -239,7 +239,7 @@ class TextToSpeech extends Provider {
 				if ( ! empty( $current_settings['voices'] ) ) {
 					$current_settings['authenticated'] = true;
 				} else {
-					$current_settings['voices'] = [];
+					$current_settings['voices']        = [];
 					$current_settings['authenticated'] = false;
 				}
 			}
@@ -268,8 +268,6 @@ class TextToSpeech extends Provider {
 
 		if ( isset( $settings['voice'] ) && ! empty( $settings['voice'] ) ) {
 			$current_settings['voice'] = sanitize_text_field( $settings['voice'] );
-		} else {
-			$current_settings['voice'] = '';
 		}
 
 		return $current_settings;
@@ -452,6 +450,17 @@ class TextToSpeech extends Provider {
 	 * @return {bool}                     The initial state of audio generation. Default true.
 	 */
 	public function get_audio_generation_initial_state( $post = null ) {
+		/**
+		 * Initial state of the audio generation toggle when no audio already exists for the post.
+		 *
+		 * @since 2.3.0
+		 * @hook classifai_audio_generation_initial_state
+		 *
+		 * @param  {bool}    $state Initial state of audio generation toggle on a post. Default true.
+		 * @param  {WP_Post} $post  The current Post object.
+		 *
+		 * @return {bool}           Initial state the audio generation toggle should be set to when no audio exists.
+		 */
 		return apply_filters( 'classifai_audio_generation_initial_state', true, get_post( $post ) );
 	}
 
@@ -466,6 +475,17 @@ class TextToSpeech extends Provider {
 	 * @return {bool}                    The subsequenet state of audio generation. Default false.
 	 */
 	public function get_audio_generation_subsequent_state( $post = null ) {
+		/**
+		 * Subsequent state of the audio generation toggle when audio exists for the post.
+		 *
+		 * @since 2.3.0
+		 * @hook classifai_audio_generation_subsequent_state
+		 *
+		 * @param  {bool}    $state Subsequent state of audio generation toggle on a post. Default false.
+		 * @param  {WP_Post} $post  The current Post object.
+		 *
+		 * @return {bool}           Subsequent state the audio generation toggle should be set to when audio exists.
+		 */
 		return apply_filters( 'classifai_audio_generation_subsequent_state', false, get_post( $post ) );
 	}
 

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -188,7 +188,7 @@ class TextToSpeech extends Provider {
 				'label_for'      => 'post_types',
 				'option_index'   => 'post_types',
 				'options'        => $this->get_post_types_select_options(),
-				'default_values' => $default_settings['post-types'],
+				'default_values' => $default_settings['post_types'],
 			]
 		);
 
@@ -238,6 +238,9 @@ class TextToSpeech extends Provider {
 
 				if ( ! empty( $current_settings['voices'] ) ) {
 					$current_settings['authenticated'] = true;
+				} else {
+					$current_settings['voices'] = [];
+					$current_settings['authenticated'] = false;
 				}
 			}
 		} else {
@@ -434,7 +437,7 @@ class TextToSpeech extends Provider {
 			'voices'        => array(),
 			'voice'         => '',
 			'authenticated' => false,
-			'post-types'    => array(),
+			'post_types'    => array(),
 		];
 	}
 

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -444,10 +444,10 @@ class TextToSpeech extends Provider {
 	 *
 	 * Fetch the initial state of audio generation prior to the audio existing for the post.
 	 *
-	 * @param  {int|WP_Post|null} $post   Optional. Post ID or post object. `null`, `false`, `0` and other PHP falsey values
+	 * @param  int|WP_Post|null $post   Optional. Post ID or post object. `null`, `false`, `0` and other PHP falsey values
 	 *                                    return the current global post inside the loop. A numerically valid post ID that
 	 *                                    points to a non-existent post returns `null`. Defaults to global $post.
-	 * @return {bool}                     The initial state of audio generation. Default true.
+	 * @return bool                     The initial state of audio generation. Default true.
 	 */
 	public function get_audio_generation_initial_state( $post = null ) {
 		/**
@@ -469,10 +469,10 @@ class TextToSpeech extends Provider {
 	 *
 	 * Fetch the subsequent state of audio generation once audio is generated for the post.
 	 *
-	 * @param {int|WP_Post|null} $post   Optional. Post ID or post object. `null`, `false`, `0` and other PHP falsey values
+	 * @param int|WP_Post|null $post   Optional. Post ID or post object. `null`, `false`, `0` and other PHP falsey values
 	 *                                   return the current global post inside the loop. A numerically valid post ID that
 	 *                                   points to a non-existent post returns `null`. Defaults to global $post.
-	 * @return {bool}                    The subsequenet state of audio generation. Default false.
+	 * @return bool                    The subsequent state of audio generation. Default false.
 	 */
 	public function get_audio_generation_subsequent_state( $post = null ) {
 		/**

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -11,6 +11,7 @@ use stdClass;
 use WP_Http;
 
 use function Classifai\get_post_types_for_language_settings;
+use function Classifai\get_tts_supported_post_types;
 use function Classifai\get_asset_info;
 
 class TextToSpeech extends Provider {
@@ -30,12 +31,11 @@ class TextToSpeech extends Provider {
 	const API_PATH = 'cognitiveservices/v1';
 
 	/**
-	 * Meta key to store data indicating whether Text to Speech is enabled for
-	 * the current post.
+	 * Meta key to hide/unhide already generated audio file.
 	 *
 	 * @var string
 	 */
-	const SYNTHESIZE_SPEECH_KEY = '_classifai_synthesize_speech';
+	const DISPLAY_GENERATED_AUDIO = '_classifai_display_generated_audio';
 
 	/**
 	 * Meta key to get/set the ID of the speech audio file.
@@ -87,21 +87,13 @@ class TextToSpeech extends Provider {
 	 * Enqueue the editor scripts.
 	 */
 	public function enqueue_editor_assets() {
-		global $post;
-
-		wp_enqueue_script(
-			'classifai-editor', // Handle.
-			CLASSIFAI_PLUGIN_URL . 'dist/editor.js',
-			array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor', 'wp-edit-post' ),
-			CLASSIFAI_PLUGIN_VERSION,
-			true
-		);
+		$post = get_post();
 
 		if ( empty( $post ) ) {
 			return;
 		}
 
-		$supported_post_types = self::get_supported_post_types();
+		$supported_post_types = get_tts_supported_post_types();
 
 		if ( ! in_array( $post->post_type, $supported_post_types, true ) ) {
 			return;
@@ -115,13 +107,13 @@ class TextToSpeech extends Provider {
 			true
 		);
 
-		wp_localize_script(
+		wp_add_inline_script(
 			'classifai-gutenberg-plugin',
-			'classifaiTextToSpeechData',
-			[
-				'supportedPostTypes' => self::get_supported_post_types(),
-				'noPermissions'      => ! is_user_logged_in() || ! current_user_can( 'edit_post', $post->ID ),
-			]
+			sprintf(
+				'var classifaiTTSEnabled = %d;',
+				true
+			),
+			'before'
 		);
 	}
 
@@ -133,6 +125,12 @@ class TextToSpeech extends Provider {
 		add_action( 'rest_api_init', [ $this, 'add_synthesize_speech_meta_to_rest_api' ] );
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_box' ] );
 		add_action( 'save_post', [ $this, 'save_post_metadata' ], 5 );
+
+		$supported_post_type = get_tts_supported_post_types();
+		foreach ( get_tts_supported_post_types() as $post_type ) {
+			add_action( 'rest_insert_' . $post_type, [ $this, 'rest_handle_audio' ], 10, 2 );
+		}
+
 		add_filter( 'the_content', [ $this, 'render_post_audio_controls' ] );
 	}
 
@@ -427,7 +425,7 @@ class TextToSpeech extends Provider {
 	/**
 	 * Returns the default settings.
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'credentials'   => array(
 				'url'     => '',
@@ -441,39 +439,81 @@ class TextToSpeech extends Provider {
 	}
 
 	/**
-	 * Add `classifai_synthesize_speech` to rest API for view/edit.
+	 * Initial audio generation state.
+	 *
+	 * Fetch the initial state of audio generation prior to the audio existing for the post.
+	 *
+	 * @param  {int|WP_Post|null} $post   Optional. Post ID or post object. `null`, `false`, `0` and other PHP falsey values
+	 *                                    return the current global post inside the loop. A numerically valid post ID that
+	 *                                    points to a non-existent post returns `null`. Defaults to global $post.
+	 * @return {bool}                     The initial state of audio generation. Default true.
+	 */
+	public function get_audio_generation_initial_state( $post = null ) {
+		return apply_filters( 'classifai_audio_generation_initial_state', true, get_post( $post ) );
+	}
+
+	/**
+	 * Subsequent audio generation state.
+	 *
+	 * Fetch the subsequent state of audio generation once audio is generated for the post.
+	 *
+	 * @param {int|WP_Post|null} $post   Optional. Post ID or post object. `null`, `false`, `0` and other PHP falsey values
+	 *                                   return the current global post inside the loop. A numerically valid post ID that
+	 *                                   points to a non-existent post returns `null`. Defaults to global $post.
+	 * @return {bool}                    The subsequenet state of audio generation. Default false.
+	 */
+	public function get_audio_generation_subsequent_state( $post = null ) {
+		return apply_filters( 'classifai_audio_generation_subsequent_state', false, get_post( $post ) );
+	}
+
+	/**
+	 * Add audio related fields to rest API for view/edit.
 	 */
 	public function add_synthesize_speech_meta_to_rest_api() {
-		$settings             = $this->get_settings();
-		$supported_post_types = $settings['post_types'] ?? array();
-
-		$supported_post_types = array_keys(
-			array_filter(
-				$supported_post_types,
-				function( $post_type ) {
-					return ! is_null( $post_type );
-				}
-			)
-		);
-
-		if ( empty( $supported_post_types ) ) {
-			return;
-		}
+		$supported_post_types = get_tts_supported_post_types();
 
 		register_rest_field(
 			$supported_post_types,
 			'classifai_synthesize_speech',
 			array(
-				'get_callback'    => function( $object ) {
-					$process_content = get_post_meta( $object['id'], self::SYNTHESIZE_SPEECH_KEY, true );
-					return ( 'no' === $process_content ) ? 'no' : 'yes';
+				'get_callback' => function( $object ) {
+					$audio_id = get_post_meta( $object['id'], self::AUDIO_ID_KEY, true );
+					if (
+						( $this->get_audio_generation_initial_state( $object['id'] ) && ! $audio_id ) ||
+						( $this->get_audio_generation_subsequent_state( $object['id'] ) && $audio_id )
+					) {
+						return true;
+					} else {
+						return false;
+					}
 				},
-				'update_callback' => function ( $value, $object ) {
-					$value = ( 'no' === $value ) ? 'no' : 'yes';
-					return update_post_meta( $object->ID, self::SYNTHESIZE_SPEECH_KEY, $value );
+				'schema'       => [
+					'type'    => 'boolean',
+					'context' => [ 'view', 'edit' ],
+				],
+			)
+		);
+
+		register_rest_field(
+			$supported_post_types,
+			'classifai_display_generated_audio',
+			array(
+				'get_callback'    => function( $object ) {
+					// Default to display the audio if available.
+					if ( metadata_exists( 'post', $object['id'], self::DISPLAY_GENERATED_AUDIO ) ) {
+						return (bool) get_post_meta( $object['id'], self::DISPLAY_GENERATED_AUDIO, true );
+					}
+					return true;
+				},
+				'update_callback' => function( $value, $object ) {
+					if ( $value ) {
+						delete_post_meta( $object->ID, self::DISPLAY_GENERATED_AUDIO );
+					} else {
+						update_post_meta( $object->ID, self::DISPLAY_GENERATED_AUDIO, false );
+					}
 				},
 				'schema'          => [
-					'type'    => 'string',
+					'type'    => 'boolean',
 					'context' => [ 'view', 'edit' ],
 				],
 			)
@@ -496,12 +536,41 @@ class TextToSpeech extends Provider {
 	}
 
 	/**
+	 * Handles audio generation on rest updates / inserts.
+	 *
+	 * @param WP_Post         $post     Inserted or updated post object.
+	 * @param WP_REST_Request $request  Request object.
+	 */
+	public function rest_handle_audio( $post, $request ) {
+
+		$audio_id = get_post_meta( $request->get_param( 'id' ), self::AUDIO_ID_KEY, true );
+
+		// Since we have dynamic generation option agnostic to meta saves we need a flag to differentiate audio generation accurately
+		$process_content = false;
+		if (
+			( $this->get_audio_generation_initial_state( $post ) && ! $audio_id ) ||
+			( $this->get_audio_generation_subsequent_state( $post ) && $audio_id )
+		) {
+			$process_content = true;
+		}
+
+		// Add/Update audio if it was requested.
+		if (
+			( $process_content && null === $request->get_param( 'classifai_synthesize_speech' ) ) ||
+			true === $request->get_param( 'classifai_synthesize_speech' )
+		) {
+			$save_post_handler = new SavePostHandler();
+			$save_post_handler->synthesize_speech( $request->get_param( 'id' ) );
+		}
+	}
+
+	/**
 	 * Add meta box to post types that support speech synthesis.
 	 *
 	 * @param string $post_type Post type.
 	 */
 	public function add_meta_box( $post_type ) {
-		if ( ! in_array( $post_type, $this->get_supported_post_types(), true ) ) {
+		if ( ! in_array( $post_type, get_tts_supported_post_types(), true ) ) {
 			return;
 		}
 
@@ -511,7 +580,7 @@ class TextToSpeech extends Provider {
 			[ $this, 'render_meta_box' ],
 			null,
 			'side',
-			'low',
+			'high',
 			array( '__back_compat_meta_box' => true )
 		);
 	}
@@ -524,38 +593,65 @@ class TextToSpeech extends Provider {
 	public function render_meta_box( $post ) {
 		wp_nonce_field( 'classifai_text_to_speech_meta_action', 'classifai_text_to_speech_meta' );
 
-		$process_content = get_post_meta( $post->ID, self::SYNTHESIZE_SPEECH_KEY, true );
-		$process_content = ( 'no' === $process_content ) ? 'no' : 'yes';
+		$source_url = false;
+		$audio_id   = get_post_meta( $post->ID, self::AUDIO_ID_KEY, true );
+		if ( $audio_id ) {
+			$source_url = wp_get_attachment_url( $audio_id );
+		}
 
-		$post_type       = get_post_type_object( get_post_type( $post ) );
+		$process_content = false;
+		if (
+			( $this->get_audio_generation_initial_state( $post ) && ! $audio_id ) ||
+			( $this->get_audio_generation_subsequent_state( $post ) && $audio_id )
+		) {
+			$process_content = true;
+		}
+
+		$display_audio = true;
+		if ( metadata_exists( 'post', $post->ID, self::DISPLAY_GENERATED_AUDIO ) &&
+			! (bool) get_post_meta( $post->ID, self::DISPLAY_GENERATED_AUDIO, true ) ) {
+			$display_audio = false;
+		}
+
 		$post_type_label = esc_html__( 'Post', 'classifai' );
+		$post_type       = get_post_type_object( get_post_type( $post ) );
 		if ( $post_type ) {
 			$post_type_label = $post_type->labels->singular_name;
 		}
 
-		$audio_id = get_post_meta( $post->ID, self::AUDIO_ID_KEY, true );
 		?>
-
 		<p>
 			<label for="classifai_synthesize_speech">
-				<input type="checkbox" value="yes" id="classifai_synthesize_speech" name="classifai_synthesize_speech" <?php checked( $process_content, 'yes' ); ?> />
+				<input type="checkbox" value="1" id="classifai_synthesize_speech" name="classifai_synthesize_speech" <?php checked( $process_content ); ?> />
 				<?php esc_html_e( 'Enable audio generation', 'classifai' ); ?>
 			</label>
 			<span class="description">
 				<?php
 				/* translators: %s Post type label */
-				printf( esc_html__( 'ClassifAI will generate audio for this %s when it is published or updated', 'classifai' ), esc_html( $post_type_label ) );
+				printf( esc_html__( 'ClassifAI will generate audio for this %s when it is published or updated.', 'classifai' ), esc_html( $post_type_label ) );
+				?>
+			</span>
+		</p>
+
+		<p<?php echo $source_url ? '' : ' class="hidden"'; ?>>
+			<label for="classifai_display_generated_audio">
+				<input type="checkbox" value="1" id="classifai_display_generated_audio" name="classifai_display_generated_audio" <?php checked( $display_audio ); ?> />
+				<?php esc_html_e( 'Display audio controls', 'classifai' ); ?>
+			</label>
+			<span class="description">
+				<?php
+				esc_html__( 'Controls the display of the audio player on the front-end.', 'classifai' );
 				?>
 			</span>
 		</p>
 
 		<?php
-		if ( 'yes' === $process_content && $audio_id && wp_get_attachment_url( $audio_id ) ) {
+		if ( $source_url ) {
 			$cache_busting_url = add_query_arg(
 				[
 					'ver' => time(),
 				],
-				wp_get_attachment_url( $audio_id )
+				$source_url
 			);
 			?>
 
@@ -574,6 +670,11 @@ class TextToSpeech extends Provider {
 	 * @param int $post_id Post ID.
 	 */
 	public function save_post_metadata( $post_id ) {
+
+		if ( ! in_array( get_post_type( $post_id ), get_tts_supported_post_types(), true ) ) {
+			return;
+		}
+
 		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! current_user_can( 'edit_post', $post_id ) || 'revision' === get_post_type( $post_id ) ) {
 			return;
 		}
@@ -582,18 +683,15 @@ class TextToSpeech extends Provider {
 			return;
 		}
 
-		$supported_post_types = $this->get_supported_post_types();
-		if ( ! in_array( get_post_type( $post_id ), $supported_post_types, true ) ) {
-			return;
+		if ( ! isset( $_POST['classifai_display_generated_audio'] ) ) {
+			update_post_meta( $post_id, self::DISPLAY_GENERATED_AUDIO, false );
+		} else {
+			delete_post_meta( $post_id, self::DISPLAY_GENERATED_AUDIO );
 		}
 
-		if ( isset( $_POST['classifai_synthesize_speech'] ) && 'yes' === sanitize_text_field( wp_unslash( $_POST['classifai_synthesize_speech'] ) ) ) {
-			update_post_meta( $post_id, self::SYNTHESIZE_SPEECH_KEY, 'yes' );
-
+		if ( isset( $_POST['classifai_synthesize_speech'] ) ) {
 			$save_post_handler = new SavePostHandler();
 			$save_post_handler->synthesize_speech( $post_id );
-		} else {
-			update_post_meta( $post_id, self::SYNTHESIZE_SPEECH_KEY, 'no' );
 		}
 	}
 
@@ -611,7 +709,7 @@ class TextToSpeech extends Provider {
 			return $content;
 		}
 
-		if ( ! in_array( $_post->post_type, self::get_supported_post_types(), true ) ) {
+		if ( ! in_array( $_post->post_type, get_tts_supported_post_types(), true ) ) {
 			return $content;
 		}
 
@@ -630,8 +728,9 @@ class TextToSpeech extends Provider {
 			return $content;
 		}
 
-		$is_audio_enabled = get_post_meta( $_post->ID, self::SYNTHESIZE_SPEECH_KEY, true );
-		if ( 'no' === $is_audio_enabled ) {
+		// Respect the audio display settings of the post.
+		if ( metadata_exists( 'post', $_post->ID, self::DISPLAY_GENERATED_AUDIO ) &&
+			! (bool) get_post_meta( $_post->ID, self::DISPLAY_GENERATED_AUDIO, true ) ) {
 			return $content;
 		}
 
@@ -750,26 +849,6 @@ class TextToSpeech extends Provider {
 		}
 
 		return $options;
-	}
-
-	/**
-	 * Returns supported post types for Azure Text to Speech.
-	 *
-	 * @todo Move this to a more generic method during refactoring of the plugin.
-	 * @return array
-	 */
-	public static function get_supported_post_types() {
-		$settings             = \Classifai\get_plugin_settings( 'language_processing', self::FEATURE_NAME );
-		$supported_post_types = isset( $settings['post_types'] ) ? $settings['post_types'] : array();
-
-		return array_keys(
-			array_filter(
-				$supported_post_types,
-				function( $post_type ) {
-					return '0' !== $post_type;
-				}
-			)
-		);
 	}
 
 }

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -442,7 +442,10 @@ class ChatGPT extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
+		if ( ! function_exists( 'get_editable_roles' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/user.php';
+		}
 		$editable_roles = get_editable_roles() ?? [];
 
 		return [

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -387,7 +387,7 @@ class DallE extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'authenticated'    => false,
 			'api_key'          => '',

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -282,7 +282,7 @@ class Embeddings extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'authenticated'         => false,
 			'api_key'               => '',

--- a/includes/Classifai/Providers/OpenAI/Whisper.php
+++ b/includes/Classifai/Providers/OpenAI/Whisper.php
@@ -300,7 +300,7 @@ class Whisper extends Provider {
 	 *
 	 * @return array
 	 */
-	private function get_default_settings() {
+	public function get_default_settings() {
 		return [
 			'authenticated'      => false,
 			'api_key'            => '',

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -153,7 +153,7 @@ abstract class Provider {
 	 * @return string|array|mixed
 	 */
 	public function get_settings( $index = false ) {
-		$defaults = [];
+		$defaults = $this->get_default_settings();
 		$settings = get_option( $this->get_option_name(), [] );
 		$settings = wp_parse_args( $settings, $defaults );
 
@@ -162,6 +162,13 @@ abstract class Provider {
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Returns the default settings.
+	 */
+	public function get_default_settings() {
+		return [];
 	}
 
 	/**

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -166,6 +166,8 @@ abstract class Provider {
 
 	/**
 	 * Returns the default settings.
+	 *
+	 * @return array
 	 */
 	public function get_default_settings() {
 		return [];

--- a/includes/Classifai/Services/LanguageProcessing.php
+++ b/includes/Classifai/Services/LanguageProcessing.php
@@ -6,7 +6,6 @@
 namespace Classifai\Services;
 
 use Classifai\Admin\SavePostHandler;
-use Classifai\Providers\Azure\TextToSpeech;
 use function Classifai\find_provider_class;
 use WP_REST_Server;
 use WP_REST_Request;
@@ -390,7 +389,7 @@ class LanguageProcessing extends Service {
 
 		if ( ! empty( $post_id ) && current_user_can( 'edit_post', $post_id ) ) {
 			$post_type = get_post_type( $post_id );
-			$supported = TextToSpeech::get_supported_post_types();
+			$supported = \Classifai\get_tts_supported_post_types();
 
 			// Check if processing allowed.
 			if ( ! in_array( $post_type, $supported, true ) ) {

--- a/src/js/gutenberg-plugin.js
+++ b/src/js/gutenberg-plugin.js
@@ -12,10 +12,9 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { useState, useEffect, useRef } from '@wordpress/element';
-import { store as noticesStore } from '@wordpress/notices';
 import { store as postAudioStore } from './store/register';
 
-const { classifaiEmbeddingData, classifaiPostData } = window;
+const { classifaiEmbeddingData, classifaiPostData, classifaiTTSEnabled } = window;
 
 /**
  * Create the ClassifAI icon
@@ -191,107 +190,40 @@ const ClassifAIGenerateTagsButton = () => {
 	);
 };
 
-let errorCode = '';
-
-/**
- * Calls the server-side method that synthesizes speech for a post.
- *
- * @param {number} postId The Post ID
- * @return {boolean} Returns true on success.
- */
-const synthesizeSpeech = async ( postId ) => {
-	const { select, dispatch } = wp.data;
-
-	// Endpoint URL.
-	const synthesizeSpeechUrl = `${ wpApiSettings.root }classifai/v1/synthesize-speech/${ postId }`;
-
-	// Stores status of the synthensis process.
-	const isProcessing = select( postAudioStore ).getIsProcessing();
-
-	// Return early if already processing.
-	if ( isProcessing ) {
-		return;
-	}
-
-	// Set state indicating the synthesis process has begun.
-	dispatch( postAudioStore ).setIsProcessing( true );
-
-	const response = await fetch( synthesizeSpeechUrl, {
-		headers: new Headers( {
-			'X-WP-Nonce': wpApiSettings.nonce,
-		} ),
-	} );
-
-	// Return false if error.
-	if ( 200 !== response.status ) {
-		// Set state indicating the synthesis process has ended.
-		dispatch( postAudioStore ).setIsProcessing( false );
-		return false;
-	}
-
-	const result = await response.json();
-
-	if ( result.success ) {
-		// Set audio ID state after successful synthesis.
-		dispatch( postAudioStore ).setAudioId( result.audio_id );
-
-		// Set state indicating the synthesis process has ended.
-		dispatch( postAudioStore ).setIsProcessing( false );
-
-		if ( errorCode ) {
-			dispatch( noticesStore ).removeNotice( errorCode );
-			errorCode = '';
-		}
-
-		return true;
-	}
-	errorCode = result.code;
-	dispatch( 'core/notices' ).createErrorNotice( result.message, {
-		id: errorCode,
-	} );
-	dispatch( postAudioStore ).setIsProcessing( false );
-};
-
 /**
  * ClassifAI Text to Audio component.
  *
  * @param {Object} props Props object.
  */
-const ClassifAITSpeechSynthesisToggle = ( props ) => {
+const ClassifAITTS = () => {
 	// State of the audio being previewed in PluginDocumentSettingPanel.
 	const [ isPreviewing, setIsPreviewing ] = useState( false );
 
 	const [ timestamp, setTimestamp ] = useState( new Date().getTime() );
 
-	// Indicates whether speech synthesis is supported for the current post.
-	let isFeatureSupported = false;
-
 	// Indicates whether speech synthesis is enabled for the current post.
-	const isSynthesizeSpeech =
-		'yes' ===
-		useSelect( ( select ) =>
-			select( 'core/editor' ).getEditedPostAttribute(
-				'classifai_synthesize_speech'
-			)
-		);
+	const isSynthesizeSpeech = useSelect( ( select ) =>
+		select( 'core/editor' ).getEditedPostAttribute(
+			'classifai_synthesize_speech'
+		)
+	);
 
-	// Post type of the current post.
-	const postType = useSelect( ( select ) =>
-		select( 'core/editor' ).getCurrentPostType()
+	// Indicates whether generated audio should be displayed on the frontend.
+	const displayGeneratedAudio = useSelect( ( select ) =>
+		select( 'core/editor' ).getEditedPostAttribute(
+			'classifai_display_generated_audio'
+		)
+	);
+
+	// Post type label.
+	const postTypeLabel = useSelect( ( select ) =>
+		select( 'core/editor' ).getPostTypeLabel() || __( 'Post', 'classifai' )
 	);
 
 	// Says whether speech synthesis is in progress.
 	const isProcessingAudio = useSelect( ( select ) =>
 		select( postAudioStore ).getIsProcessing()
 	);
-
-	// Figure out if speech synthesis is supported by the current post.
-	if (
-		'undefined' !== typeof classifaiTextToSpeechData &&
-		classifaiTextToSpeechData.supportedPostTypes.includes( postType )
-	) {
-		isFeatureSupported = true;
-	}
 
 	// The audio ID saved in the DB for the current post.
 	const defaultAudioId = useSelect( ( select ) =>
@@ -301,7 +233,9 @@ const ClassifAITSpeechSynthesisToggle = ( props ) => {
 	);
 
 	// New audio ID in case it is regenerated manually or through publishing/updating the current post.
-	const audioId = props.audioId || defaultAudioId;
+	const audioId =
+		useSelect( ( select ) => select( postAudioStore ).getAudioId() ) ||
+		defaultAudioId;
 
 	// Get the attachment data by audio ID.
 	const attachments = useSelect( ( select ) =>
@@ -315,6 +249,17 @@ const ClassifAITSpeechSynthesisToggle = ( props ) => {
 		attachments && attachments.length > 0 && attachments[ 0 ].source_url;
 
 	const isProcessingAudioProgress = useRef( false );
+	const isPostSavingInProgress = useRef( false );
+	const { isSavingPost } = useSelect( ( select ) => {
+		return {
+			isSavingPost: select( 'core/editor' ).isSavingPost(),
+		}
+	} );
+	const { isAutosavingPost } = useSelect( ( select ) => {
+		return {
+			isSavingPost: select( 'core/editor' ).isAutosavingPost(),
+		}
+	} );
 
 	// Handles playing/pausing post audio during preview.
 	useEffect( () => {
@@ -342,6 +287,22 @@ const ClassifAITSpeechSynthesisToggle = ( props ) => {
 		}
 	}, [ isProcessingAudio ] );
 
+	useEffect( () => {
+		// Code to run during post saving is in process.
+		if ( isSavingPost && !isAutosavingPost && ! isPostSavingInProgress.current ) {
+			isPostSavingInProgress.current = true;
+			if ( isSynthesizeSpeech ) {
+				wp.data.dispatch( postAudioStore ).setIsProcessing( true );
+			}
+		}
+
+		if ( ! isSavingPost && ! isAutosavingPost && isPostSavingInProgress.current ) {
+			// Code to run after post is done saving.
+			isPostSavingInProgress.current = false;
+			wp.data.dispatch( postAudioStore ).setIsProcessing( false );
+		}
+	}, [ isSavingPost ] );
+
 	// Fetches the latest audio file to avoid disk cache.
 	const cacheBustingUrl = `${ sourceUrl }?ver=${ timestamp }`;
 
@@ -358,24 +319,66 @@ const ClassifAITSpeechSynthesisToggle = ( props ) => {
 			<ToggleControl
 				label={ __( 'Enable audio generation', 'classifai' ) }
 				help={
-					isFeatureSupported
-						? __(
-								'ClassifAI will generate audio for the post when it is published or updated.',
-								'classifai'
-						  )
-						: __(
-								'Text to Speech generation is disabled for this post type.',
-								'classifai'
-						  )
+					sprintf(
+					/** translators: %s is post type label. */
+					__(
+						'ClassifAI will generate audio for this %s when it is published or updated.',
+						'classifai'
+					),
+						postTypeLabel
+					)
 				}
-				checked={ isFeatureSupported && isSynthesizeSpeech }
+				checked={ isSynthesizeSpeech }
 				onChange={ ( value ) => {
 					wp.data.dispatch( 'core/editor' ).editPost( {
-						classifai_synthesize_speech: value ? 'yes' : 'no',
+						classifai_synthesize_speech: value,
 					} );
 				} }
-				disabled={ ! isFeatureSupported }
+				disabled={ isProcessingAudio }
+				isBusy={ isProcessingAudio }
 			/>
+			{ sourceUrl && (
+				<>
+					<ToggleControl
+						label={ __( 'Display audio controls', 'classifai' ) }
+						help={
+							__(
+								'Controls the display of the audio player on the front-end.',
+								'classifai'
+							)
+						}
+						checked={ displayGeneratedAudio }
+						onChange={ ( value ) => {
+							wp.data.dispatch( 'core/editor' ).editPost( {
+								classifai_display_generated_audio: value,
+							} );
+						} }
+						disabled={ isProcessingAudio }
+						isBusy={ isProcessingAudio }
+					/>
+					<BaseControl
+						id="classifai-audio-preview-controls"
+						help={
+							isProcessingAudio
+								? ''
+								: __( 'Preview the generated audio.', 'classifai' )
+						}
+					>
+						<Button
+							id="classifai-audio-controls__preview-btn"
+							icon={ <Icon icon={ audioIcon } /> }
+							variant="secondary"
+							onClick={ () => setIsPreviewing( ! isPreviewing ) }
+							disabled={ isProcessingAudio }
+							isBusy={ isProcessingAudio }
+						>
+							{ isProcessingAudio
+								? __( 'Generating audio..', 'classifai' )
+								: __( 'Preview', 'classifai' ) }
+						</Button>
+					</BaseControl>
+				</>
+			) }
 			{ sourceUrl && (
 				<audio
 					id="classifai-audio-preview"
@@ -383,70 +386,9 @@ const ClassifAITSpeechSynthesisToggle = ( props ) => {
 					onEnded={ () => setIsPreviewing( false ) }
 				></audio>
 			) }
-			{ sourceUrl && isSynthesizeSpeech && (
-				<BaseControl
-					id="classifai-audio-controls"
-					help={
-						isProcessingAudio
-							? ''
-							: __( 'Preview the generated audio.', 'classifai' )
-					}
-				>
-					<Button
-						id="classifai-audio-controls__preview-btn"
-						icon={ <Icon icon={ audioIcon } /> }
-						variant="secondary"
-						onClick={ () => setIsPreviewing( ! isPreviewing ) }
-						disabled={ isProcessingAudio }
-						isBusy={ isProcessingAudio }
-					>
-						{ isProcessingAudio
-							? __( 'Generating audio..', 'classifai' )
-							: __( 'Preview', 'classifai' ) }
-					</Button>
-				</BaseControl>
-			) }
 		</>
 	);
 };
-
-let isPostSavingInProgress = false;
-
-// Synthesises audio for the post whenever a post is publish/updated.
-wp.data.subscribe( function () {
-	const { select } = wp.data;
-
-	const isSynthesizeSpeech =
-		'yes' ===
-		select( 'core/editor' ).getEditedPostAttribute(
-			'classifai_synthesize_speech'
-		);
-
-	if ( ! isSynthesizeSpeech ) {
-		return;
-	}
-
-	// Says whether if post is saving?
-	let isSavingPost = select( 'core/editor' ).isSavingPost();
-
-	// Says whether if post is autosaving?
-	const isAutosavingPost = select( 'core/editor' ).isAutosavingPost();
-
-	// Current post ID.
-	const postId = select( 'core/editor' ).getCurrentPostId();
-
-	// We want the speech synthesis to only happen on save and not autosave.
-	isSavingPost = isSavingPost && ! isAutosavingPost;
-
-	if ( isSavingPost && ! isPostSavingInProgress ) {
-		isPostSavingInProgress = true;
-	}
-
-	if ( ! isSavingPost && isPostSavingInProgress ) {
-		synthesizeSpeech( postId );
-		isPostSavingInProgress = false;
-	}
-} );
 
 /**
  * Add the ClassifAI panel to Gutenberg
@@ -458,15 +400,6 @@ const ClassifAIPlugin = () => {
 	const postStatus = useSelect( ( select ) =>
 		select( 'core/editor' ).getCurrentPostAttribute( 'status' )
 	);
-
-	const defaultAudioId = useSelect( ( select ) =>
-		select( 'core/editor' ).getEditedPostAttribute(
-			'classifai_post_audio_id'
-		)
-	);
-	const audioId =
-		useSelect( ( select ) => select( postAudioStore ).getAudioId() ) ||
-		defaultAudioId;
 
 	// Ensure that at least one feature is enabled.
 	const isNLULanguageProcessingEnabled =
@@ -539,8 +472,10 @@ const ClassifAIPlugin = () => {
 						) }
 					</>
 				) }
+				{ classifaiTTSEnabled && (
+					<ClassifAITTS />
+				) }
 			</>
-			<ClassifAITSpeechSynthesisToggle audioId={ audioId } />
 		</PluginDocumentSettingPanel>
 	);
 };

--- a/src/js/gutenberg-plugin.js
+++ b/src/js/gutenberg-plugin.js
@@ -14,7 +14,8 @@ import { registerPlugin } from '@wordpress/plugins';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { store as postAudioStore } from './store/register';
 
-const { classifaiEmbeddingData, classifaiPostData, classifaiTTSEnabled } = window;
+const { classifaiEmbeddingData, classifaiPostData, classifaiTTSEnabled } =
+	window;
 
 /**
  * Create the ClassifAI icon
@@ -192,8 +193,6 @@ const ClassifAIGenerateTagsButton = () => {
 
 /**
  * ClassifAI Text to Audio component.
- *
- * @param {Object} props Props object.
  */
 const ClassifAITTS = () => {
 	// State of the audio being previewed in PluginDocumentSettingPanel.
@@ -216,8 +215,10 @@ const ClassifAITTS = () => {
 	);
 
 	// Post type label.
-	const postTypeLabel = useSelect( ( select ) =>
-		select( 'core/editor' ).getPostTypeLabel() || __( 'Post', 'classifai' )
+	const postTypeLabel = useSelect(
+		( select ) =>
+			select( 'core/editor' ).getPostTypeLabel() ||
+			__( 'Post', 'classifai' )
 	);
 
 	// Says whether speech synthesis is in progress.
@@ -253,12 +254,12 @@ const ClassifAITTS = () => {
 	const { isSavingPost } = useSelect( ( select ) => {
 		return {
 			isSavingPost: select( 'core/editor' ).isSavingPost(),
-		}
+		};
 	} );
 	const { isAutosavingPost } = useSelect( ( select ) => {
 		return {
 			isSavingPost: select( 'core/editor' ).isAutosavingPost(),
-		}
+		};
 	} );
 
 	// Handles playing/pausing post audio during preview.
@@ -289,19 +290,27 @@ const ClassifAITTS = () => {
 
 	useEffect( () => {
 		// Code to run during post saving is in process.
-		if ( isSavingPost && !isAutosavingPost && ! isPostSavingInProgress.current ) {
+		if (
+			isSavingPost &&
+			! isAutosavingPost &&
+			! isPostSavingInProgress.current
+		) {
 			isPostSavingInProgress.current = true;
 			if ( isSynthesizeSpeech ) {
 				wp.data.dispatch( postAudioStore ).setIsProcessing( true );
 			}
 		}
 
-		if ( ! isSavingPost && ! isAutosavingPost && isPostSavingInProgress.current ) {
+		if (
+			! isSavingPost &&
+			! isAutosavingPost &&
+			isPostSavingInProgress.current
+		) {
 			// Code to run after post is done saving.
 			isPostSavingInProgress.current = false;
 			wp.data.dispatch( postAudioStore ).setIsProcessing( false );
 		}
-	}, [ isSavingPost ] );
+	}, [ isSavingPost, isAutosavingPost, isSynthesizeSpeech ] );
 
 	// Fetches the latest audio file to avoid disk cache.
 	const cacheBustingUrl = `${ sourceUrl }?ver=${ timestamp }`;
@@ -318,16 +327,14 @@ const ClassifAITTS = () => {
 		<>
 			<ToggleControl
 				label={ __( 'Enable audio generation', 'classifai' ) }
-				help={
-					sprintf(
+				help={ sprintf(
 					/** translators: %s is post type label. */
 					__(
 						'ClassifAI will generate audio for this %s when it is published or updated.',
 						'classifai'
 					),
-						postTypeLabel
-					)
-				}
+					postTypeLabel
+				) }
 				checked={ isSynthesizeSpeech }
 				onChange={ ( value ) => {
 					wp.data.dispatch( 'core/editor' ).editPost( {
@@ -341,12 +348,10 @@ const ClassifAITTS = () => {
 				<>
 					<ToggleControl
 						label={ __( 'Display audio controls', 'classifai' ) }
-						help={
-							__(
-								'Controls the display of the audio player on the front-end.',
-								'classifai'
-							)
-						}
+						help={ __(
+							'Controls the display of the audio player on the front-end.',
+							'classifai'
+						) }
 						checked={ displayGeneratedAudio }
 						onChange={ ( value ) => {
 							wp.data.dispatch( 'core/editor' ).editPost( {
@@ -361,7 +366,10 @@ const ClassifAITTS = () => {
 						help={
 							isProcessingAudio
 								? ''
-								: __( 'Preview the generated audio.', 'classifai' )
+								: __(
+										'Preview the generated audio.',
+										'classifai'
+								  )
 						}
 					>
 						<Button
@@ -472,9 +480,7 @@ const ClassifAIPlugin = () => {
 						) }
 					</>
 				) }
-				{ classifaiTTSEnabled && (
-					<ClassifAITTS />
-				) }
+				{ classifaiTTSEnabled && <ClassifAITTS /> }
 			</>
 		</PluginDocumentSettingPanel>
 	);

--- a/src/js/gutenberg-plugin.js
+++ b/src/js/gutenberg-plugin.js
@@ -217,7 +217,8 @@ const ClassifAITTS = () => {
 	// Post type label.
 	const postTypeLabel = useSelect(
 		( select ) =>
-			select( 'core/editor' ).getPostTypeLabel() ||
+			( typeof select( 'core/editor' ).getPostTypeLabel !== 'undefined' &&
+				select( 'core/editor' ).getPostTypeLabel() ) ||
 			__( 'Post', 'classifai' )
 	);
 

--- a/tests/Classifai/Providers/Azure/ComputerVisionTest.php
+++ b/tests/Classifai/Providers/Azure/ComputerVisionTest.php
@@ -81,14 +81,30 @@ class ComputerVisionTest extends WP_UnitTestCase {
 
 
 	/**
-	 * Ensure that settings returns empty array of the `classifai_computer_vision` is not set.
+	 * Ensure that settings returns default settings array if the `classifai_computer_vision` is not set.
 	 */
 	public function test_no_computer_vision_option_set() {
 		delete_option( 'classifai_computer_vision' );
 
 		$settings = $this->get_computer_vision()->get_settings();
 
-		$this->assertSame( $settings, array() );
+		$this->assertSame( $settings, [
+			'valid'                 => false,
+			'url'                   => '',
+			'api_key'               => '',
+			'enable_image_captions' => array(
+				'alt'         => 0,
+				'caption'     => 0,
+				'description' => 0,
+			),
+			'enable_image_tagging'  => true,
+			'enable_smart_cropping' => false,
+			'enable_ocr'            => false,
+			'enable_read_pdf'       => false,
+			'caption_threshold'     => 75,
+			'tag_threshold'         => 70,
+			'image_tag_taxonomy'    => 'classifai-image-tags',
+		] );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #540 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
We need to test the entire audio generation / regeneration process along with it's ability to hide/display the audio on the FE using the new display controls.
There are two new filters that allows us to manipulate the initial state of audio generation and the subsequent state of audio generation once it has already been generated. We need to manipulate the filters and review the process to see if it works as expected.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Option to hide/unhide audio controls on the FE if the audio exists.
> Changed - The audio generation process.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @joshuaabenazer 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
