### PR TITLE
Update the Cypress WP Utils package to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "tippy.js": "^6.3.7"
       },
       "devDependencies": {
-        "@10up/cypress-wp-utils": "^0.1.0",
+        "@10up/cypress-wp-utils": "^0.2.0",
         "@wordpress/env": "^8.1.0",
         "@wordpress/scripts": "^26.6.0",
         "cypress": "^12.14.0",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@10up/cypress-wp-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.1.0.tgz",
-      "integrity": "sha512-6yige9N0kqG0XM4HBQBPcr2k7TwUV+4PLESvQEvsDyIkvRvLzL1Fnbork+s1+hvni+2qL6Ghjhjjd2npTNbqRg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.2.0.tgz",
+      "integrity": "sha512-5gzamtHIFojT+wx0OzSAEeVY6FVrlcVPHVFH23uExkaqQhNsJvrnpdtqtT98wAYkXg56c1qDN7Ju7ZRTaNzP5g==",
       "dev": true,
       "engines": {
         "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "env": "wp-env",
     "env:start": "wp-env start",
     "env:stop": "wp-env stop",
+    "env:destroy": "wp-env destroy",
     "archive": "composer archive --file=$npm_package_name --format=zip",
     "postarchive": "rm -rf ./release && unzip $npm_package_name.zip -d ./release",
     "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "role": "developer"
   },
   "devDependencies": {
-    "@10up/cypress-wp-utils": "^0.1.0",
+    "@10up/cypress-wp-utils": "^0.2.0",
     "@wordpress/env": "^8.1.0",
     "@wordpress/scripts": "^26.6.0",
     "cypress": "^12.14.0",

--- a/tests/cypress/config.config.js
+++ b/tests/cypress/config.config.js
@@ -1,18 +1,19 @@
-const { defineConfig } = require('cypress')
+const { defineConfig } = require( 'cypress' );
 
-module.exports = defineConfig({
-  fixturesFolder: __dirname+'/fixtures',
-  screenshotsFolder: __dirname+'/screenshots',
-  videosFolder: __dirname+'/videos',
-  downloadsFolder: __dirname+'/downloads',
-  video: false,
-  e2e: {
-    // We've imported your old cypress plugins here.
-    // You may want to clean this up later by importing these.
-    setupNodeEvents(on, config) {
-      return require(__dirname+'/plugins/index.js')(on, config)
-    },
-    specPattern: __dirname+'/integration/**/*.test.{js,jsx,ts,tsx}',
-    supportFile: __dirname+'/support/index.js',
-  },
-})
+module.exports = defineConfig( {
+	chromeWebSecurity: false,
+	fixturesFolder: __dirname + '/fixtures',
+	screenshotsFolder: __dirname + '/screenshots',
+	videosFolder: __dirname + '/videos',
+	downloadsFolder: __dirname + '/downloads',
+	video: false,
+	e2e: {
+		// We've imported your old cypress plugins here.
+		// You may want to clean this up later by importing these.
+		setupNodeEvents( on, config ) {
+			return require( __dirname + '/plugins/index.js' )( on, config );
+		},
+		specPattern: __dirname + '/integration/**/*.test.{js,jsx,ts,tsx}',
+		supportFile: __dirname + '/support/index.js',
+	},
+} );

--- a/tests/cypress/integration/language-processing.test.js
+++ b/tests/cypress/integration/language-processing.test.js
@@ -523,7 +523,7 @@ describe('Language processing Tests', () => {
 		cy.get('.title-modal .classifai-title').first().find('button').click();
 
 		cy.get('.title-modal').should('not.exist');
-		cy.get('.editor-post-title__input').should(($el) => {
+		cy.getBlockEditor.find('.editor-post-title__input').should(($el) => {
 			expect($el.first()).to.contain(data);
 		});
 	});

--- a/tests/cypress/integration/language-processing.test.js
+++ b/tests/cypress/integration/language-processing.test.js
@@ -523,7 +523,7 @@ describe('Language processing Tests', () => {
 		cy.get('.title-modal .classifai-title').first().find('button').click();
 
 		cy.get('.title-modal').should('not.exist');
-		cy.getBlockEditor.find('.editor-post-title__input').should(($el) => {
+		cy.getBlockEditor().find('.editor-post-title__input').should(($el) => {
 			expect($el.first()).to.contain(data);
 		});
 	});

--- a/tests/test-plugin/e2e-test-plugin.php
+++ b/tests/test-plugin/e2e-test-plugin.php
@@ -95,14 +95,3 @@ function classifai_test_prepare_response( $response ) {
 if ( ! defined( 'FS_METHOD' ) ) {
 	define( 'FS_METHOD', 'direct' );
 }
-
-// Load our recommended content block to force the non-iframe editor.
-// Cypress fails to run correctly when the editor is iframed.
-add_action(
-	'admin_init',
-	function() {
-		if ( function_exists( 'Classifai\Blocks\setup' ) ) {
-			Classifai\Blocks\setup();
-		}
-	}
-);


### PR DESCRIPTION
### Description of the Change

The `@10up/cypress/wp-utils` package was recently updated to v0.2.0. This version contains a number of fixes for WP 6.3. This PR updates to use that version and removes our temporary fix where we forced the non-iframed block editor to load. This also required a few other changes anywhere we interact with the editor.

### How to test the Change

Ensure all E2E tests pass on this PR

### Changelog Entry

None needed as this is a partner to #562 

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
