### PR TITLE
Use get_asset_info to get dependencies and version of script file for wp_enqueue_script function

### DIFF
--- a/includes/Classifai/Blocks.php
+++ b/includes/Classifai/Blocks.php
@@ -48,7 +48,7 @@ function blocks_styles() {
 		'recommended-content-block-style',
 		CLASSIFAI_PLUGIN_URL . 'dist/recommended-content-block-frontend.css',
 		[],
-		CLASSIFAI_PLUGIN_VERSION
+		get_asset_info( 'recommended-content-block-frontend', 'version' )
 	);
 
 	wp_enqueue_script(

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -159,7 +159,7 @@ class Plugin {
 	/**
 	 * Enqueue the admin scripts.
 	 *
-	 * @since x.x.x Use get_asset_info to get the asset version and dependencies.
+	 * @since 2.4.0 Use get_asset_info to get the asset version and dependencies.
 	 */
 	public function enqueue_admin_assets() {
 

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -158,6 +158,8 @@ class Plugin {
 
 	/**
 	 * Enqueue the admin scripts.
+	 *
+	 * @since x.x.x Use get_asset_info to get the asset version and dependencies.
 	 */
 	public function enqueue_admin_assets() {
 

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -172,8 +172,8 @@ class Plugin {
 		wp_enqueue_script(
 			'classifai-admin-script',
 			CLASSIFAI_PLUGIN_URL . 'dist/admin.js',
-			[],
-			CLASSIFAI_PLUGIN_VERSION,
+			get_asset_info( 'admin', 'dependencies' ),
+			get_asset_info( 'admin', 'version' ),
 			true
 		);
 

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -167,7 +167,7 @@ class Plugin {
 			'classifai-admin-style',
 			CLASSIFAI_PLUGIN_URL . 'dist/admin.css',
 			array(),
-			CLASSIFAI_PLUGIN_VERSION,
+			get_asset_info( 'admin', 'version' ),
 			'all'
 		);
 

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -103,7 +103,7 @@ class TextToSpeech extends Provider {
 			'classifai-gutenberg-plugin',
 			CLASSIFAI_PLUGIN_URL . 'dist/gutenberg-plugin.js',
 			array_merge( get_asset_info( 'gutenberg-plugin', 'dependencies' ), array( 'lodash' ) ),
-			CLASSIFAI_PLUGIN_VERSION,
+			get_asset_info( 'gutenberg-plugin', 'version' ),
 			true
 		);
 

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -85,6 +85,8 @@ class TextToSpeech extends Provider {
 
 	/**
 	 * Enqueue the editor scripts.
+	 *
+	 * @since x.x.x Use get_asset_info to get the asset version and dependencies.
 	 */
 	public function enqueue_editor_assets() {
 		$post = get_post();

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -86,7 +86,7 @@ class TextToSpeech extends Provider {
 	/**
 	 * Enqueue the editor scripts.
 	 *
-	 * @since x.x.x Use get_asset_info to get the asset version and dependencies.
+	 * @since 2.4.0 Use get_asset_info to get the asset version and dependencies.
 	 */
 	public function enqueue_editor_assets() {
 		$post = get_post();

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -216,7 +216,7 @@ class ChatGPT extends Provider {
 				'classifai-content-resizing-plugin-css',
 				CLASSIFAI_PLUGIN_URL . 'dist/content-resizing-plugin.css',
 				[],
-				CLASSIFAI_PLUGIN_VERSION,
+				get_asset_info( 'content-resizing-plugin', 'version' ),
 				'all'
 			);
 		}
@@ -245,7 +245,7 @@ class ChatGPT extends Provider {
 					'classifai-generate-title-classic-css',
 					CLASSIFAI_PLUGIN_URL . 'dist/generate-title-classic.css',
 					[],
-					CLASSIFAI_PLUGIN_VERSION,
+					get_asset_info( 'generate-title-classic', 'version' ),
 					'all'
 				);
 
@@ -275,7 +275,7 @@ class ChatGPT extends Provider {
 					'classifai-generate-title-classic-css',
 					CLASSIFAI_PLUGIN_URL . 'dist/generate-title-classic.css',
 					[],
-					CLASSIFAI_PLUGIN_VERSION,
+					get_asset_info( 'generate-title-classic', 'version' ),
 					'all'
 				);
 
@@ -308,7 +308,7 @@ class ChatGPT extends Provider {
 			'classifai-language-processing-style',
 			CLASSIFAI_PLUGIN_URL . 'dist/language-processing.css',
 			[],
-			CLASSIFAI_PLUGIN_VERSION,
+			get_asset_info( 'language-processing', 'version' ),
 			'all'
 		);
 	}

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -102,7 +102,7 @@ class DallE extends Provider {
 			'classifai-image-processing-style',
 			CLASSIFAI_PLUGIN_URL . 'dist/media-modal.css',
 			[],
-			CLASSIFAI_PLUGIN_VERSION,
+			get_asset_info( 'media-modal', 'version' ),
 			'all'
 		);
 

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -107,7 +107,7 @@ class DallE extends Provider {
 		wp_enqueue_script(
 			'classifai-generate-images',
 			CLASSIFAI_PLUGIN_URL . 'dist/media-modal.js',
-			[ 'jquery', 'wp-api', 'wp-media-utils', 'wp-url' ],
+			array_merge( get_asset_info( 'media-modal', 'dependencies' ), array( 'jquery', 'wp-api' ) ),
 			get_asset_info( 'media-modal', 'version' ),
 			true
 		);
@@ -158,7 +158,7 @@ class DallE extends Provider {
 				wp_enqueue_script(
 					'classifai-generate-images-media-upload',
 					CLASSIFAI_PLUGIN_URL . 'dist/generate-image-media-upload.js',
-					[ 'jquery' ],
+					array_merge( get_asset_info( 'generate-image-media-upload', 'dependencies' ), array( 'jquery' ) ),
 					get_asset_info( 'classifai-generate-images-media-upload', 'version' ),
 					true
 				);

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -84,7 +84,7 @@ class DallE extends Provider {
 	/**
 	 * Enqueue the admin scripts.
 	 *
-	 * @since x.x.x Use get_asset_info to get the asset version and dependencies.
+	 * @since 2.4.0 Use get_asset_info to get the asset version and dependencies.
 	 *
 	 * @param string $hook_suffix The current admin page.
 	 */

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -84,6 +84,8 @@ class DallE extends Provider {
 	/**
 	 * Enqueue the admin scripts.
 	 *
+	 * @since x.x.x Use get_asset_info to get the asset version and dependencies.
+	 *
 	 * @param string $hook_suffix The current admin page.
 	 */
 	public function enqueue_admin_scripts( $hook_suffix = '' ) {

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -241,7 +241,7 @@ class NLU extends Provider {
 			'classifai-language-processing-style',
 			CLASSIFAI_PLUGIN_URL . 'dist/language-processing.css',
 			array(),
-			CLASSIFAI_PLUGIN_VERSION,
+			get_asset_info( 'language-processing', 'version' ),
 			'all'
 		);
 	}

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -46,7 +46,7 @@ class ImageProcessing extends Service {
 		wp_enqueue_script(
 			'classifai-media-script',
 			CLASSIFAI_PLUGIN_URL . 'dist/media.js',
-			array( 'jquery', 'media-editor', 'lodash', 'wp-i18n' ),
+			array_merge( get_asset_info( 'media', 'dependencies' ), array( 'jquery', 'media-editor', 'lodash' ) ),
 			get_asset_info( 'media', 'version' ),
 			true
 		);

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -41,6 +41,8 @@ class ImageProcessing extends Service {
 
 	/**
 	 * Enqueue the script for the media modal.
+	 *
+	 * @since x.x.x Use get_asset_info to get the asset version and dependencies.
 	 */
 	public function enqueue_media_scripts() {
 		wp_enqueue_script(

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -42,7 +42,7 @@ class ImageProcessing extends Service {
 	/**
 	 * Enqueue the script for the media modal.
 	 *
-	 * @since x.x.x Use get_asset_info to get the asset version and dependencies.
+	 * @since 2.4.0 Use get_asset_info to get the asset version and dependencies.
 	 */
 	public function enqueue_media_scripts() {
 		wp_enqueue_script(


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
I use `get_asset_info` function to get dependencies and version of script for `wp_enqeueue_script`.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/classifai/issues/607

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
- [ ] All edited script files should load correctly.
- [ ] We are using `get_asset_info` function in each `wp_enqueue_script`

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Use `get_asset_info` to get dependencies and version of script file for the `wp_enqueue_script` function.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ravinderk @dkotter, @berkod 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
