### PR TITLE
Wording updates in ClassifAI settings

### DIFF
--- a/includes/Classifai/Admin/templates/onboarding-step-three.php
+++ b/includes/Classifai/Admin/templates/onboarding-step-three.php
@@ -31,34 +31,35 @@ $args = array(
 // Header
 require_once 'onboarding-header.php';
 ?>
-
-<div class="classifai-tabs tabs-center">
-	<?php
-	foreach ( $enabled_providers as $key => $provider ) {
-		$provider_url = add_query_arg( 'tab', $key, $base_url );
-		$is_active    = ( $current_provider === $key ) ? 'active' : '';
-		?>
-		<a href="<?php echo esc_url( $provider_url ); ?>" class="tab <?php echo esc_attr( $is_active ); ?>">
-			<?php echo esc_html( $provider['title'] ); ?>
-		</a>
+<div class="classifai-providers-wrapper">
+	<div class="classifai-tabs tabs-center">
 		<?php
-	}
-	?>
-</div>
-<div class="classifai-setup-form">
-	<input name="classifai-setup-provider" type="hidden" value="<?php echo esc_attr( $current_provider ); ?>" />
-	<?php
-	// Load the appropriate provider settings.
-	if ( ! empty( $current_provider ) && ! empty( $enabled_providers ) ) {
-		Classifai\Admin\Onboarding::render_classifai_setup_settings( $current_provider, $enabled_providers[ $current_provider ]['fields'] );
-	} else {
+		foreach ( $enabled_providers as $key => $provider ) {
+			$provider_url = add_query_arg( 'tab', $key, $base_url );
+			$is_active    = ( $current_provider === $key ) ? 'active' : '';
+			?>
+			<a href="<?php echo esc_url( $provider_url ); ?>" class="tab <?php echo esc_attr( $is_active ); ?>">
+				<?php echo esc_html( $provider['title'] ); ?>
+			</a>
+			<?php
+		}
 		?>
-		<p class="classifai-setup-error">
-			<?php esc_html_e( 'No features are enabled.', 'classifai' ); ?>
-		</p>
+	</div>
+	<div class="classifai-setup-form">
+		<input name="classifai-setup-provider" type="hidden" value="<?php echo esc_attr( $current_provider ); ?>" />
 		<?php
-	}
-	?>
+		// Load the appropriate provider settings.
+		if ( ! empty( $current_provider ) && ! empty( $enabled_providers ) ) {
+			Classifai\Admin\Onboarding::render_classifai_setup_settings( $current_provider, $enabled_providers[ $current_provider ]['fields'] );
+		} else {
+			?>
+			<p class="classifai-setup-error">
+				<?php esc_html_e( 'No features are enabled.', 'classifai' ); ?>
+			</p>
+			<?php
+		}
+		?>
+	</div>
 </div>
 
 <?php

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -38,7 +38,7 @@ class ComputerVision extends Provider {
 
 		// Set the onboarding options.
 		$this->onboarding_options = array(
-			'title'    => __( 'Microsoft Azure AI Vision', 'classifai' ),
+			'title'    => __( 'Image Processing', 'classifai' ),
 			'fields'   => array( 'url', 'api-key' ),
 			'features' => array(
 				'enable_image_captions' => __( 'Automatically add alt-text to images', 'classifai' ),

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -30,7 +30,7 @@ class ComputerVision extends Provider {
 	 */
 	public function __construct( $service ) {
 		parent::__construct(
-			'Microsoft Azure',
+			'Image Processing',
 			'AI Vision',
 			'computer_vision',
 			$service

--- a/includes/Classifai/Providers/Azure/Personalizer.php
+++ b/includes/Classifai/Providers/Azure/Personalizer.php
@@ -34,7 +34,7 @@ class Personalizer extends Provider {
 	 */
 	public function __construct( $service ) {
 		parent::__construct(
-			'Microsoft Azure',
+			'Recommended Content Block',
 			'AI Personalizer',
 			'personalizer',
 			$service

--- a/includes/Classifai/Providers/Azure/Personalizer.php
+++ b/includes/Classifai/Providers/Azure/Personalizer.php
@@ -42,7 +42,7 @@ class Personalizer extends Provider {
 
 		// Set the onboarding options.
 		$this->onboarding_options = array(
-			'title'    => __( 'Microsoft Azure AI Personalizer', 'classifai' ),
+			'title'    => __( 'Recommended Content', 'classifai' ),
 			'fields'   => array( 'url', 'api-key' ),
 			'features' => array(
 				'authenticated' => __( 'Recommended content block', 'classifai' ),

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -67,7 +67,7 @@ class TextToSpeech extends Provider {
 	 */
 	public function __construct( $service ) {
 		parent::__construct(
-			'Microsoft Azure',
+			self::FEATURE_NAME,
 			self::FEATURE_NAME,
 			'azure_text_to_speech',
 			$service

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -75,7 +75,7 @@ class TextToSpeech extends Provider {
 
 		// Set the onboarding options.
 		$this->onboarding_options = array(
-			'title'    => __( 'Microsoft Azure Text to Speech', 'classifai' ),
+			'title'    => __( 'Text to Speech', 'classifai' ),
 			'fields'   => array( 'url', 'api-key' ),
 			'features' => array(
 				'authenticated' => __( 'Generate speech for post content', 'classifai' ),

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -50,7 +50,7 @@ class ChatGPT extends Provider {
 
 		// Set the onboarding options.
 		$this->onboarding_options = array(
-			'title'    => __( 'OpenAI ChatGPT', 'classifai' ),
+			'title'    => __( 'Content Generation', 'classifai' ),
 			'fields'   => array( 'api-key' ),
 			'features' => array(
 				'enable_excerpt'        => __( 'Excerpt generation', 'classifai' ),

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -42,7 +42,7 @@ class ChatGPT extends Provider {
 	 */
 	public function __construct( $service ) {
 		parent::__construct(
-			'OpenAI ChatGPT',
+			'Content Generation',
 			'ChatGPT',
 			'openai_chatgpt',
 			$service

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -35,7 +35,7 @@ class DallE extends Provider {
 	 */
 	public function __construct( $service ) {
 		parent::__construct(
-			'OpenAI',
+			'Image Generation',
 			'DALL·E',
 			'openai_dalle',
 			$service

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -43,7 +43,7 @@ class DallE extends Provider {
 
 		// Set the onboarding options.
 		$this->onboarding_options = array(
-			'title'    => __( 'OpenAI DALL·E', 'classifai' ),
+			'title'    => __( 'Image Generation', 'classifai' ),
 			'fields'   => array( 'api-key' ),
 			'features' => array(
 				'enable_image_gen' => __( 'Image generation', 'classifai' ),

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -55,7 +55,7 @@ class Embeddings extends Provider {
 
 		// Set the onboarding options.
 		$this->onboarding_options = array(
-			'title'    => __( 'OpenAI Embeddings', 'classifai' ),
+			'title'    => __( 'Classify Content (OpenAI)', 'classifai' ),
 			'fields'   => array( 'api-key' ),
 			'features' => array(
 				'enable_classification' => __( 'Classify content within existing term structure', 'classifai' ),

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -47,7 +47,7 @@ class Embeddings extends Provider {
 	 */
 	public function __construct( $service ) {
 		parent::__construct(
-			'OpenAI Embeddings',
+			'Classify Content (OpenAI)',
 			'Embeddings',
 			'openai_embeddings',
 			$service

--- a/includes/Classifai/Providers/OpenAI/Whisper.php
+++ b/includes/Classifai/Providers/OpenAI/Whisper.php
@@ -30,7 +30,7 @@ class Whisper extends Provider {
 
 		// Set the onboarding options.
 		$this->onboarding_options = array(
-			'title'    => __( 'OpenAI Whisper', 'classifai' ),
+			'title'    => __( 'Speech to Text', 'classifai' ),
 			'fields'   => array( 'api-key' ),
 			'features' => array(
 				'enable_transcripts' => __( 'Generate transcripts from audio files', 'classifai' ),

--- a/includes/Classifai/Providers/OpenAI/Whisper.php
+++ b/includes/Classifai/Providers/OpenAI/Whisper.php
@@ -22,7 +22,7 @@ class Whisper extends Provider {
 	 */
 	public function __construct( $service ) {
 		parent::__construct(
-			'OpenAI Whisper',
+			'Speech to Text',
 			'Whisper',
 			'openai_whisper',
 			$service

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -39,7 +39,7 @@ class NLU extends Provider {
 	 */
 	public function __construct( $service ) {
 		parent::__construct(
-			'Classify Content (Watson NLU)',
+			'Classify Content (IBM Watson)',
 			'Natural Language Understanding',
 			'watson_nlu',
 			$service
@@ -78,7 +78,7 @@ class NLU extends Provider {
 
 		// Set the onboarding options.
 		$this->onboarding_options = array(
-			'title'    => __( 'Classify Content (Watson NLU)', 'classifai' ),
+			'title'    => __( 'Classify Content (IBM Watson)', 'classifai' ),
 			'fields'   => array( 'url', 'username', 'password', 'toggle' ),
 			'features' => array(),
 		);

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -39,7 +39,7 @@ class NLU extends Provider {
 	 */
 	public function __construct( $service ) {
 		parent::__construct(
-			'IBM Watson',
+			'Classify Content (Watson NLU)',
 			'Natural Language Understanding',
 			'watson_nlu',
 			$service

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -78,7 +78,7 @@ class NLU extends Provider {
 
 		// Set the onboarding options.
 		$this->onboarding_options = array(
-			'title'    => __( 'IBM Watson NLU', 'classifai' ),
+			'title'    => __( 'Classify Content (Watson NLU)', 'classifai' ),
 			'fields'   => array( 'url', 'username', 'password', 'toggle' ),
 			'features' => array(),
 		);

--- a/includes/Classifai/Services/LanguageProcessing.php
+++ b/includes/Classifai/Services/LanguageProcessing.php
@@ -22,8 +22,8 @@ class LanguageProcessing extends Service {
 			'language_processing',
 			[
 				'Classifai\Providers\Watson\NLU',
-				'Classifai\Providers\OpenAI\ChatGPT',
 				'Classifai\Providers\OpenAI\Embeddings',
+				'Classifai\Providers\OpenAI\ChatGPT',
 				'Classifai\Providers\OpenAI\Whisper',
 				'Classifai\Providers\Azure\TextToSpeech',
 			]

--- a/src/scss/admin.scss
+++ b/src/scss/admin.scss
@@ -291,6 +291,11 @@ input.classifai-button {
 			}
 		}
 	}
+
+	span.classifai-input-description {
+		display: block;
+		margin-top: 8px;
+	}
 }
 
 .classifai-setup {
@@ -603,7 +608,6 @@ input.classifai-button {
 			}
 
 			&.tabs-center {
-				margin: auto;
 				margin-bottom: 24px;
 			}
 

--- a/src/scss/admin.scss
+++ b/src/scss/admin.scss
@@ -100,7 +100,8 @@ input.classifai-button {
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 1px #fff, 0 0 0 3px var(--classifai-admin-theme-color-darker-10);
+		box-shadow: 0 0 0 1px #fff,
+			0 0 0 3px var(--classifai-admin-theme-color-darker-10);
 	}
 
 	&:active {
@@ -263,17 +264,18 @@ input.classifai-button {
 		position: relative;
 
 		&:after {
-			transition: all .3s cubic-bezier(1, 0, 0, 1);
+			transition: all 0.3s cubic-bezier(1, 0, 0, 1);
 			will-change: transform, box-shadow, opacity;
 			position: absolute;
-			content: '';
+			content: "";
 			height: 3px;
 			bottom: 0px;
 			left: 0px;
 			right: 0px;
 			border-radius: 3px 3px 0px 0px;
 			background: var(--classifai-admin-theme-color);
-			box-shadow: 0px 4px 10px 3px rgba(var(--classifai-admin-theme-color--rgb), .15);
+			box-shadow: 0px 4px 10px 3px
+				rgba(var(--classifai-admin-theme-color--rgb), 0.15);
 			opacity: 0;
 			transform: scale(0, 1);
 		}
@@ -483,7 +485,7 @@ input.classifai-button {
 			clear: both;
 
 			span.dashicons.dashicons-yes-alt {
-				color: #48BE1E;
+				color: #48be1e;
 			}
 
 			span.dashicons.dashicons-dismiss {
@@ -520,7 +522,6 @@ input.classifai-button {
 		}
 
 		@media screen and (max-width: 767px) {
-
 			.classifai-step1-content,
 			.classifai-step4-content {
 				max-width: 100%;
@@ -533,10 +534,8 @@ input.classifai-button {
 		}
 
 		.classifai-setup-form {
-
 			.classifai-step3-content & {
 				margin: 0 auto;
-				max-width: 480px;
 			}
 
 			.classifai-setup-form-field {
@@ -565,25 +564,43 @@ input.classifai-button {
 
 		.classifai-step3-content {
 			margin: 0 auto;
+			max-width: 840px;
+			width: 100%;
 
 			.classifai-setup-title {
 				text-align: center;
 				margin-bottom: 12px;
 			}
 
-			.classifai-setup-form,
-			.classifai-setup-footer {
-				margin: 0 auto;
-				max-width: 480px;
+			.classifai-setup-form {
+				padding-left: 48px;
+				width: 70%;
+				box-sizing: border-box;
+
+				@media screen and (max-width: 782px) {
+					padding-left: 18px;
+				}
+
+				@media screen and (max-width: 600px) {
+					width: 100%;
+					padding-left: 0px;
+					margin-bottom: 20px;
+				}
 			}
 
 			.classifai-setup-footer {
-				margin-top: 40px;
+				margin-top: 0px;
 			}
 		}
 
 		.classifai-tabs {
 			display: block;
+			width: 30%;
+			box-sizing: border-box;
+
+			@media screen and (max-width: 600px) {
+				width: 100%;
+			}
 
 			&.tabs-center {
 				margin: auto;
@@ -598,12 +615,11 @@ input.classifai-button {
 			a.tab {
 				text-decoration: none;
 				position: relative;
-				display: inline-block;
-				transition: all ease .3s;
+				display: block;
+				transition: all ease 0.3s;
 				padding: 16px 12px;
 				transform: translate3d(0, 0, 0);
 				color: #1d2327;
-				white-space: nowrap;
 				cursor: pointer;
 				font-size: 14px;
 
@@ -615,24 +631,10 @@ input.classifai-button {
 					color: var(--classifai-admin-theme-color);
 				}
 
-				&:after {
-					transition: all .3s cubic-bezier(1, 0, 0, 1);
-					will-change: transform, box-shadow, opacity;
-					position: absolute;
-					content: '';
-					height: 3px;
-					bottom: 0px;
-					left: 0px;
-					right: 0px;
-					border-radius: 3px 3px 0px 0px;
-					background: var(--classifai-admin-theme-color);
-					box-shadow: 0px 4px 10px 3px rgba(var(--classifai-admin-theme-color--rgb), .15);
-					opacity: 0;
-					transform: scale(0, 1);
-				}
-
 				&.active {
-					color: var(--classifai-admin-theme-color);
+					background: #f0f0f0;
+					box-shadow: none;
+					border-radius: 4px;
 					font-weight: 600;
 
 					&:after {
@@ -641,6 +643,12 @@ input.classifai-button {
 					}
 				}
 			}
+		}
+
+		.classifai-providers-wrapper {
+			display: flex;
+			flex-direction: row;
+			flex-wrap: wrap;
 		}
 
 		p.classifai-setup-error {
@@ -691,7 +699,7 @@ input.classifai-button {
 		transition: left 0.25s;
 	}
 
-	.classifai-toggle-checkbox:checked+& {
+	.classifai-toggle-checkbox:checked + & {
 		background: var(--classifai-admin-theme-color);
 		border-color: var(--classifai-admin-theme-color);
 


### PR DESCRIPTION
### Description of the Change
PR attempts to update the Classifai settings tab wording to feature group names in order to make it simpler and easier for users. PR also updates UI on the "Set up AI Providers" step of classifAI setup. Please check the screenshots below for more information on updated wording.

| develop branch | PR branch |
| --- | --- |
|![Screenshot 2023-09-19 at 8 31 07 PM](https://github.com/10up/classifai/assets/10613171/aaa97504-d573-4e31-b221-68f850d79350)|![Screenshot 2023-09-20 at 10 29 54 AM](https://github.com/10up/classifai/assets/10613171/62a61631-e328-45bb-8f37-63f1be1487c9)|
|![Screenshot 2023-09-19 at 8 31 14 PM](https://github.com/10up/classifai/assets/10613171/3a0a3a27-bdc7-4094-bae1-5459ba1de134)|![Screenshot 2023-09-19 at 8 30 39 PM](https://github.com/10up/classifai/assets/10613171/69831d25-05da-477a-b010-95cb0991e363)|
|![Screenshot 2023-09-19 at 8 31 19 PM](https://github.com/10up/classifai/assets/10613171/d0097f0e-ab37-40ae-b1b2-ce3f4afff15f)|![Screenshot 2023-09-19 at 8 30 49 PM](https://github.com/10up/classifai/assets/10613171/e6ea48b2-a4c5-4b0f-88c5-4441e80fbee1)|
|![Screenshot 2023-09-19 at 8 32 48 PM](https://github.com/10up/classifai/assets/10613171/d581ab55-11bc-4302-9e8b-f4be0dc94b75)|![Screenshot 2023-09-19 at 8 33 12 PM](https://github.com/10up/classifai/assets/10613171/14a2b6f1-e06f-4ebf-b8b3-83c43a26acf2)|

@jeffpaul @dkotter Looking for feedback from you on updates here.

### How to test the Change
Validate wording updates from the settings screen or screenshots given here. 

### Changelog Entry
> Changed - Wording updates in ClassifAI settings


### Credits
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
