### PR TITLE
Show the default prompt as the first prompt in our settings

### DIFF
--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -436,7 +436,7 @@ class ChatGPT extends Provider {
 				'label_for'     => 'generate_excerpt_prompt',
 				'placeholder'   => $this->generate_excerpt_prompt,
 				'default_value' => $default_settings['generate_excerpt_prompt'],
-				'description'   => __( "Note the following variables that can be used in the prompt and will be replaced with content: {{WORDS}} will be replaced with the desired excerpt length setting. {{TITLE}} will be replaced with the item's title.", 'classifai' ),
+				'description'   => __( 'Note the following variables that can be used in the prompt and will be replaced with content: {{WORDS}} will be replaced with the desired excerpt length setting. {{TITLE}} will be replaced with the item\'s title.', 'classifai' ),
 			]
 		);
 

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -436,7 +436,7 @@ class ChatGPT extends Provider {
 				'label_for'     => 'generate_excerpt_prompt',
 				'placeholder'   => $this->generate_excerpt_prompt,
 				'default_value' => $default_settings['generate_excerpt_prompt'],
-				'description'   => __( "Enter your custom prompt. Note the following variables that can be used in the prompt and will be replaced with content: {{WORDS}} will be replaced with the desired excerpt length setting. {{TITLE}} will be replaced with the item's title.", 'classifai' ),
+				'description'   => __( "Note the following variables that can be used in the prompt and will be replaced with content: {{WORDS}} will be replaced with the desired excerpt length setting. {{TITLE}} will be replaced with the item's title.", 'classifai' ),
 			]
 		);
 
@@ -501,7 +501,6 @@ class ChatGPT extends Provider {
 				'label_for'     => 'generate_title_prompt',
 				'placeholder'   => $this->generate_title_prompt,
 				'default_value' => $default_settings['generate_title_prompt'],
-				'description'   => __( 'Enter a custom prompt, if desired.', 'classifai' ),
 			]
 		);
 
@@ -570,7 +569,6 @@ class ChatGPT extends Provider {
 				'label_for'     => 'shrink_content_prompt',
 				'placeholder'   => $this->shrink_content_prompt,
 				'default_value' => $default_settings['shrink_content_prompt'],
-				'description'   => __( 'Enter a custom prompt, if desired.', 'classifai' ),
 			]
 		);
 
@@ -585,7 +583,6 @@ class ChatGPT extends Provider {
 				'label_for'     => 'grow_content_prompt',
 				'placeholder'   => $this->grow_content_prompt,
 				'default_value' => $default_settings['grow_content_prompt'],
-				'description'   => __( 'Enter a custom prompt, if desired.', 'classifai' ),
 			]
 		);
 	}

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -713,9 +713,9 @@ class ChatGPT extends Provider {
 			'length'                  => $excerpt_length,
 			'generate_excerpt_prompt' => array(
 				array(
-					'title'   => esc_html__( 'Default', 'classifai' ),
-					'prompt'  => '',
-					'default' => 1,
+					'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
+					'prompt'   => $this->generate_excerpt_prompt,
+					'original' => 1,
 				),
 			),
 			'enable_titles'           => false,
@@ -723,9 +723,9 @@ class ChatGPT extends Provider {
 			'number_titles'           => 1,
 			'generate_title_prompt'   => array(
 				array(
-					'title'   => esc_html__( 'Default', 'classifai' ),
-					'prompt'  => '',
-					'default' => 1,
+					'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
+					'prompt'   => $this->generate_title_prompt,
+					'original' => 1,
 				),
 			),
 			'enable_resize_content'   => false,
@@ -733,16 +733,16 @@ class ChatGPT extends Provider {
 			'number_resize_content'   => 1,
 			'shrink_content_prompt'   => array(
 				array(
-					'title'   => esc_html__( 'Default', 'classifai' ),
-					'prompt'  => '',
-					'default' => 1,
+					'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
+					'prompt'   => $this->shrink_content_prompt,
+					'original' => 1,
 				),
 			),
 			'grow_content_prompt'     => array(
 				array(
-					'title'   => esc_html__( 'Default', 'classifai' ),
-					'prompt'  => '',
-					'default' => 1,
+					'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
+					'prompt'   => $this->grow_content_prompt,
+					'original' => 1,
 				),
 			),
 		];
@@ -1219,9 +1219,10 @@ class ChatGPT extends Provider {
 				}
 
 				return array(
-					'title'   => sanitize_text_field( $prompt['title'] ),
-					'prompt'  => sanitize_textarea_field( $prompt['prompt'] ),
-					'default' => absint( $default ),
+					'title'    => sanitize_text_field( $prompt['title'] ),
+					'prompt'   => sanitize_textarea_field( $prompt['prompt'] ),
+					'default'  => absint( $default ),
+					'original' => absint( $prompt['original'] ),
 				);
 			},
 			$prompts
@@ -1251,14 +1252,14 @@ class ChatGPT extends Provider {
 			$prompt_data = array_filter(
 				$prompts,
 				function ( $prompt ) {
-					return $prompt['default'];
+					return $prompt['default'] && ! $prompt['original'];
 				}
 			);
 
 			if ( ! empty( $prompt_data ) ) {
 				$default_prompt = current( $prompt_data )['prompt'];
-			} elseif ( ! empty( $prompts[0]['prompt'] ) ) {
-				// If there is no default, use the first prompt.
+			} elseif ( ! empty( $prompts[0]['prompt'] ) && ! $prompts[0]['original'] ) {
+				// If there is no default, use the first prompt, unless it's the original prompt.
 				$default_prompt = $prompts[0]['prompt'];
 			}
 		}

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -239,7 +239,7 @@ abstract class Provider {
 	public function render_prompt_repeater_field( array $args ): void {
 		$option_index      = $args['option_index'] ?? false;
 		$setting_index     = $this->get_settings( $option_index );
-		$value             = $setting_index[ $args['label_for'] ] ?? '';
+		$prompts           = $setting_index[ $args['label_for'] ] ?? '';
 		$class             = $args['class'] ?? 'large-text';
 		$placeholder       = $args['placeholder'] ?? '';
 		$field_name_prefix = sprintf(
@@ -249,20 +249,26 @@ abstract class Provider {
 			$args['label_for']
 		);
 
-		$value = ( empty( $value ) && isset( $args['default_value'] ) ) ? $args['default_value'] : $value;
+		$prompts = empty( $prompts ) && isset( $args['default_value'] ) ? $args['default_value'] : $prompts;
 
-		$prompt_count = count( $value );
+		$prompt_count = count( $prompts );
 		$field_index  = 0;
 		?>
 
-		<?php foreach ( $value as $prompt ) : ?>
-			<?php $is_default_prompt = 1 === $prompt['default']; ?>
+		<?php foreach ( $prompts as $prompt ) : ?>
+			<?php
+			$is_default_prompt  = ( isset( $prompt['default'] ) && 1 === $prompt['default'] ) || 1 === $prompt_count;
+			$is_original_prompt = isset( $prompt['original'] ) && 1 === $prompt['original'];
+			?>
 
 			<fieldset class="classifai-field-type-prompt-setting">
 				<input type="hidden"
 					name="<?php echo esc_attr( $field_name_prefix . "[$field_index][default]" ); ?>"
 					value="<?php echo esc_attr( $prompt['default'] ?? '' ); ?>"
 					class="js-setting-field__default">
+				<input type="hidden"
+					name="<?php echo esc_attr( $field_name_prefix . "[$field_index][original]" ); ?>"
+					value="<?php echo esc_attr( $prompt['original'] ?? '' ); ?>">
 				<label>
 					<?php esc_html_e( 'Title', 'classifai' ); ?>&nbsp;*
 					<span class="dashicons dashicons-editor-help"
@@ -271,6 +277,7 @@ abstract class Provider {
 						name="<?php echo esc_attr( $field_name_prefix . "[$field_index][title]" ); ?>"
 						placeholder="<?php esc_attr_e( 'Prompt title', 'classifai' ); ?>"
 						value="<?php echo esc_attr( $prompt['title'] ?? '' ); ?>"
+						<?php echo $is_original_prompt ? 'readonly' : ''; ?>
 						required>
 				</label>
 
@@ -281,18 +288,21 @@ abstract class Provider {
 						rows="4"
 						name="<?php echo esc_attr( $field_name_prefix . "[$field_index][prompt]" ); ?>"
 						placeholder="<?php echo esc_attr( $placeholder ); ?>"
-					><?php echo esc_textarea( $prompt['prompt'] ?? '' ); ?></textarea>
+						<?php echo $is_original_prompt ? 'readonly' : ''; ?>
+					><?php echo esc_textarea( $is_original_prompt ? $placeholder : $prompt['prompt'] ?? '' ); ?></textarea>
 				</label>
 
 				<div class="actions-rows">
 					<a href="#" class="action__set_default <?php echo $is_default_prompt ? 'selected' : ''; ?>">
-						<?php if ( $is_default_prompt ) : ?>
-							<?php esc_html_e( 'Default Prompt', 'classifai' ); ?>
+						<?php if ( $is_original_prompt && $is_default_prompt ) : ?>
+							<?php esc_html_e( 'ClassifAI default prompt', 'classifai' ); ?>
+						<?php elseif ( $is_default_prompt ) : ?>
+							<?php esc_html_e( 'Default prompt', 'classifai' ); ?>
 						<?php else : ?>
 							<?php esc_html_e( 'Set as default prompt', 'classifai' ); ?>
 						<?php endif; ?>
 					</a>
-					<a href="#" class="action__remove_prompt" style="<?php echo 1 === $prompt_count ? 'display:none;' : ''; ?>">
+					<a href="#" class="action__remove_prompt" style="<?php echo 1 === $prompt_count || $is_original_prompt ? 'display:none;' : ''; ?>">
 						<?php esc_html_e( 'Trash', 'classifai' ); ?>
 					</a>
 				</div>

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -262,6 +262,20 @@ abstract class Provider {
 			?>
 
 			<fieldset class="classifai-field-type-prompt-setting">
+				<?php if ( $is_original_prompt ) : ?>
+					<p class="classifai-original-prompt">
+						<?php
+						printf(
+							/* translators: %1$s is replaced with <strong>; %2$s with </strong>; %3$s with prompt. */
+							esc_html__( '%1$sClassifAI default prompt%2$s: %3$s', 'classifai' ),
+							'<strong>',
+							'</strong>',
+							esc_html( $placeholder )
+						);
+						?>
+					</p>
+				<?php endif; ?>
+
 				<input type="hidden"
 					name="<?php echo esc_attr( $field_name_prefix . "[$field_index][default]" ); ?>"
 					value="<?php echo esc_attr( $prompt['default'] ?? '' ); ?>"
@@ -289,14 +303,12 @@ abstract class Provider {
 						name="<?php echo esc_attr( $field_name_prefix . "[$field_index][prompt]" ); ?>"
 						placeholder="<?php echo esc_attr( $placeholder ); ?>"
 						<?php echo $is_original_prompt ? 'readonly' : ''; ?>
-					><?php echo esc_textarea( $is_original_prompt ? $placeholder : $prompt['prompt'] ?? '' ); ?></textarea>
+					><?php echo esc_textarea( $prompt['prompt'] ?? '' ); ?></textarea>
 				</label>
 
 				<div class="actions-rows">
 					<a href="#" class="action__set_default <?php echo $is_default_prompt ? 'selected' : ''; ?>">
-						<?php if ( $is_original_prompt && $is_default_prompt ) : ?>
-							<?php esc_html_e( 'ClassifAI default prompt', 'classifai' ); ?>
-						<?php elseif ( $is_default_prompt ) : ?>
+						<?php if ( $is_default_prompt ) : ?>
 							<?php esc_html_e( 'Default prompt', 'classifai' ); ?>
 						<?php else : ?>
 							<?php esc_html_e( 'Set as default prompt', 'classifai' ); ?>

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -131,6 +131,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		// Reset form fields.
 		fields.forEach( ( field ) => {
 			field.value = '';
+			field.removeAttribute( 'readonly' );
 
 			// Add index to field name.
 			field.name = field.name.replace(
@@ -283,19 +284,14 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			'.classifai-field-type-prompt-setting'
 		);
 
-		// Show remove button if fieldset is single.
-		if (
-			1 === $sibling.parentElement.querySelectorAll( 'fieldset' ).length
-		) {
-			$sibling.parentElement.querySelector(
-				'.action__remove_prompt'
-			).style.display = 'block';
-		}
-
 		const $newPromptFieldset = $promptFieldsetTemplate.cloneNode( true );
 
 		resetInputFields( $newPromptFieldset, $sibling.closest( 'tr' ) );
 		attachEventPromptFieldset( $newPromptFieldset );
+
+		$newPromptFieldset.querySelector(
+			'.action__remove_prompt'
+		).style.display = 'block';
 
 		$sibling.insertAdjacentElement( 'afterend', $newPromptFieldset );
 

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -201,7 +201,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			// Set selected class.
 			e.target.classList.add( 'selected' );
 
-			e.target.textContent = __( 'Default Prompt', 'classifai' );
+			e.target.textContent = __( 'Default prompt', 'classifai' );
 
 			// Set default value.
 			$newPromptFieldset.querySelector(

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -289,6 +289,10 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		resetInputFields( $newPromptFieldset, $sibling.closest( 'tr' ) );
 		attachEventPromptFieldset( $newPromptFieldset );
 
+		$newPromptFieldset
+			.querySelector( '.classifai-original-prompt' )
+			.remove();
+
 		$newPromptFieldset.querySelector(
 			'.action__remove_prompt'
 		).style.display = 'block';

--- a/src/scss/admin.scss
+++ b/src/scss/admin.scss
@@ -251,7 +251,7 @@ input.classifai-button {
 			line-height: 1.4;
 		}
 
-		.classifai-field-type-prompt-setting{
+		.classifai-field-type-prompt-setting {
 			padding: 5px 20px;
 			border: 1px solid #f0f0f1;
 			position: relative;
@@ -259,15 +259,15 @@ input.classifai-button {
 			flex-direction:column;
 			max-width: 600px;
 
-			&:nth-child(2n + 1){
+			&:nth-child(2n + 1) {
 				background-color: #f0f0f1;
 			}
 
-			label{
+			label {
 				display: block;
 			}
 
-			input, textarea{
+			input, textarea {
 				margin-right: 0;
 				display: block;
 			}
@@ -276,45 +276,53 @@ input.classifai-button {
 				width: 90%;
 			}
 
+			input:read-only,
+			textarea:read-only {
+				background: rgba(255,255,255,.5);
+				border-color: rgba(220,220,222,.75);
+				box-shadow: inset 0 1px 2px rgba(0,0,0,.04);
+				color: rgba(44,51,56,.5);
+			}
+
 			/* Style for prompt action items container */
-			.actions-rows{
+			.actions-rows {
 				display: flex;
 				margin: 0.35em 0 .5em!important;
 
 				/* Style for prompt actions */
-				a{
+				a {
 					cursor: pointer;
 					text-decoration: none;
 					margin-left: 8px;
 
-					&.action__remove_prompt{
+					&.action__remove_prompt {
 						color: #b32d2e;
 					}
 				}
 
 				/* action items separator */
-				a:before{
+				a:before {
 					content: '|';
 					color: #a7aaad;
 				}
 
 				/* Styling for default prompt first action */
-				a:first-child{
+				a:first-child {
 					margin-left: 0;
 
-					&.selected{
+					&.selected {
 						color: #a7aaad;
 						pointer-events: none;
 					}
 
-					&:before{
+					&:before {
 						content: '';
 					}
 				}
 
 			}
 
-			+ button{
+			+ button {
 				margin-top: 10px;
 			}
 		}

--- a/src/scss/admin.scss
+++ b/src/scss/admin.scss
@@ -259,6 +259,13 @@ input.classifai-button {
 			flex-direction:column;
 			max-width: 600px;
 
+			&:first-child {
+				> input,
+				> label {
+					display: none;
+				}
+			}
+
 			&:nth-child(2n + 1) {
 				background-color: #f0f0f1;
 			}
@@ -274,14 +281,6 @@ input.classifai-button {
 
 			input[type="text"] {
 				width: 90%;
-			}
-
-			input:read-only,
-			textarea:read-only {
-				background: rgba(255,255,255,.5);
-				border-color: rgba(220,220,222,.75);
-				box-shadow: inset 0 1px 2px rgba(0,0,0,.04);
-				color: rgba(44,51,56,.5);
 			}
 
 			/* Style for prompt action items container */

--- a/tests/cypress/integration/language-processing.test.js
+++ b/tests/cypress/integration/language-processing.test.js
@@ -261,65 +261,6 @@ describe( 'Language processing Tests', () => {
 		cy.get( '#deactivate-classic-editor' ).click();
 	} );
 
-	it( 'Can set a custom excerpt generation prompt', () => {
-		cy.visit(
-			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=openai_chatgpt'
-		);
-
-		cy.get(
-			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][0][title]"]'
-		)
-			.clear()
-			.type( 'Custom prompt' );
-		cy.get(
-			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][0][prompt]"]'
-		)
-			.clear()
-			.type( 'This is a custom excerpt prompt' );
-		cy.get( '#submit' ).click();
-
-		const data = getChatGPTData( 'excerpt' );
-
-		// Create test post.
-		cy.createPost( {
-			title: 'Test ChatGPT post',
-			content: 'Test GPT content',
-		} );
-
-		// Close post publish panel.
-		const closePanelSelector = 'button[aria-label="Close panel"]';
-		cy.get( 'body' ).then( ( $body ) => {
-			if ( $body.find( closePanelSelector ).length > 0 ) {
-				cy.get( closePanelSelector ).click();
-			}
-		} );
-
-		// Open post settings sidebar.
-		cy.openDocumentSettingsSidebar();
-
-		// Find and open the excerpt panel.
-		const panelButtonSelector = `.components-panel__body .components-panel__body-title button:contains("Excerpt")`;
-
-		cy.get( panelButtonSelector ).then( ( $panelButton ) => {
-			// Find the panel container.
-			const $panel = $panelButton.parents( '.components-panel__body' );
-
-			// Open panel.
-			if ( ! $panel.hasClass( 'is-opened' ) ) {
-				cy.wrap( $panelButton ).click();
-			}
-
-			// Verify button exists.
-			cy.wrap( $panel )
-				.find( '.editor-post-excerpt button' )
-				.should( 'exist' );
-
-			// Click on button and verify data loads in.
-			cy.wrap( $panel ).find( '.editor-post-excerpt button' ).click();
-			cy.wrap( $panel ).find( 'textarea' ).should( 'have.value', data );
-		} );
-	} );
-
 	it( 'Can set multiple custom excerpt generation prompts, select one as the default and delete one.', () => {
 		cy.visit(
 			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=openai_chatgpt'
@@ -332,50 +273,51 @@ describe( 'Language processing Tests', () => {
 			.parents( 'td:first' )
 			.find( 'button.js-classifai-add-prompt-fieldset' )
 			.click()
+			.click()
 			.click();
 		cy.get(
 			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][0][default]"]'
 		)
 			.parents( 'td' )
 			.find( '.classifai-field-type-prompt-setting' )
-			.should( 'have.length', 3 );
+			.should( 'have.length', 4 );
 
 		// Set the data for each prompt.
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][0][title]"]'
+			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][1][title]"]'
 		)
 			.clear()
 			.type( 'First custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][0][prompt]"]'
+			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][1][prompt]"]'
 		)
 			.clear()
 			.type( 'This is our first custom excerpt prompt' );
 
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][1][title]"]'
+			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][2][title]"]'
 		)
 			.clear()
 			.type( 'Second custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][1][prompt]"]'
+			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][2][prompt]"]'
 		)
 			.clear()
 			.type( 'This prompt should be deleted' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][2][title]"]'
+			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][3][title]"]'
 		)
 			.clear()
 			.type( 'Third custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][2][prompt]"]'
+			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][3][prompt]"]'
 		)
 			.clear()
 			.type( 'This is a custom excerpt prompt' );
 
 		// Set the third prompt as our default.
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][2][default]"]'
+			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][3][default]"]'
 		)
 			.parent()
 			.find( 'a.action__set_default' )
@@ -383,7 +325,7 @@ describe( 'Language processing Tests', () => {
 
 		// Delete the second prompt.
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][1][default]"]'
+			'[name="classifai_openai_chatgpt[generate_excerpt_prompt][2][default]"]'
 		)
 			.parent()
 			.find( 'a.action__remove_prompt' )
@@ -396,7 +338,7 @@ describe( 'Language processing Tests', () => {
 		)
 			.parents( 'td:first' )
 			.find( '.classifai-field-type-prompt-setting' )
-			.should( 'have.length', 2 );
+			.should( 'have.length', 3 );
 
 		cy.get( '#submit' ).click();
 
@@ -792,85 +734,6 @@ describe( 'Language processing Tests', () => {
 		cy.get( '#deactivate-classic-editor' ).click();
 	} );
 
-	it( 'Can set a custom title generation prompt', () => {
-		cy.visit(
-			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=openai_chatgpt'
-		);
-
-		cy.get(
-			'[name="classifai_openai_chatgpt[generate_title_prompt][0][title]"]'
-		)
-			.clear()
-			.type( 'Custom prompt' );
-		cy.get(
-			'[name="classifai_openai_chatgpt[generate_title_prompt][0][prompt]"]'
-		)
-			.clear()
-			.type( 'This is a custom title prompt' );
-		cy.get( '#submit' ).click();
-
-		const data = getChatGPTData( 'title' );
-
-		// Create test post.
-		cy.createPost( {
-			title: 'Test ChatGPT generate titles',
-			content: 'Test content',
-		} );
-
-		// Close post publish panel.
-		const closePanelSelector = 'button[aria-label="Close panel"]';
-		cy.get( 'body' ).then( ( $body ) => {
-			if ( $body.find( closePanelSelector ).length > 0 ) {
-				cy.get( closePanelSelector ).click();
-			}
-		} );
-
-		// Open post settings sidebar.
-		cy.openDocumentSettingsSidebar();
-
-		// Find and open the summary panel.
-		const panelButtonSelector = `.components-panel__body.edit-post-post-status .components-panel__body-title button`;
-
-		cy.get( panelButtonSelector ).then( ( $panelButton ) => {
-			// Find the panel container.
-			const $panel = $panelButton.parents( '.components-panel__body' );
-
-			// Open panel.
-			if ( ! $panel.hasClass( 'is-opened' ) ) {
-				cy.wrap( $panelButton ).click();
-			}
-
-			// Verify button exists.
-			cy.wrap( $panel )
-				.find( '.classifai-post-status button.title' )
-				.should( 'exist' );
-
-			// Click on button and verify modal shows.
-			cy.wrap( $panel )
-				.find( '.classifai-post-status button.title' )
-				.click();
-		} );
-
-		cy.get( '.title-modal' ).should( 'exist' );
-
-		// Click on button and verify data loads in.
-		cy.get( '.title-modal .classifai-title' )
-			.first()
-			.find( 'textarea' )
-			.should( 'have.value', data );
-		cy.get( '.title-modal .classifai-title' )
-			.first()
-			.find( 'button' )
-			.click();
-
-		cy.get( '.title-modal' ).should( 'not.exist' );
-		cy.getBlockEditor()
-			.find( '.editor-post-title__input' )
-			.should( ( $el ) => {
-				expect( $el.first() ).to.contain( data );
-			} );
-	} );
-
 	it( 'Can set multiple custom title generation prompts, select one as the default and delete one.', () => {
 		cy.visit(
 			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=openai_chatgpt'
@@ -883,50 +746,51 @@ describe( 'Language processing Tests', () => {
 			.parents( 'td:first' )
 			.find( 'button.js-classifai-add-prompt-fieldset' )
 			.click()
+			.click()
 			.click();
 		cy.get(
 			'[name="classifai_openai_chatgpt[generate_title_prompt][0][default]"]'
 		)
 			.parents( 'td:first' )
 			.find( '.classifai-field-type-prompt-setting' )
-			.should( 'have.length', 3 );
+			.should( 'have.length', 4 );
 
 		// Set the data for each prompt.
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_title_prompt][0][title]"]'
+			'[name="classifai_openai_chatgpt[generate_title_prompt][1][title]"]'
 		)
 			.clear()
 			.type( 'First custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_title_prompt][0][prompt]"]'
+			'[name="classifai_openai_chatgpt[generate_title_prompt][1][prompt]"]'
 		)
 			.clear()
 			.type( 'This is our first custom title prompt' );
 
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_title_prompt][1][title]"]'
+			'[name="classifai_openai_chatgpt[generate_title_prompt][2][title]"]'
 		)
 			.clear()
 			.type( 'Second custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_title_prompt][1][prompt]"]'
+			'[name="classifai_openai_chatgpt[generate_title_prompt][2][prompt]"]'
 		)
 			.clear()
 			.type( 'This prompt should be deleted' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_title_prompt][2][title]"]'
+			'[name="classifai_openai_chatgpt[generate_title_prompt][3][title]"]'
 		)
 			.clear()
 			.type( 'Third custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_title_prompt][2][prompt]"]'
+			'[name="classifai_openai_chatgpt[generate_title_prompt][3][prompt]"]'
 		)
 			.clear()
 			.type( 'This is a custom title prompt' );
 
 		// Set the third prompt as our default.
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_title_prompt][2][default]"]'
+			'[name="classifai_openai_chatgpt[generate_title_prompt][3][default]"]'
 		)
 			.parent()
 			.find( 'a.action__set_default' )
@@ -934,7 +798,7 @@ describe( 'Language processing Tests', () => {
 
 		// Delete the second prompt.
 		cy.get(
-			'[name="classifai_openai_chatgpt[generate_title_prompt][1][default]"]'
+			'[name="classifai_openai_chatgpt[generate_title_prompt][2][default]"]'
 		)
 			.parent()
 			.find( 'a.action__remove_prompt' )
@@ -947,7 +811,7 @@ describe( 'Language processing Tests', () => {
 		)
 			.parents( 'td:first' )
 			.find( '.classifai-field-type-prompt-setting' )
-			.should( 'have.length', 2 );
+			.should( 'have.length', 3 );
 
 		cy.get( '#submit' ).click();
 
@@ -1261,81 +1125,6 @@ describe( 'Language processing Tests', () => {
 			);
 	} );
 
-	it( 'Can set a custom grow and shrink prompt', () => {
-		cy.visit(
-			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=openai_chatgpt'
-		);
-
-		cy.get(
-			'[name="classifai_openai_chatgpt[shrink_content_prompt][0][title]"]'
-		)
-			.clear()
-			.type( 'Custom prompt' );
-		cy.get(
-			'[name="classifai_openai_chatgpt[shrink_content_prompt][0][prompt]"]'
-		)
-			.clear()
-			.type( 'This is a custom shrink prompt' );
-		cy.get(
-			'[name="classifai_openai_chatgpt[grow_content_prompt][0][title]"]'
-		)
-			.clear()
-			.type( 'Custom prompt' );
-		cy.get(
-			'[name="classifai_openai_chatgpt[grow_content_prompt][0][prompt]"]'
-		)
-			.clear()
-			.type( 'This is a custom grow prompt' );
-		cy.get( '#submit' ).click();
-
-		cy.createPost( {
-			title: 'Resize content',
-			content: 'Hello, world.',
-		} );
-
-		cy.get( '.classifai-resize-content-btn' ).click();
-		cy.get( '.components-button' ).contains( 'Expand this text' ).click();
-		cy.get(
-			'.classifai-content-resize__result-table tbody tr:first .classifai-content-resize__grow-stat'
-		).should( 'contain.text', '+6 words' );
-		cy.get(
-			'.classifai-content-resize__result-table tbody tr:first .classifai-content-resize__grow-stat'
-		).should( 'contain.text', '+31 characters' );
-		cy.get(
-			'.classifai-content-resize__result-table tbody tr:first button'
-		).click();
-		cy.getBlockEditor()
-			.find( '[data-type="core/paragraph"]' )
-			.should(
-				'contain.text',
-				'Start with the basic block of one narrative.'
-			);
-
-		cy.createPost( {
-			title: 'Resize content',
-			content:
-				'Start with the basic building block of one narrative to begin with the editorial process.',
-		} );
-
-		cy.get( '.classifai-resize-content-btn' ).click();
-		cy.get( '.components-button' ).contains( 'Condense this text' ).click();
-		cy.get(
-			'.classifai-content-resize__result-table tbody tr:first .classifai-content-resize__shrink-stat'
-		).should( 'contain.text', '-7 words' );
-		cy.get(
-			'.classifai-content-resize__result-table tbody tr:first .classifai-content-resize__shrink-stat'
-		).should( 'contain.text', '-45 characters' );
-		cy.get(
-			'.classifai-content-resize__result-table tbody tr:first button'
-		).click();
-		cy.getBlockEditor()
-			.find( '[data-type="core/paragraph"]' )
-			.should(
-				'contain.text',
-				'Start with the basic block of one narrative.'
-			);
-	} );
-
 	it( 'Can set multiple custom resize generation prompts, select one as the default and delete one.', () => {
 		cy.visit(
 			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=openai_chatgpt'
@@ -1348,13 +1137,14 @@ describe( 'Language processing Tests', () => {
 			.parents( 'td:first' )
 			.find( 'button.js-classifai-add-prompt-fieldset' )
 			.click()
+			.click()
 			.click();
 		cy.get(
 			'[name="classifai_openai_chatgpt[shrink_content_prompt][0][default]"]'
 		)
 			.parents( 'td:first' )
 			.find( '.classifai-field-type-prompt-setting' )
-			.should( 'have.length', 3 );
+			.should( 'have.length', 4 );
 
 		// Add three custom grow prompts.
 		cy.get(
@@ -1363,87 +1153,88 @@ describe( 'Language processing Tests', () => {
 			.parents( 'td:first' )
 			.find( 'button.js-classifai-add-prompt-fieldset:first' )
 			.click()
+			.click()
 			.click();
 		cy.get(
 			'[name="classifai_openai_chatgpt[grow_content_prompt][0][default]"]'
 		)
 			.parents( 'td:first' )
 			.find( '.classifai-field-type-prompt-setting' )
-			.should( 'have.length', 3 );
+			.should( 'have.length', 4 );
 
 		// Set the data for each prompt.
 		cy.get(
-			'[name="classifai_openai_chatgpt[shrink_content_prompt][0][title]"]'
+			'[name="classifai_openai_chatgpt[shrink_content_prompt][1][title]"]'
 		)
 			.clear()
 			.type( 'First custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[shrink_content_prompt][0][prompt]"]'
+			'[name="classifai_openai_chatgpt[shrink_content_prompt][1][prompt]"]'
 		)
 			.clear()
 			.type( 'This is our first custom shrink prompt' );
 
 		cy.get(
-			'[name="classifai_openai_chatgpt[shrink_content_prompt][1][title]"]'
+			'[name="classifai_openai_chatgpt[shrink_content_prompt][2][title]"]'
 		)
 			.clear()
 			.type( 'Second custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[shrink_content_prompt][1][prompt]"]'
+			'[name="classifai_openai_chatgpt[shrink_content_prompt][2][prompt]"]'
 		)
 			.clear()
 			.type( 'This prompt should be deleted' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[shrink_content_prompt][2][title]"]'
+			'[name="classifai_openai_chatgpt[shrink_content_prompt][3][title]"]'
 		)
 			.clear()
 			.type( 'Third custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[shrink_content_prompt][2][prompt]"]'
+			'[name="classifai_openai_chatgpt[shrink_content_prompt][3][prompt]"]'
 		)
 			.clear()
 			.type( 'This is a custom shrink prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[grow_content_prompt][0][title]"]'
+			'[name="classifai_openai_chatgpt[grow_content_prompt][1][title]"]'
 		)
 			.clear()
 			.type( 'First custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[grow_content_prompt][0][prompt]"]'
+			'[name="classifai_openai_chatgpt[grow_content_prompt][1][prompt]"]'
 		)
 			.clear()
 			.type( 'This is our first custom grow prompt' );
 
 		cy.get(
-			'[name="classifai_openai_chatgpt[grow_content_prompt][1][title]"]'
+			'[name="classifai_openai_chatgpt[grow_content_prompt][2][title]"]'
 		)
 			.clear()
 			.type( 'Second custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[grow_content_prompt][1][prompt]"]'
+			'[name="classifai_openai_chatgpt[grow_content_prompt][2][prompt]"]'
 		)
 			.clear()
 			.type( 'This prompt should be deleted' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[grow_content_prompt][2][title]"]'
+			'[name="classifai_openai_chatgpt[grow_content_prompt][3][title]"]'
 		)
 			.clear()
 			.type( 'Third custom prompt' );
 		cy.get(
-			'[name="classifai_openai_chatgpt[grow_content_prompt][2][prompt]"]'
+			'[name="classifai_openai_chatgpt[grow_content_prompt][3][prompt]"]'
 		)
 			.clear()
 			.type( 'This is a custom grow prompt' );
 
 		// Set the third prompt as our default.
 		cy.get(
-			'[name="classifai_openai_chatgpt[shrink_content_prompt][2][default]"]'
+			'[name="classifai_openai_chatgpt[shrink_content_prompt][3][default]"]'
 		)
 			.parent()
 			.find( 'a.action__set_default' )
 			.click( { force: true } );
 		cy.get(
-			'[name="classifai_openai_chatgpt[grow_content_prompt][2][default]"]'
+			'[name="classifai_openai_chatgpt[grow_content_prompt][3][default]"]'
 		)
 			.parent()
 			.find( 'a.action__set_default' )
@@ -1451,7 +1242,7 @@ describe( 'Language processing Tests', () => {
 
 		// Delete the second prompt.
 		cy.get(
-			'[name="classifai_openai_chatgpt[shrink_content_prompt][1][default]"]'
+			'[name="classifai_openai_chatgpt[shrink_content_prompt][2][default]"]'
 		)
 			.parent()
 			.find( 'a.action__remove_prompt' )
@@ -1464,9 +1255,9 @@ describe( 'Language processing Tests', () => {
 		)
 			.parents( 'td:first' )
 			.find( '.classifai-field-type-prompt-setting' )
-			.should( 'have.length', 2 );
+			.should( 'have.length', 3 );
 		cy.get(
-			'[name="classifai_openai_chatgpt[grow_content_prompt][1][default]"]'
+			'[name="classifai_openai_chatgpt[grow_content_prompt][2][default]"]'
 		)
 			.parent()
 			.find( 'a.action__remove_prompt' )
@@ -1479,7 +1270,7 @@ describe( 'Language processing Tests', () => {
 		)
 			.parents( 'td:first' )
 			.find( '.classifai-field-type-prompt-setting' )
-			.should( 'have.length', 2 );
+			.should( 'have.length', 3 );
 
 		cy.get( '#submit' ).click();
 


### PR DESCRIPTION
### Description of the Change

Following on from #602, this PR ensures that our default prompt within ClassifAI always shows as the first prompt in our settings. This prompt can't be edited and can't be removed. This makes it easier for someone to go back to using the ClassifAI default prompt.

Important to note that to keep things simple, this ClassifAI default prompt is added and saved just like any other prompt. This does mean the prompt itself is saved in the database. In order to support situations where we may change the default prompt at a code-level, if this prompt is selected, instead of using the prompt text that is stored in the database, we use the prompt that is in the code.

The new flow will be as follows:

When first setting up a feature that uses prompts (like Title Generation), the only prompt you'll see is the default that is included in ClassifAI. The prompt fields are there but hidden (this allows us to save this as the default prompt):

![Default prompt](https://github.com/10up/classifai/assets/916738/6552c0a1-80ae-4cb0-9bd9-0c69c55720a2)

If a custom prompt is needed, instead of editing the default prompt (which is how things landed in #602), you'll now need to click the `Add new prompt` button and then set a custom prompt in the fields that are added. In addition, to use the new prompt, you'll need to set that as the default:

![New prompt added](https://github.com/10up/classifai/assets/916738/2382e204-786c-444b-9f8c-7752d6086251)

You can add as many new prompts as needed, set whichever of those you want to be the default and delete any of those prompts. But you can't ever delete the ClassifAI default prompt but you can at any point set that as the default again.

### How to test the Change

1. Checkout the changes in this PR
2. If you've previously tested #602, you may need to delete the existing prompt data (easiest is to delete the `openai_chatgpt` option)
3. Ensure you have proper OpenAI credentials in place and at least one feature turned on (like excerpt generation)
4. Without entering a new prompt, test that feature out and ensure it works
5. Add a new prompt but don't set it as the default. Ensure things save and test the feature out again, ensuring it works
6. Set this new prompt as the default and ensure it saves and the feature still works
7. Can continue testing by adding more prompts across all the various features, ensuring you can change which one is the default and can delete prompts
8. Ensure you can set the ClassifAI default as the default prompt again and that the feature works
9. If desired, you can add some logging or debug statements in any of the features to ensure the prompt that gets used is the prompt you're setting as the default

### Changelog Entry

> Changed - Ensure the default prompts in ClassifAI show as the first prompt in our settings and that they can't be removed or edited.

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
