### PR TITLE
Updated release GH action workflow files.

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -1,28 +1,29 @@
 name: Build release zip
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
   build_zip:
-    name: New release
+    name: Build release zip
     runs-on: ubuntu-latest
     steps:
-
     - name: Checkout code
       uses: actions/checkout@v3
-
-    - name: Create ZIP
-      run: |
-        git archive --prefix=classifai/ HEAD -o classifai.zip
-
-    - name: Upload release asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set Node.js 16.x
+      uses: actions/setup-node@v3
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ${{github.workspace}}/classifai.zip
-        asset_name: classifai.zip
-        asset_content_type: application/zip
+        node-version-file: .nvmrc
+    - name: npm install and build
+      run: |
+        npm install
+        npm run build
+        npm run makepot
+        composer install --no-dev
+        npm run archive
+    - name: Upload the ZIP file as an artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.event.repository.name }}
+        path: release
+        retention-days: 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,36 @@
-name: Build Release
+name: Release
+
 on:
-  push:
-    branches:
-    - trunk
+  release:
+    types: [published]
+
 jobs:
   release:
-    name: Push (merge) to trunk
+    name: New release
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
     - name: Set Node.js 16.x
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
-    - name: npm install and build
+        node-version-file: .nvmrc
+
+    - name: Install dependencies, build files and archive
       run: |
         npm install
         npm run build
         npm run makepot
         composer install --no-dev
         npm run archive
-    - name: Release to Stable
-      uses: s0/git-publish-subdir-action@develop
+
+    - name: Upload release asset
+      uses: actions/upload-release-asset@v1
       env:
-        REPO: self
-        BRANCH: stable
-        FOLDER: release
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MESSAGE: 'Release: ({sha}) {msg}'
-    - name: Build docs
-      run: npm run build:docs
-    - name: Deploy docs update
-      uses: peaceiris/actions-gh-pages@v3
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: './docs'
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{github.workspace}}/classifai.zip
+        asset_name: classifai.zip
+        asset_content_type: application/zip

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,0 +1,38 @@
+name: Release to Stable
+on:
+  push:
+    branches:
+    - trunk
+jobs:
+  release:
+    name: Push (merge) to trunk
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set Node.js 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+    - name: npm install and build
+      run: |
+        npm install
+        npm run build
+        npm run makepot
+        composer install --no-dev
+        npm run archive
+    - name: Release to Stable
+      uses: s0/git-publish-subdir-action@develop
+      env:
+        REPO: self
+        BRANCH: stable
+        FOLDER: release
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MESSAGE: 'Release: ({sha}) {msg}'
+    - name: Build docs
+      run: npm run build:docs
+    - name: Deploy docs update
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: './docs'


### PR DESCRIPTION
### Description of the Change
As discussed in #412, currently, the release zip archive not getting attached to the GH release. Earlier Generate release zip workflow was common between the release event and workflow dispatch event, but somehow workflow was not getting triggered on the release event. _(Note: in [b8d8d2c](https://github.com/10up/classifai/commit/b8d8d2cfddfb938076b5af37bc3e12e122386cb3) we updated the file to follow what we are doing in the distributor, but it creates zip without build files)_

This PR updates release workflow files to fix the issue and also adds workflow dispatch generate zip workflow to manually generate a zip archive.
 
Closes #412

### How to test the Change
This can be tested after the PR merge.
- Verify that the "Generate release zip" action working fine.
- Verify that the stable branch is updated with build files when we push anything to the `trunk` branch.
- Verify that release zip archive to new release.

### Changelog Entry
> Changed - Updated release GH action workflow files.


### Credits
Props @jeffpaul @ravinderk @dkotter @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
