### PR TITLE
Fix/636 Pre Classification Popup terms limit removed

### DIFF
--- a/src/js/gutenberg-plugin.js
+++ b/src/js/gutenberg-plugin.js
@@ -95,7 +95,6 @@ const ClassifAIGenerateTagsButton = () => {
 				setFeatureTaxonomies( resp.feature_taxonomies );
 			}
 
-			let termsReady = false;
 			const taxonomies = resp.terms;
 			const taxTerms = {};
 			const taxTermsExisting = {};
@@ -123,8 +122,6 @@ const ClassifAIGenerateTagsButton = () => {
 
 				const newTerms = Object.values( resp.terms[ taxonomy ] );
 				if ( newTerms && Object.keys( newTerms ).length ) {
-					termsReady = true;
-
 					// Loop through each term and add in taxTermsAI if it does not exist in the post.
 					taxTermsAI = taxTermsAI || {};
 					Object( newTerms ).forEach( ( termId ) => {

--- a/src/js/taxonomy-controls.js
+++ b/src/js/taxonomy-controls.js
@@ -144,11 +144,11 @@ const TaxonomyControls = ( { onChange, query } ) => {
 
 				if ( response && response.id ) {
 					newTerm = {
-						'id' : response.id,
-						'name': termValue,
-						'taxonomy': taxonomySlug,
-						'count': 0,
-						'description': ''
+						id: response.id,
+						name: termValue,
+						taxonomy: taxonomySlug,
+						count: 0,
+						description: '',
 					};
 
 					// Update taxonomiesInfo with new term.
@@ -164,11 +164,11 @@ const TaxonomyControls = ( { onChange, query } ) => {
 									],
 									mapById: {
 										...taxoInfo.terms.mapById,
-										[newTerm.id]: newTerm,
+										[ newTerm.id ]: newTerm,
 									},
 									mapByName: {
 										...taxoInfo.terms.mapByName,
-										[newTerm.name]: newTerm,
+										[ newTerm.name ]: newTerm,
 									},
 									names: [
 										...taxoInfo.terms.names,

--- a/src/js/taxonomy-controls.js
+++ b/src/js/taxonomy-controls.js
@@ -103,7 +103,6 @@ const TaxonomyControls = ( { onChange, query } ) => {
 	}
 
 	const onTermsChange = ( taxonomySlug ) => async ( newTermValues ) => {
-		let newTermsCreated = 0; // Track the number of new terms created
 		const taxonomyInfo = taxonomiesInfo.find(
 			( { slug } ) => slug === taxonomySlug
 		);
@@ -144,7 +143,6 @@ const TaxonomyControls = ( { onChange, query } ) => {
 					} );
 
 				if ( response && response.id ) {
-					newTermsCreated++; // Increment the count of new terms created
 					newTerm = {
 						'id' : response.id,
 						'name': termValue,
@@ -152,6 +150,44 @@ const TaxonomyControls = ( { onChange, query } ) => {
 						'count': 0,
 						'description': ''
 					};
+
+					// Update taxonomiesInfo with new term.
+					const updatedTaxonomiesInfo = taxonomiesInfo.map(
+						( taxoInfo ) => {
+							if ( taxoInfo.slug === taxonomySlug ) {
+								// Append newTerm to taxoInfo.terms.
+								const terms = {
+									...taxoInfo.terms,
+									entitites: [
+										...taxoInfo.terms.entities,
+										newTerm,
+									],
+									mapById: {
+										...taxoInfo.terms.mapById,
+										[newTerm.id]: newTerm,
+									},
+									mapByName: {
+										...taxoInfo.terms.mapByName,
+										[newTerm.name]: newTerm,
+									},
+									names: [
+										...taxoInfo.terms.names,
+										newTerm.name,
+									],
+								};
+
+								return {
+									...taxoInfo,
+									terms,
+								};
+							}
+
+							return taxoInfo;
+						}
+					);
+
+					setNewTermsInfo( updatedTaxonomiesInfo );
+
 					return {
 						[ termValue ]: response.id,
 					}; // Create an object with the term name as the key and the ID as the value
@@ -169,45 +205,6 @@ const TaxonomyControls = ( { onChange, query } ) => {
 			}
 			return accumulator;
 		}, {} );
-
-		if ( newTermsCreated > 0 ) {
-			// Update taxonomiesInfo with new term.
-			const updatedTaxonomiesInfo = taxonomiesInfo.map(
-				( taxoInfo ) => {
-					if ( taxoInfo.slug === taxonomySlug ) {
-						// Append newTerm to taxoInfo.terms.
-						const terms = {
-							...taxoInfo.terms,
-							entitites: [
-								...taxoInfo.terms.entities,
-								newTerm,
-							],
-							mapById: {
-								...taxoInfo.terms.mapById,
-								[newTerm.id]: newTerm,
-							},
-							mapByName: {
-								...taxoInfo.terms.mapByName,
-								[newTerm.name]: newTerm,
-							},
-							names: [
-								...taxoInfo.terms.names,
-								newTerm.name,
-							],
-						};
-
-						return {
-							...taxoInfo,
-							terms,
-						};
-					}
-
-					return taxoInfo;
-				}
-			);
-
-			setNewTermsInfo( updatedTaxonomiesInfo );
-		}
 
 		const newTaxQuery = {
 			...query.taxQuery,

--- a/src/js/taxonomy-controls.js
+++ b/src/js/taxonomy-controls.js
@@ -179,7 +179,7 @@ const TaxonomyControls = ( { onChange, query } ) => {
 						const terms = {
 							...taxoInfo.terms,
 							entitites: [
-								...taxoInfo.terms.entitites,
+								...taxoInfo.terms.entities,
 								newTerm,
 							],
 							mapById: {
@@ -196,17 +196,17 @@ const TaxonomyControls = ( { onChange, query } ) => {
 							],
 						};
 
-							return {
-								...taxoInfo,
-								terms,
-							};
-						}
-						return taxoInfo;
+						return {
+							...taxoInfo,
+							terms,
+						};
 					}
-				);
 
-				setNewTermsInfo( updatedTaxonomiesInfo );
-			}
+					return taxoInfo;
+				}
+			);
+
+			setNewTermsInfo( updatedTaxonomiesInfo );
 		}
 
 		const newTaxQuery = {

--- a/src/js/taxonomy-controls.js
+++ b/src/js/taxonomy-controls.js
@@ -171,30 +171,30 @@ const TaxonomyControls = ( { onChange, query } ) => {
 		}, {} );
 
 		if ( newTermsCreated > 0 ) {
-			// Fetch rest API
-			const request = {
-				path: `/wp/v2/${ taxonomySlug }`,
-				data: {
-					per_page: termsPerPage,
-				},
-			};
-			const response = await wp
-				.apiRequest( request )
-				.catch( ( error ) => {
-					// eslint-disable-next-line no-console
-					console.log( 'Error', error );
-					return null;
-				} );
-
-			if ( response ) {
-				// Update taxonomiesInfo
-				const updatedTaxonomiesInfo = taxonomiesInfo.map(
-					( taxoInfo ) => {
-						if ( taxoInfo.slug === taxonomySlug ) {
-							const terms = getEntitiesInfo( response );
-
-							// Append "[AI]" prefix
-							appendAIPrefix( terms, taxonomySlug );
+			// Update taxonomiesInfo with new term.
+			const updatedTaxonomiesInfo = taxonomiesInfo.map(
+				( taxoInfo ) => {
+					if ( taxoInfo.slug === taxonomySlug ) {
+						// Append newTerm to taxoInfo.terms.
+						const terms = {
+							...taxoInfo.terms,
+							entitites: [
+								...taxoInfo.terms.entitites,
+								newTerm,
+							],
+							mapById: {
+								...taxoInfo.terms.mapById,
+								[newTerm.id]: newTerm,
+							},
+							mapByName: {
+								...taxoInfo.terms.mapByName,
+								[newTerm.name]: newTerm,
+							},
+							names: [
+								...taxoInfo.terms.names,
+								newTerm.name,
+							],
+						};
 
 							return {
 								...taxoInfo,

--- a/src/js/taxonomy-controls.js
+++ b/src/js/taxonomy-controls.js
@@ -111,6 +111,7 @@ const TaxonomyControls = ( { onChange, query } ) => {
 		if ( ! taxonomyInfo ) {
 			return;
 		}
+		let newTerm = {};
 		const termData = await Promise.all(
 			newTermValues.map( async ( termValue ) => {
 				const termId = getTermIdByTermValue(
@@ -144,6 +145,13 @@ const TaxonomyControls = ( { onChange, query } ) => {
 
 				if ( response && response.id ) {
 					newTermsCreated++; // Increment the count of new terms created
+					newTerm = {
+						'id' : response.id,
+						'name': termValue,
+						'taxonomy': taxonomySlug,
+						'count': 0,
+						'description': ''
+					};
 					return {
 						[ termValue ]: response.id,
 					}; // Create an object with the term name as the key and the ID as the value

--- a/src/js/taxonomy-controls.js
+++ b/src/js/taxonomy-controls.js
@@ -14,7 +14,7 @@ import {
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
-const termsPerPage = 100;
+const termsPerPage = -1;
 
 // Helper function to get the term id based on user input in terms `FormTokenField`.
 // eslint-disable-next-line consistent-return


### PR DESCRIPTION
### Description of the Change

* This PR removes the maximum allowed term limit (i.e. 100) in the pre-classification popup.
* Instead of fetching all the terms on the new term insertion, it just updates the existing term object by adding a new term item to it. This is super helpful in terms of performance. This change was required because after adding a new term, we need to fetch all the terms for the updated term object, but fetching all the terms is not possible (i.e. `{ per_page: -1 }` does not work).

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #636

### How to test the Change

Make sure the following issues are fixed.

- The terms beyond 100 are not visible in the pop-up.
- The terms beyond 100 will not be suggested in the drop downs.
- Even if the term is already added, it attempts to re-add because it doesn't detect it within 100 terms.
- When trying to add new terms, it doesn't display the newly added term, even though the term is added to the site.

Also, test the popup; confirm everything related to the popup works.

### Changelog Entry
> Fixed - Pre Classification Popup Limits to 100 terms

### Credits
Props @faisal-alvi @dkotter

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
