### PR TITLE
Fix failing E2E tests and add back testing on `trunk`

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,6 +17,7 @@ jobs:
         core:
           - {name: 'WP latest', version: 'latest'}
           - {name: 'WP minimum', version: 'WordPress/WordPress#5.7'}
+          - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/tests/test-plugin/e2e-test-plugin.php
+++ b/tests/test-plugin/e2e-test-plugin.php
@@ -95,3 +95,14 @@ function classifai_test_prepare_response( $response ) {
 if ( ! defined( 'FS_METHOD' ) ) {
 	define( 'FS_METHOD', 'direct' );
 }
+
+// Load our recommended content block to force the non-iframe editor.
+// Cypress fails to run correctly when the editor is iframed.
+add_action(
+	'admin_init',
+	function() {
+		if ( function_exists( 'Classifai\Blocks\setup' ) ) {
+			Classifai\Blocks\setup();
+		}
+	}
+);


### PR DESCRIPTION
### Description of the Change

E2E tests have been failing on WP `trunk` for a few months (and thus we had removed that from our test matrix) and now tests are failing on the latest release. In digging in, it seems the issue is that in WordPress 6.3, the post editor is loaded in an iframe if all registered blocks support the Block API version 3 or greater. It seems that Cypress doesn't like this iframed approach and the editor fails to load. This means any tests that need to interact with the block editor (like creating a new post) won't work.

I don't think this is an issue on the WordPress side, I think this is a Cypress specific problem. I was unable to figure out a true fix though and so this PR addresses this by ensuring our custom Recommended Content block is loaded for all tests. This block supports the Block API v2, so the editor ends up being loaded as before (not in an iframe) and tests work. This isn't a true fix and probably won't work forever but I figure having passing tests is worth it for now.

### How to test the Change

Ensure E2E tests are passing

### Changelog Entry

> Fixed - Ensure our E2E tests work properly on WordPress 6.3

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
