### PR TITLE
Prepare for the new GPT 3.5 Turbo model

### DIFF
--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -33,7 +33,7 @@ class ChatGPT extends Provider {
 	 *
 	 * @var int
 	 */
-	protected $max_tokens = 4096;
+	protected $max_tokens = 16385;
 
 	/**
 	 * Prompt for generating excerpts


### PR DESCRIPTION
### Description of the Change

As part of their dev day last week, OpenAI [announced](https://openai.com/blog/new-models-and-developer-products-announced-at-devday) that the base GPT 3.5 Turbo model will be updated to support 16K context length starting on December 11th.

This model can be used now by referencing `gpt-3.5-turbo-1106` instead of the generic `gpt-3.5-turbo` and I had considered doing this but by keeping our reference to `gpt-3.5-turbo`, this will ensure we are always using the latest version of that model, which I would prefer.

This PR just changes the max content length we consider, from the [previous of 4,096 to the new of 16,385](https://platform.openai.com/docs/models/gpt-3-5). This PR should be merged and released sometime between now and December 11th when this becomes the new default context length (not a huge risk to release this sooner, could mean users run into max token length errors though).

### How to test the Change

Verify any OpenAI ChatGPT features still work as expected

### Changelog Entry

> Changed - Increase our max content length for any interactions with ChatGPT

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
