### PR TITLE
Classify content within existing Taxonomy terms

### DIFF
--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -199,6 +199,21 @@ function get_classification_mode() {
 }
 
 /**
+ * Get IBM Watson Content Classification method.
+ *
+ * @since 2.6.0
+ *
+ * @return string
+ */
+function get_classification_method() {
+	$provider = new NLU( 'language_processing' );
+	$settings = $provider->get_settings();
+	$value    = $settings['classification_method'] ?? '';
+
+	return $value;
+}
+
+/**
  * Returns the currently configured Watson username. Lookup order is,
  *
  * - Options

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -399,9 +399,13 @@ abstract class Provider {
 	 */
 	public function render_checkbox_group( array $args = array() ) {
 		$setting_index = $this->get_settings();
+		$options       = $args['options'] ?? [];
+		if ( ! is_array( $options ) ) {
+			return;
+		}
 
 		// Iterate through all of our options.
-		foreach ( $args['options'] as $option_value => $option_label ) {
+		foreach ( $options as $option_value => $option_label ) {
 			$value       = '';
 			$default_key = array_search( $option_value, $args['default_values'], true );
 
@@ -454,9 +458,13 @@ abstract class Provider {
 	public function render_radio_group( array $args = array() ) {
 		$setting_index = $this->get_settings();
 		$value         = $setting_index[ $args['label_for'] ] ?? '';
+		$options       = $args['options'] ?? [];
+		if ( ! is_array( $options ) ) {
+			return;
+		}
 
 		// Iterate through all of our options.
-		foreach ( $args['options'] as $option_value => $option_label ) {
+		foreach ( $options as $option_value => $option_label ) {
 			// Render radio button.
 			printf(
 				'<p>

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -447,6 +447,42 @@ abstract class Provider {
 	}
 
 	/**
+	 * Render a group of radio.
+	 *
+	 * @param array $args The args passed to add_settings_field
+	 */
+	public function render_radio_group( array $args = array() ) {
+		$setting_index = $this->get_settings();
+		$value         = $setting_index[ $args['label_for'] ] ?? '';
+
+		// Iterate through all of our options.
+		foreach ( $args['options'] as $option_value => $option_label ) {
+			// Render radio button.
+			printf(
+				'<p>
+					<label for="%1$s_%2$s_%3$s">
+						<input type="radio" id="%1$s_%2$s_%3$s" name="classifai_%1$s[%2$s]" value="%3$s" %4$s />
+						%5$s
+					</label>
+				</p>',
+				esc_attr( $this->option_name ),
+				esc_attr( $args['label_for'] ),
+				esc_attr( $option_value ),
+				checked( $value, $option_value, false ),
+				esc_html( $option_label )
+			);
+		}
+
+		// Render description, if any.
+		if ( ! empty( $args['description'] ) ) {
+			printf(
+				'<span class="description">%s</span>',
+				esc_html( $args['description'] )
+			);
+		}
+	}
+
+	/**
 	 * Renders the checkbox group for 'Generate descriptive text' setting.
 	 *
 	 * @param array $args The args passed to add_settings_field.

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -466,8 +466,8 @@ class NLU extends Provider {
 				'label_for'     => 'classification_method',
 				'default_value' => $default_settings['classification_method'],
 				'options'       => array(
-					'recommended_terms' => __( 'Add all suggested terms', 'classifai' ),
-					'existing_terms'    => __( 'Only add suggested terms that already exist', 'classifai' ),
+					'recommended_terms' => __( 'Recommend terms even if they do not exist on the site', 'classifai' ),
+					'existing_terms'    => __( 'Only recommend terms that already exist on the site', 'classifai' ),
 				),
 			]
 		);

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -446,7 +446,7 @@ class NLU extends Provider {
 		$this->add_access_settings( 'content_classification' );
 		add_settings_field(
 			'classification-mode',
-			esc_html__( 'Classification Mode', 'classifai' ),
+			esc_html__( 'Classification mode', 'classifai' ),
 			[ $this, 'render_classification_mode_radios' ],
 			$this->get_option_name(),
 			$this->get_option_name(),
@@ -458,7 +458,7 @@ class NLU extends Provider {
 
 		add_settings_field(
 			'classification-method',
-			esc_html__( 'Classification Method', 'classifai' ),
+			esc_html__( 'Classification method', 'classifai' ),
 			[ $this, 'render_radio_group' ],
 			$this->get_option_name(),
 			$this->get_option_name(),
@@ -466,8 +466,8 @@ class NLU extends Provider {
 				'label_for'     => 'classification_method',
 				'default_value' => $default_settings['classification_method'],
 				'options'       => array(
-					'recommended_terms' => __( 'Add recommended terms', 'classifai' ),
-					'existing_terms'    => __( 'Only classify based on existing terms', 'classifai' ),
+					'recommended_terms' => __( 'Add all suggested terms', 'classifai' ),
+					'existing_terms'    => __( 'Only add suggested terms that already exist', 'classifai' ),
 				),
 			]
 		);

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -137,6 +137,7 @@ class NLU extends Provider {
 					'entity_threshold'   => WATSON_ENTITY_THRESHOLD,
 					'entity_taxonomy'    => WATSON_ENTITY_TAXONOMY,
 				],
+				'classification_method'         => 'recommended_terms',
 			]
 		);
 	}
@@ -452,6 +453,22 @@ class NLU extends Provider {
 			[
 				'option_index' => 'classification_mode',
 				'input_type'   => 'radio',
+			]
+		);
+
+		add_settings_field(
+			'classification-method',
+			esc_html__( 'Classification Method', 'classifai' ),
+			[ $this, 'render_radio_group' ],
+			$this->get_option_name(),
+			$this->get_option_name(),
+			[
+				'label_for'     => 'classification_method',
+				'default_value' => $default_settings['classification_method'],
+				'options'       => array(
+					'recommended_terms' => __( 'Add recommended terms', 'classifai' ),
+					'existing_terms'    => __( 'Only classify based on existing terms', 'classifai' ),
+				),
 			]
 		);
 
@@ -805,6 +822,10 @@ class NLU extends Provider {
 
 		if ( isset( $settings['classification_mode'] ) ) {
 			$new_settings['classification_mode'] = sanitize_text_field( $settings['classification_mode'] );
+		}
+
+		if ( isset( $settings['classification_method'] ) ) {
+			$new_settings['classification_method'] = sanitize_text_field( $settings['classification_method'] );
 		}
 
 		// Sanitize the post type checkboxes

--- a/includes/Classifai/Watson/Linker.php
+++ b/includes/Classifai/Watson/Linker.php
@@ -2,6 +2,8 @@
 
 namespace Classifai\Watson;
 
+use function Classifai\get_classification_method;
+
 /**
  * Linker connects Watson classification results with Taxonomy Terms.
  *
@@ -93,8 +95,9 @@ class Linker {
 	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
 	public function link_categories( int $post_id, array $categories, bool $link_categories = true ) {
-		$terms_to_link = [];
-		$taxonomy      = \Classifai\get_feature_taxonomy( 'category' );
+		$terms_to_link           = [];
+		$taxonomy                = \Classifai\get_feature_taxonomy( 'category' );
+		$classify_existing_terms = 'existing_terms' === get_classification_method();
 
 		foreach ( $categories as $category ) {
 			if ( $this->can_link_category( $category ) ) {
@@ -106,6 +109,11 @@ class Linker {
 
 					foreach ( $parts as $part ) {
 						$term = get_term_by( 'name', $part, $taxonomy );
+
+						// Skip if the term is not found and we are classifying based on existing terms.
+						if ( $classify_existing_terms && false === $term ) {
+							continue;
+						}
 
 						if ( false === $term ) {
 							$term = wp_insert_term( $part, $taxonomy, [ 'parent' => $parent ] );
@@ -156,14 +164,20 @@ class Linker {
 	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
 	public function link_keywords( int $post_id, array $keywords, bool $link_keywords = true ) {
-		$terms_to_link = [];
-		$taxonomy      = \Classifai\get_feature_taxonomy( 'keyword' );
+		$terms_to_link           = [];
+		$taxonomy                = \Classifai\get_feature_taxonomy( 'keyword' );
+		$classify_existing_terms = 'existing_terms' === get_classification_method();
 
 		foreach ( $keywords as $keyword ) {
 			if ( $this->can_link_keyword( $keyword ) ) {
 				$name = $keyword['text'];
 				$name = preg_replace( '#^[a-z]+ ([A-Z].*)$#', '$1', $name );
 				$term = get_term_by( 'name', $name, $taxonomy );
+
+				// Skip if the term is not found and we are classifying based on existing terms.
+				if ( $classify_existing_terms && false === $term ) {
+					continue;
+				}
 
 				if ( false === $term ) {
 					$term = wp_insert_term( $name, $taxonomy, [] );
@@ -210,13 +224,19 @@ class Linker {
 	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
 	public function link_concepts( int $post_id, array $concepts, bool $link_concepts = true ) {
-		$terms_to_link = [];
-		$taxonomy      = \Classifai\get_feature_taxonomy( 'concept' );
+		$terms_to_link           = [];
+		$taxonomy                = \Classifai\get_feature_taxonomy( 'concept' );
+		$classify_existing_terms = 'existing_terms' === get_classification_method();
 
 		foreach ( $concepts as $concept ) {
 			if ( $this->can_link_concept( $concept ) ) {
 				$name = $concept['text'];
 				$term = get_term_by( 'name', $name, $taxonomy );
+
+				// Skip if the term is not found and we are classifying based on existing terms.
+				if ( $classify_existing_terms && false === $term ) {
+					continue;
+				}
 
 				if ( false === $term ) {
 					$term = wp_insert_term( $name, $taxonomy, [] );
@@ -271,8 +291,9 @@ class Linker {
 	 * @return array|\WP_Error List of the terms to link. WP_Error class object on error.
 	 */
 	public function link_entities( int $post_id, array $entities, bool $link_entities = true ) {
-		$terms_to_link = [];
-		$taxonomy      = \Classifai\get_feature_taxonomy( 'entity' );
+		$terms_to_link           = [];
+		$taxonomy                = \Classifai\get_feature_taxonomy( 'entity' );
+		$classify_existing_terms = 'existing_terms' === get_classification_method();
 
 		foreach ( $entities as $entity ) {
 			if ( $this->can_link_entity( $entity ) ) {
@@ -283,6 +304,11 @@ class Linker {
 				}
 
 				$term = get_term_by( 'name', $name, $taxonomy );
+
+				// Skip if the term is not found and we are classifying based on existing terms.
+				if ( $classify_existing_terms && false === $term ) {
+					continue;
+				}
 
 				if ( false === $term ) {
 					$term = wp_insert_term( $name, $taxonomy, [] );

--- a/tests/cypress/integration/language-processing/classify-content-ibm-watson.test.js
+++ b/tests/cypress/integration/language-processing/classify-content-ibm-watson.test.js
@@ -401,7 +401,7 @@ describe( '[Language processing] Classify content (IBM Watson - NLU) Tests', () 
 	} );
 
 	it( 'Can create post and tags get created by ClassifAI', () => {
-		const threshold = 75;
+		const threshold = 70;
 		cy.visit(
 			'/wp-admin/tools.php?page=classifai&tab=language_processing'
 		);

--- a/tests/test-plugin/e2e-test-plugin.php
+++ b/tests/test-plugin/e2e-test-plugin.php
@@ -112,3 +112,35 @@ function classifai_test_prepare_response( $response ) {
 if ( ! defined( 'FS_METHOD' ) ) {
 	define( 'FS_METHOD', 'direct' );
 }
+
+// Add a route to clean taxonomy terms.
+add_action(
+	'rest_api_init',
+	function () {
+		register_rest_route(
+			'classifai/v1',
+			'clean/taxonomy-terms',
+			array(
+				'methods'  => 'GET',
+				'callback' => function() {
+					$taxonomies = ['watson-category', 'watson-concept', 'watson-entity', 'watson-keyword'];
+
+					foreach ( $taxonomies as $taxonomy ) {
+						$terms = get_terms(
+							array(
+								'taxonomy'   => $taxonomy,
+								'hide_empty' => false,
+							)
+						);
+
+						foreach ( $terms as $term ) {
+							wp_delete_term( $term->term_id, $taxonomy );
+						}
+					}
+
+					return true;
+				},
+			)
+		);
+	}
+);


### PR DESCRIPTION
### Description of the Change
The PR introduces a new setting option in content classification (IBM Watson NLU) to classify content within existing taxonomy terms. By default, it will adhere to the current behavior, recommending and adding new terms to the post. When the user chooses "Only classify based on existing terms" in the classification method, it will recommend terms only from the existing terms.

![image](https://github.com/10up/classifai/assets/10613171/bbae2345-7048-404d-bd7e-5062434f6670)

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #592 

### How to test the Change
1. Go to `Tools` > `ClassifAI` > `Language Processing` > `IBM Watson`
1. Choose "Only classify based on existing terms" in the classification method.
1. Create/Edit the post and click the "Suggest terms & tags" button from the classifAI sidebar panel.
1. Verify that suggested terms/tags are from the existing terms only.
1. Go to ClassifAI settings, choose "Add recommended terms " in the classification method and verify that it now suggests new terms/tags as well.
1. Go to ClassifAI settings, and verify that the results of terms/tags in the language processing previewer are also aligned with the current classification method setting.

### Changelog Entry
> Added - New setting option in content classification to classify content within existing taxonomy terms


### Credits
Props @jeffpaul @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
