### PR TITLE
Ensure that the ClassifAI panel only appears when the related feature is enabled.

### DIFF
--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -145,7 +145,7 @@ class NLU extends Provider {
 	 * Register what we need for the plugin.
 	 */
 	public function register() {
-		if ( $this->has_access( 'content_classification' ) ) {
+		if ( $this->is_feature_enabled( 'content_classification' ) ) {
 			add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_editor_assets' ] );
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 


### PR DESCRIPTION
### Description of the Change
PR fixes the issue reported in #627 and ensures that the ClassifAI panel only appears when the related feature is enabled and the user has access to a specific feature.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #627

### How to test the Change
1. Uncheck the `Classify content` option for the NLU feature
2. Check `Enable role-based access`
3. Ensure your role is in the allowed list
4. Go to a post and verify that the ClassifAI panel in the sidebar is not visible
5. Verify that `language-processing.css` is not loaded 

### Changelog Entry
> Fixed - Ensure that the ClassifAI panel only appears when the related feature is enabled.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dkotter @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
