### PR TITLE
Add post autosave for title generation and content resizing.

### DIFF
--- a/src/js/gutenberg-plugins/content-resizing-plugin.js
+++ b/src/js/gutenberg-plugins/content-resizing-plugin.js
@@ -222,7 +222,11 @@ const ContentResizingPlugin = () => {
 	 *
 	 * @param {string} updateWith The content that will be used to replace the selection.
 	 */
-	function updateContent( updateWith ) {
+	async function updateContent( updateWith ) {
+		const isDirty = await select( 'core/editor' ).isEditedPostDirty();
+		const postId = select( 'core/editor' ).getCurrentPostId();
+		const postType = select( 'core/editor' ).getCurrentPostType();
+
 		dispatch( blockEditorStore ).updateBlockAttributes(
 			selectedBlock.clientId,
 			{
@@ -237,6 +241,15 @@ const ContentResizingPlugin = () => {
 			updateWith.length
 		);
 		resetStates();
+
+		// If no edited values in post trigger save.
+		if ( ! isDirty ) {
+			await dispatch( 'core' ).saveEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+		}
 	}
 
 	// We don't want to use the reszing feature when multiple blocks are selected.

--- a/src/js/gutenberg-plugins/post-status-info.js
+++ b/src/js/gutenberg-plugins/post-status-info.js
@@ -37,6 +37,7 @@ const PostStatusInfo = () => {
 	}
 
 	const postId = select( 'core/editor' ).getCurrentPostId();
+	const postType = select( 'core/editor' ).getCurrentPostType();
 	const postContent =
 		select( 'core/editor' ).getEditedPostAttribute( 'content' );
 	const openModal = () => setOpen( true );
@@ -85,11 +86,24 @@ const PostStatusInfo = () => {
 							</textarea>
 							<Button
 								variant="secondary"
-								onClick={ () => {
+								onClick={ async () => {
+									const isDirty =
+										select(
+											'core/editor'
+										).isEditedPostDirty();
 									dispatch( 'core/editor' ).editPost( {
 										title: data[ i ],
 									} );
 									closeModal();
+									if ( ! isDirty ) {
+										await dispatch(
+											'core'
+										).saveEditedEntityRecord(
+											'postType',
+											postType,
+											postId
+										);
+									}
 								} }
 							>
 								{ __( 'Select', 'classifai' ) }

--- a/src/js/openai/classic-editor-title-generator.js
+++ b/src/js/openai/classic-editor-title-generator.js
@@ -17,6 +17,23 @@ const scriptData = classifaiChatGPTData.enabledFeatures.reduce(
 	} );
 
 	/**
+	 * Returns whether the post has unsaved changes or not.
+	 *
+	 * @return {boolean} Whether the post has unsaved change or not.
+	 */
+	function isPostChanged() {
+		const editor = window.tinymce && window.tinymce.get( 'content' );
+		let changed = false;
+
+		if ( wp.autosave ) {
+			changed = wp.autosave.server.postChanged();
+		} else if ( editor ) {
+			changed = ! editor.isHidden() && editor.isDirty();
+		}
+		return changed;
+	}
+
+	/**
 	 * This function is solely responsible for rendering, generating
 	 * and applying the generated title for the classic editor.
 	 */
@@ -57,8 +74,11 @@ const scriptData = classifaiChatGPTData.enabledFeatures.reduce(
 			const textarea = selectBtnEl
 				.closest( '.classifai-openai__result-item' )
 				.find( 'textarea' );
-
+			const isDirty = isPostChanged();
 			$( '#title' ).val( textarea.val() ).trigger( 'input' );
+			if ( ! isDirty && wp.autosave ) {
+				wp.autosave.server.triggerSave();
+			}
 			hidePopup();
 		};
 


### PR DESCRIPTION
### Description of the Change
PR adds autosave functionality for post title generation and content resizing when the post is not dirty (meaning it doesn't contain any other changes). This addition aims to keep a record of every small change made by classifAI, and the editor can restore previous post content by utilizing WordPress core's revision functionality.

Note: Autosave has not been added to excerpt generation yet, as it directly replaces the post excerpt before manual human review.

Closes #590 

### How to test the Change
1. Create/Edit any post.
1. Click "Generate titles" without making any changes to the post.
1. Verify that the post title value is updated and the post is also saved.
1. Make changes in post content.
1. Click "Generate titles".
1. Verify that it only updates the title value without saving the post.
1. Verify this with the classic editor.
1. Test the same with Resizing content.

### Changelog Entry
> Added - Post autosave for title generation and content resizing.


### Credits
Props @jeffpaul @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
