### PR TITLE
Update `yahnis-elsts/plugin-update-checker` from 4.13 to 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "license": "GPLv2",
   "require": {
     "php": ">=7.4",
-    "yahnis-elsts/plugin-update-checker": "4.13",
+    "yahnis-elsts/plugin-update-checker": "5.1",
     "ua-parser/uap-php": "dev-master"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d639edc8e5a46bb27962d4b225e48456",
+    "content-hash": "eac83010094406077b2bc944e936a9c2",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -149,26 +149,26 @@
         },
         {
             "name": "yahnis-elsts/plugin-update-checker",
-            "version": "v4.13",
+            "version": "v5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/YahnisElsts/plugin-update-checker.git",
-                "reference": "6eb27a6911e0e0880d09e5b11f577d3f688f7da7"
+                "reference": "48b03e93c9c2587f9276dce00ce2b6d94c1190d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/YahnisElsts/plugin-update-checker/zipball/6eb27a6911e0e0880d09e5b11f577d3f688f7da7",
-                "reference": "6eb27a6911e0e0880d09e5b11f577d3f688f7da7",
+                "url": "https://api.github.com/repos/YahnisElsts/plugin-update-checker/zipball/48b03e93c9c2587f9276dce00ce2b6d94c1190d2",
+                "reference": "48b03e93c9c2587f9276dce00ce2b6d94c1190d2",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": ">=5.2.0"
+                "php": ">=5.6.20"
             },
             "type": "library",
             "autoload": {
                 "files": [
-                    "load-v4p13.php"
+                    "load-v5p1.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -179,7 +179,7 @@
                 {
                     "name": "Yahnis Elsts",
                     "email": "whiteshadow@w-shadow.com",
-                    "homepage": "http://w-shadow.com/",
+                    "homepage": "https://w-shadow.com/",
                     "role": "Developer"
                 }
             ],
@@ -193,9 +193,9 @@
             ],
             "support": {
                 "issues": "https://github.com/YahnisElsts/plugin-update-checker/issues",
-                "source": "https://github.com/YahnisElsts/plugin-update-checker/tree/v4.13"
+                "source": "https://github.com/YahnisElsts/plugin-update-checker/tree/v5.1"
             },
-            "time": "2022-07-29T12:36:25+00:00"
+            "time": "2023-05-20T11:55:43+00:00"
         }
     ],
     "packages-dev": [
@@ -2695,7 +2695,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2"
+        "php": ">=7.4"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/includes/Classifai/Admin/Update.php
+++ b/includes/Classifai/Admin/Update.php
@@ -7,7 +7,7 @@
 
 namespace Classifai\Admin;
 
-use Puc_v4_Factory;
+use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 
 /**
  * Plugin update class.
@@ -24,7 +24,7 @@ class Update {
 	/**
 	 * The update checker object.
 	 *
-	 * @var Puc_v4p13_Plugin_UpdateChecker
+	 * @var YahnisElsts\PluginUpdateChecker\v5p1\Vcs\PluginUpdateChecker
 	 */
 	protected $updater;
 
@@ -34,7 +34,7 @@ class Update {
 	 * @return bool
 	 */
 	public function can_register() {
-		return class_exists( '\Puc_v4_Factory' ) && self::license_check();
+		return class_exists( '\YahnisElsts\PluginUpdateChecker\v5\PucFactory' ) && self::license_check();
 	}
 
 	/**
@@ -52,7 +52,7 @@ class Update {
 	 * @return void
 	 */
 	public function init() {
-		$this->updater = Puc_v4_Factory::buildUpdateChecker(
+		$this->updater = PucFactory::buildUpdateChecker(
 			self::$repo_url,
 			CLASSIFAI_PLUGIN,
 			'classifai'

--- a/includes/Classifai/Admin/Update.php
+++ b/includes/Classifai/Admin/Update.php
@@ -87,7 +87,9 @@ class Update {
 
 			// Adding the plugin info to the `no_update` property is required
 			// for the enable/disable auto-update links to appear correctly in the UI.
-			$transient->no_update[ $update->filename ] = $update;
+			if ( $update ) {
+				$transient->no_update[ $update->filename ] = $update;
+			}
 		}
 
 		return $transient;


### PR DESCRIPTION
### Description of the Change

The Plugin Update Checker library we use is also used on a few other 10up projects.  We need to ensure we are using the same version across all of these or you can end up with conflicts (especially when using composer to manage all dependencies of a project). This PR updates this library to the latest version, which will also be done in other repos that are using this library.

### How to test the Change

1. Pull these changes down
2. Within the `classifai.php` file, set the version number to something lower, like 2.1.0
3. Ensure you have a proper license in place
4. Go to the plugins section and ensure you see an update notice for Classifai (may need to click the `Check for updates` link; also ensure the plugin is active)
5. Click on the `View version X.X.X details` link and ensure you see proper details
6. Go to the WordPress Updates page and ensure you see Classifai there as well, with the icon
7. Click on the `View version X.X.X details` link and ensure you see proper details
8. If desired, click the `update now` link and ensure an update works (either from the plugins page or the main updates page). Note though that this will wipe out your version controlled `classifai` directory, so proceed with caution

### Changelog Entry

> Changed - Upgrade the Plugin Update Checker library to 5.1

### Credits

Props @dkotter

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
