### PR TITLE
Add support for prompt modification from feature settings

### DIFF
--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -102,7 +102,7 @@ class TextToSpeech extends Provider {
 		wp_enqueue_script(
 			'classifai-gutenberg-plugin',
 			CLASSIFAI_PLUGIN_URL . 'dist/gutenberg-plugin.js',
-			array( 'lodash', 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor', 'wp-edit-post', 'wp-components', 'wp-data', 'wp-plugins' ),
+			array_merge( get_asset_info( 'gutenberg-plugin', 'dependencies' ), array( 'lodash' ) ),
 			CLASSIFAI_PLUGIN_VERSION,
 			true
 		);

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -416,9 +416,9 @@ class ChatGPT extends Provider {
 			$this->get_option_name() . '_excerpt',
 			[
 				'label_for'     => 'generate_excerpt_prompt',
-				'placeholder'   => $this->generate_excerpt_prompt,
+				'placeholder'   => str_replace( array( '{{WORDS}}' ), array( absint( $this->get_settings( 'length' ) ?? 55 ) ), $this->generate_excerpt_prompt ),
 				'default_value' => $default_settings['generate_excerpt_prompt'],
-				'description'   => __( "Enter your custom prompt. If no custom prompt is entered, the default shown above will be used. Note the following variables that can be used in the prompt and will be replaced with content: {{WORDS}} - replaced with the excerpt length setting. {{TITLE}} will be replaced with the item's title.", 'classifai' ),
+				'description'   => __( "Enter your custom prompt. If no custom prompt is entered, the default shown above will be used. Note the following variables that can be used in the prompt and will be replaced with content: {{TITLE}} will be replaced with the item's title.", 'classifai' ),
 			]
 		);
 

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -50,14 +50,14 @@ class ChatGPT extends Provider {
 	protected $generate_title_prompt = 'Write an SEO-friendly title for the following content that will encourage readers to clickthrough, staying within a range of 40 to 60 characters.';
 
 	/**
-	 * Prompt for Shrink content.
+	 * Prompt for shrinking content
 	 *
 	 * @var string
 	 */
 	protected $shrink_content_prompt = 'Decrease the content length no more than 2 to 4 sentences.';
 
 	/**
-	 * Prompt for Grow content.
+	 * Prompt for growing content
 	 *
 	 * @var string
 	 */
@@ -472,7 +472,7 @@ class ChatGPT extends Provider {
 			]
 		);
 
-		// Custom prompt for generate titles
+		// Custom prompt for generating titles.
 		add_settings_field(
 			'generate_title_prompt',
 			esc_html__( 'Prompt', 'classifai' ),
@@ -541,7 +541,7 @@ class ChatGPT extends Provider {
 			]
 		);
 
-		// Custom prompt for shrink content.
+		// Custom prompt for shrinking content.
 		add_settings_field(
 			'shrink_content_prompt',
 			esc_html__( 'Shrink content prompt', 'classifai' ),
@@ -556,7 +556,7 @@ class ChatGPT extends Provider {
 			]
 		);
 
-		// Custom prompt for grow content.
+		// Custom prompt for growing content.
 		add_settings_field(
 			'grow_content_prompt',
 			esc_html__( 'Grow content prompt', 'classifai' ),

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -95,7 +95,7 @@ class Embeddings extends Provider {
 		wp_enqueue_script(
 			'classifai-gutenberg-plugin',
 			CLASSIFAI_PLUGIN_URL . 'dist/gutenberg-plugin.js',
-			get_asset_info( 'gutenberg-plugin', 'dependencies' ),
+			array_merge( get_asset_info( 'gutenberg-plugin', 'dependencies' ), array( 'lodash' ) ),
 			get_asset_info( 'gutenberg-plugin', 'version' ),
 			true
 		);

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -242,7 +242,7 @@ abstract class Provider {
 		$placeholder   = isset( $args['placeholder'] ) ? $args['placeholder'] : '';
 
 		// Check for a default value
-		$value       = ( empty( $value ) && isset( $args['default_value'] ) ) ? $args['default_value'] : $value;
+		$value = ( empty( $value ) && isset( $args['default_value'] ) ) ? $args['default_value'] : $value;
 		?>
 		<textarea
 			id="<?php echo esc_attr( $args['label_for'] ); ?>"

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -230,6 +230,34 @@ abstract class Provider {
 	}
 
 	/**
+	 * Generic textarea field callback
+	 *
+	 * @param array $args The args passed to add_settings_field.
+	 */
+	public function render_textarea( $args ) {
+		$option_index  = isset( $args['option_index'] ) ? $args['option_index'] : false;
+		$setting_index = $this->get_settings( $option_index );
+		$value         = ( isset( $setting_index[ $args['label_for'] ] ) ) ? $setting_index[ $args['label_for'] ] : '';
+		$class         = isset( $args['class'] ) ? $args['class'] : 'large-text';
+		$placeholder   = isset( $args['placeholder'] ) ? $args['placeholder'] : '';
+
+		// Check for a default value
+		$value       = ( empty( $value ) && isset( $args['default_value'] ) ) ? $args['default_value'] : $value;
+		?>
+		<textarea
+			id="<?php echo esc_attr( $args['label_for'] ); ?>"
+			class="<?php echo esc_attr( $class ); ?>"
+			rows="4"
+			name="classifai_<?php echo esc_attr( $this->option_name ); ?><?php echo $option_index ? '[' . esc_attr( $option_index ) . ']' : ''; ?>[<?php echo esc_attr( $args['label_for'] ); ?>]"
+			placeholder="<?php echo esc_attr( $placeholder ); ?>"
+		><?php echo esc_textarea( $value ); ?></textarea>
+		<?php
+		if ( ! empty( $args['description'] ) ) {
+			echo '<br /><span class="description classifai-input-description">' . wp_kses_post( $args['description'] ) . '</span>';
+		}
+	}
+
+	/**
 	 * Renders a select menu
 	 *
 	 * @param array $args The args passed to add_settings_field.

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -207,6 +207,7 @@ class NLU extends Provider {
 		wp_enqueue_script(
 			'classifai-gutenberg-plugin',
 			CLASSIFAI_PLUGIN_URL . 'dist/gutenberg-plugin.js',
+			array_merge( get_asset_info( 'gutenberg-plugin', 'dependencies' ), array( 'lodash' ) ),
 			get_asset_info( 'gutenberg-plugin', 'dependencies' ),
 			get_asset_info( 'gutenberg-plugin', 'version' ),
 			true

--- a/src/scss/admin.scss
+++ b/src/scss/admin.scss
@@ -248,6 +248,7 @@ input.classifai-button {
 			display: block;
 			margin-top: 8px;
 			max-width: 600px;
+			line-height: 1.4;
 		}
 	}
 

--- a/src/scss/admin.scss
+++ b/src/scss/admin.scss
@@ -239,6 +239,16 @@ input.classifai-button {
 		.form-table td fieldset p {
 			margin-bottom: 12px;
 		}
+
+		textarea {
+			max-width: 600px;
+		}
+
+		.classifai-input-description {
+			display: block;
+			margin-top: 8px;
+			max-width: 600px;
+		}
 	}
 
 	input[type="text"],


### PR DESCRIPTION
### Description of the Change
PR adds prompt fields in title generation, excerpt generation, and resize content feature settings to allow admin users to modify the default prompt for the specific feature. 

![image](https://github.com/10up/classifai/assets/10613171/cd07b151-c832-4e55-90bf-e18200837e05)

Closes #587 

### How to test the Change
1. Keep the prompt field value blank in the Generate excerpt setting.
1. Create/edit the post, click on the "Generate excerpt" button in the editor, and verify feature working properly.
1. Modify the prompt by adding a custom prompt value.
1. Create/edit the post, click on the "Generate excerpt" button in the editor, and validate that the generated excerpt is as per the custom prompt value you have added in the feature settings.
1. Follow similar steps for title generation and resize content feature.

### Changelog Entry
> Added - Support for modifying prompt from the feature settings.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dkotter @jeffpaul @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
