### PR TITLE
Update `10up/phpcs-composer` to version 3 and fix all newly flagged issues

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -58,23 +58,23 @@ class Psr4AutoloaderClass {
 	/**
 	 * Loads the class file for a given class name.
 	 *
-	 * @param string $class The fully-qualified class name.
+	 * @param string $classname The fully-qualified class name.
 	 * @return mixed The mapped file name on success, or boolean false on
 	 * failure.
 	 */
-	public function load_class( $class ) {
+	public function load_class( $classname ) {
 		// the current namespace prefix
-		$prefix = $class;
+		$prefix = $classname;
 
 		// work backwards through the namespace names of the fully-qualified
 		// class name to find a mapped file name
-		while ( false !== $pos = strrpos( $prefix, '\\' ) ) { // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+		while ( false !== $pos = strrpos( $prefix, '\\' ) ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 
 			// retain the trailing namespace separator in the prefix
-			$prefix = substr( $class, 0, $pos + 1 );
+			$prefix = substr( $classname, 0, $pos + 1 );
 
 			// the rest is the relative class name
-			$relative_class = substr( $class, $pos + 1 );
+			$relative_class = substr( $classname, $pos + 1 );
 
 			// try to load a mapped file for the prefix and relative class
 			$mapped_file = $this->load_mapped_file( $prefix, $relative_class );

--- a/autoload.php
+++ b/autoload.php
@@ -68,7 +68,7 @@ class Psr4AutoloaderClass {
 
 		// work backwards through the namespace names of the fully-qualified
 		// class name to find a mapped file name
-		while ( false !== $pos = strrpos( $prefix, '\\' ) ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+		while ( false !== $pos = strrpos( $prefix, '\\' ) ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition, WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 
 			// retain the trailing namespace separator in the prefix
 			$prefix = substr( $classname, 0, $pos + 1 );

--- a/classifai.php
+++ b/classifai.php
@@ -37,7 +37,7 @@ function classifai_site_meets_php_requirements() {
 if ( ! classifai_site_meets_php_requirements() ) {
 	add_action(
 		'admin_notices',
-		function() {
+		function () {
 			?>
 			<div class="notice notice-error">
 				<p>

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ]
   },
   "require-dev": {
-    "10up/phpcs-composer": "^3",
+    "10up/phpcs-composer": "^3.0",
     "yoast/phpunit-polyfills": "^1.0.0"
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ]
   },
   "require-dev": {
-    "10up/phpcs-composer": "dev-master",
+    "10up/phpcs-composer": "^3",
     "yoast/phpunit-polyfills": "^1.0.0"
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "yoast/phpunit-polyfills": "^1.0.0"
   },
   "scripts": {
-    "lint": "phpcs . --runtime-set testVersion 7.4-",
+    "lint": "phpcs -s . --runtime-set testVersion 7.4-",
     "lint-fix": "phpcbf ."
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eac83010094406077b2bc944e936a9c2",
+    "content-hash": "c5f9a466d0a23a5d0dc24010b11aa245",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -201,26 +201,26 @@
     "packages-dev": [
         {
             "name": "10up/phpcs-composer",
-            "version": "dev-master",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/10up/phpcs-composer.git",
-                "reference": "9c085cf0554a0b5311623548663aa9e4d8f52587"
+                "reference": "04fe5f0d61948f9e38e9cd037a5ee50dcdbf4688"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/10up/phpcs-composer/zipball/9c085cf0554a0b5311623548663aa9e4d8f52587",
-                "reference": "9c085cf0554a0b5311623548663aa9e4d8f52587",
+                "url": "https://api.github.com/repos/10up/phpcs-composer/zipball/04fe5f0d61948f9e38e9cd037a5ee50dcdbf4688",
+                "reference": "04fe5f0d61948f9e38e9cd037a5ee50dcdbf4688",
                 "shasum": ""
             },
             "require": {
-                "automattic/vipwpcs": "^2.3",
-                "dealerdirect/phpcodesniffer-composer-installer": "*",
-                "phpcompatibility/phpcompatibility-wp": "^2",
-                "squizlabs/php_codesniffer": "3.7.1",
-                "wp-coding-standards/wpcs": "*"
+                "automattic/vipwpcs": "^3.0",
+                "phpcompatibility/phpcompatibility-wp": "^2"
             },
-            "default-branch": true,
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "*",
+                "phpcompatibility/php-compatibility": "dev-develop as 9.99.99"
+            },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -228,40 +228,42 @@
             ],
             "authors": [
                 {
-                    "name": "Ephraim Gregor",
-                    "email": "ephraim.gregor@10up.com"
+                    "name": "10up",
+                    "homepage": "https://10up.com/"
                 }
             ],
+            "description": "10up's PHP CodeSniffer Ruleset",
             "support": {
                 "issues": "https://github.com/10up/phpcs-composer/issues",
-                "source": "https://github.com/10up/phpcs-composer/tree/master"
+                "source": "https://github.com/10up/phpcs-composer/tree/3.0.0"
             },
-            "time": "2023-05-10T22:44:49+00:00"
+            "time": "2023-12-14T15:37:22+00:00"
         },
         {
             "name": "automattic/vipwpcs",
-            "version": "2.3.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
                 "php": ">=5.4",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
-                "squizlabs/php_codesniffer": "^3.5.5",
-                "wp-coding-standards/wpcs": "^2.3"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.17",
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "wp-coding-standards/wpcs": "^3.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9",
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
@@ -281,6 +283,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -288,39 +291,42 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2021-09-29T16:20:23+00:00"
+            "time": "2023-09-05T11:01:05+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
+                "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -336,7 +342,7 @@
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -360,10 +366,10 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2022-02-04T12:51:07+00:00"
+            "time": "2023-01-05T11:28:13+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -845,6 +851,174 @@
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
             "time": "2022-10-24T09:00:36+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.9",
+                "squizlabs/php_codesniffer": "^3.8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "default-branch": true,
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T16:49:07+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "7ce595672008088280161470266240d39a4025a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/7ce595672008088280161470266240d39a4025a3",
+                "reference": "7ce595672008088280161470266240d39a4025a3",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.8.0 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+            },
+            "default-branch": true,
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-11T10:09:05+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2238,12 +2412,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049"
+                "reference": "02703669a3780f6c9b293bfe6294cfb359264b10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3b71162a6bf0cde2bff1752e40a1788d8273d049",
-                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/02703669a3780f6c9b293bfe6294cfb359264b10",
+                "reference": "02703669a3780f6c9b293bfe6294cfb359264b10",
                 "shasum": ""
             },
             "require": {
@@ -2289,20 +2463,20 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2023-08-05T23:46:11+00:00"
+            "time": "2023-12-07T16:24:19+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "88d3cec355a252c8fb6a338c420960bf1b0d5679"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/88d3cec355a252c8fb6a338c420960bf1b0d5679",
+                "reference": "88d3cec355a252c8fb6a338c420960bf1b0d5679",
                 "shasum": ""
             },
             "require": {
@@ -2312,11 +2486,12 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
+            "default-branch": true,
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -2331,21 +2506,45 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-14T14:17:01+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2399,30 +2598,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -2439,6 +2646,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -2446,7 +2654,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-14T07:06:09+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -2512,8 +2726,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "ua-parser/uap-php": 20,
-        "10up/phpcs-composer": 20
+        "ua-parser/uap-php": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,
@@ -2521,5 +2734,5 @@
         "php": ">=7.4"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5f9a466d0a23a5d0dc24010b11aa245",
+    "content-hash": "7a9a2237236b5a380f663428adcb1357",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/includes/Classifai/Admin/BulkActions.php
+++ b/includes/Classifai/Admin/BulkActions.php
@@ -454,5 +454,4 @@ class BulkActions {
 
 		return $actions;
 	}
-
 }

--- a/includes/Classifai/Admin/DebugInfo.php
+++ b/includes/Classifai/Admin/DebugInfo.php
@@ -75,7 +75,7 @@ class DebugInfo {
 			$fields = [];
 		}
 
-		$validate_field = function( $field ) {
+		$validate_field = function ( $field ) {
 			if ( ! is_array( $field ) ) {
 				return false;
 			}

--- a/includes/Classifai/Admin/Onboarding.php
+++ b/includes/Classifai/Admin/Onboarding.php
@@ -328,14 +328,14 @@ class Onboarding {
 	 * Sanitize variables using sanitize_text_field and wp_unslash. Arrays are cleaned recursively.
 	 * Non-scalar values are ignored.
 	 *
-	 * @param string|array $var Data to sanitize.
+	 * @param string|array $data Data to sanitize.
 	 * @return string|array
 	 */
-	public function classifai_sanitize( $var ) {
-		if ( is_array( $var ) ) {
-			return array_map( array( $this, 'classifai_sanitize' ), $var );
+	public function classifai_sanitize( $data ) {
+		if ( is_array( $data ) ) {
+			return array_map( array( $this, 'classifai_sanitize' ), $data );
 		} else {
-			return is_scalar( $var ) ? sanitize_text_field( wp_unslash( $var ) ) : $var;
+			return is_scalar( $data ) ? sanitize_text_field( wp_unslash( $data ) ) : $data;
 		}
 	}
 
@@ -663,5 +663,4 @@ class Onboarding {
 
 		return $configured_features;
 	}
-
 }

--- a/includes/Classifai/Admin/PreviewClassifierData.php
+++ b/includes/Classifai/Admin/PreviewClassifierData.php
@@ -105,7 +105,7 @@ class PreviewClassifierData {
 			if ( 'categories' === $feature ) {
 				$classified_data[ $feature ] = array_filter(
 					$classified_data[ $feature ],
-					function( $item ) use ( $taxonomy ) {
+					function ( $item ) use ( $taxonomy ) {
 						$keep  = false;
 						$parts = explode( '/', $item['label'] );
 						$parts = array_filter( $parts );
@@ -128,7 +128,7 @@ class PreviewClassifierData {
 
 			$classified_data[ $feature ] = array_filter(
 				$classified_data[ $feature ],
-				function( $item ) use ( $taxonomy, $key ) {
+				function ( $item ) use ( $taxonomy, $key ) {
 					$name = $item['text'];
 					if ( 'keyword' === $key ) {
 						$name = preg_replace( '#^[a-z]+ ([A-Z].*)$#', '$1', $name );
@@ -148,4 +148,3 @@ class PreviewClassifierData {
 		return $classified_data;
 	}
 }
-

--- a/includes/Classifai/Admin/SavePostHandler.php
+++ b/includes/Classifai/Admin/SavePostHandler.php
@@ -2,8 +2,8 @@
 
 namespace Classifai\Admin;
 
-use \Classifai\Providers\Azure\TextToSpeech;
-use \Classifai\Watson\Normalizer;
+use Classifai\Providers\Azure\TextToSpeech;
+use Classifai\Watson\Normalizer;
 use function Classifai\get_classification_mode;
 
 /**

--- a/includes/Classifai/Admin/Update.php
+++ b/includes/Classifai/Admin/Update.php
@@ -59,7 +59,7 @@ class Update {
 		);
 
 		$this->updater->addResultFilter(
-			function( $plugin_info, $http_response = null ) {
+			function ( $plugin_info ) {
 				$plugin_info->icons = array(
 					'svg' => CLASSIFAI_PLUGIN_URL . 'assets/img/icon.svg',
 				);

--- a/includes/Classifai/Blocks.php
+++ b/includes/Classifai/Blocks.php
@@ -15,8 +15,8 @@ use function Classifai\get_asset_info;
  * @return void
  */
 function setup() {
-	$n = function( $function ) {
-		return __NAMESPACE__ . "\\$function";
+	$n = function ( $function_name ) {
+		return __NAMESPACE__ . "\\$function_name";
 	};
 
 	add_action( 'enqueue_block_assets', $n( 'blocks_styles' ) );

--- a/includes/Classifai/Blocks/recommended-content-block/register.php
+++ b/includes/Classifai/Blocks/recommended-content-block/register.php
@@ -7,15 +7,15 @@
 
 namespace Classifai\Blocks\RecommendedContentBlock;
 
-use function Classifai\get_asset_info;
 use Classifai\Providers\Azure\Personalizer;
+use function Classifai\get_asset_info;
 
 /**
  * Register the block
  */
 function register() {
-	$n = function( $function ) {
-		return __NAMESPACE__ . "\\$function";
+	$n = function ( $function_name ) {
+		return __NAMESPACE__ . "\\$function_name";
 	};
 
 	$personalizer = new Personalizer( false );
@@ -48,13 +48,11 @@ function register() {
 /**
  * Render callback method for the block
  *
- * @param array  $attributes The blocks attributes.
- * @param string $content    Data returned from InnerBlocks.Content.
- * @param array  $block      Block information such as context.
+ * @param array $attributes The blocks attributes.
  *
  * @return string The rendered block markup.
  */
-function render_block_callback( $attributes, $content, $block ) {
+function render_block_callback( $attributes ) {
 	// Render block in Gutenberg Editor.
 	if ( defined( 'REST_REQUEST' ) && \REST_REQUEST ) {
 		$personalizer = new Personalizer( false );

--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -106,7 +106,6 @@ class ClassifaiCommand extends \WP_CLI_Command {
 		} else {
 			\WP_CLI::log( 'No posts to classify.' );
 		}
-
 	}
 
 	/**
@@ -301,11 +300,11 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 						if ( is_wp_error( $result ) ) {
 							\WP_CLI::log( sprintf( 'Error while processing item ID %s: %s', $post_id, $result->get_error_message() ) );
-							$errors ++;
+							++$errors;
 						}
 					}
 
-					$count ++;
+					++$count;
 				}
 
 				$this->inmemory_cleanup();
@@ -314,7 +313,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 					\WP_CLI::log( sprintf( 'Batch %d is done, proceeding to next batch', $paged ) );
 				}
 
-				$paged ++;
+				++$paged;
 			} while ( $total );
 		} else {
 			// If no post type is specified, we have to have a list of post IDs.
@@ -332,7 +331,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 				// Ensure we have a valid post ID.
 				if ( ! get_post( $post_id ) ) {
 					\WP_CLI::log( sprintf( 'Item ID %d does not exist', $post_id ) );
-					$errors ++;
+					++$errors;
 					continue;
 				}
 
@@ -340,7 +339,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 				$post_type = get_post_type( $post_id );
 				if ( ! $post_type || ! in_array( $post_type, $allowed_post_types, true ) ) {
 					\WP_CLI::log( sprintf( 'The "%s" post type is not enabled for Text to Speech processing', $post_type ) );
-					$errors ++;
+					++$errors;
 					continue;
 				}
 
@@ -349,12 +348,12 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 					if ( is_wp_error( $result ) ) {
 						\WP_CLI::log( sprintf( 'Error while processing item ID %s: %s', $post_id, $result->get_error_message() ) );
-						$errors ++;
+						++$errors;
 					}
 				}
 
 				$progress_bar->tick();
-				$count ++;
+				++$count;
 			}
 
 			$progress_bar->finish();
@@ -432,7 +431,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 				$transcribe = new Transcribe( $attachment_id, $settings );
 
 				if ( ! $this->should_transcribe_attachment( $attachment, $attachment_id, $transcribe, (bool) $opts['force'] ) ) {
-					$errors ++;
+					++$errors;
 					continue;
 				}
 
@@ -441,12 +440,12 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 					if ( is_wp_error( $result ) ) {
 						\WP_CLI::error( sprintf( 'Error while processing item ID %s: %s', $attachment_id, $result->get_error_message() ), false );
-						$errors ++;
+						++$errors;
 					}
 				}
 
 				$progress_bar->tick();
-				$count ++;
+				++$count;
 			}
 
 			$progress_bar->finish();
@@ -484,7 +483,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 					$transcribe = new Transcribe( $attachment_id, $settings );
 
 					if ( ! $this->should_transcribe_attachment( $attachment, (int) $attachment_id, $transcribe, (bool) $opts['force'] ) ) {
-						$errors ++;
+						++$errors;
 						continue;
 					}
 
@@ -493,11 +492,11 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 						if ( is_wp_error( $result ) ) {
 							\WP_CLI::error( sprintf( 'Error while processing item ID %s: %s', $attachment_id, $result->get_error_message() ), false );
-							$errors ++;
+							++$errors;
 						}
 					}
 
-					$count ++;
+					++$count;
 				}
 
 				$this->inmemory_cleanup();
@@ -506,7 +505,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 					\WP_CLI::log( sprintf( 'Batch %d is done, proceeding to next batch', $paged ) );
 				}
 
-				$paged ++;
+				++$paged;
 			} while ( $total );
 		}
 
@@ -613,7 +612,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 					// Don't process if an item has an existing excerpt and we aren't forcing it.
 					if ( '' !== trim( $post->post_excerpt ) && ! $opts['force'] ) {
 						\WP_CLI::log( sprintf( 'Item ID %d has an existing excerpt and the force option hasn\'t been set. Skipping...', $post->ID ) );
-						$skipped ++;
+						++$skipped;
 						continue;
 					}
 
@@ -621,7 +620,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 					if ( is_wp_error( $result ) ) {
 						\WP_CLI::error( sprintf( 'Error while processing item ID %d: %s', $post->ID, $result->get_error_message() ), false );
-						$errors ++;
+						++$errors;
 						continue;
 					}
 
@@ -637,7 +636,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 						);
 					}
 
-					$count ++;
+					++$count;
 				}
 
 				$this->inmemory_cleanup();
@@ -646,7 +645,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 					\WP_CLI::log( sprintf( 'Batch %d is done, proceeding to next batch', $paged ) );
 				}
 
-				$paged ++;
+				++$paged;
 			} while ( $total );
 		} else {
 			// If no post type is specified, we have to have a list of post IDs.
@@ -666,7 +665,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 				// Don't process if an item has an existing excerpt and we aren't forcing it.
 				if ( $post && '' !== trim( $post->post_excerpt ) && ! $opts['force'] ) {
 					\WP_CLI::log( sprintf( 'Item ID %d has an existing excerpt and the force option hasn\'t been set. Skipping...', $post_id ) );
-					$skipped ++;
+					++$skipped;
 					continue;
 				}
 
@@ -674,7 +673,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 				if ( is_wp_error( $result ) ) {
 					\WP_CLI::error( sprintf( 'Error while processing item ID %d: %s', $post_id, $result->get_error_message() ), false );
-					$errors ++;
+					++$errors;
 					continue;
 				}
 
@@ -691,7 +690,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 				}
 
 				$progress_bar->tick();
-				$count ++;
+				++$count;
 			}
 
 			$progress_bar->finish();
@@ -913,7 +912,6 @@ class ClassifaiCommand extends \WP_CLI_Command {
 		} else {
 			\WP_CLI::error( "Cropped $total_success images, $total_errors errors." );
 		}
-
 	}
 
 	/**
@@ -1005,11 +1003,11 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 						if ( is_wp_error( $result ) ) {
 							\WP_CLI::error( sprintf( 'Error while processing item ID %s', $post_id ), false );
-							$errors ++;
+							++$errors;
 						}
 					}
 
-					$count ++;
+					++$count;
 				}
 
 				$this->inmemory_cleanup();
@@ -1018,7 +1016,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 					\WP_CLI::log( sprintf( 'Batch %d is done, proceeding to next batch', $paged ) );
 				}
 
-				$paged ++;
+				++$paged;
 			} while ( $total );
 		} else {
 			// If no post type is specified, we have to have a list of post IDs.
@@ -1036,7 +1034,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 				// Ensure we have a valid post ID.
 				if ( ! get_post( $post_id ) ) {
 					\WP_CLI::error( sprintf( 'Item ID %d does not exist', $post_id ), false );
-					$errors ++;
+					++$errors;
 					continue;
 				}
 
@@ -1044,7 +1042,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 				$post_type = get_post_type( $post_id );
 				if ( ! $post_type || ! in_array( $post_type, $allowed_post_types, true ) ) {
 					\WP_CLI::error( sprintf( 'The "%s" post type is not enabled for OpenAI Embeddings processing', $post_type ), false );
-					$errors ++;
+					++$errors;
 					continue;
 				}
 
@@ -1053,12 +1051,12 @@ class ClassifaiCommand extends \WP_CLI_Command {
 
 					if ( is_wp_error( $result ) ) {
 						\WP_CLI::error( sprintf( 'Error while processing item ID %s', $post_id ), false );
-						$errors ++;
+						++$errors;
 					}
 				}
 
 				$progress_bar->tick();
-				$count ++;
+				++$count;
 			}
 
 			$progress_bar->finish();
@@ -1229,7 +1227,6 @@ class ClassifaiCommand extends \WP_CLI_Command {
 			\WP_CLI::warning( "Failed to classify $post_id: " . $output->get_error_message() );
 		}
 	}
-
 }
 
 try {

--- a/includes/Classifai/Command/RSSImporterCommand.php
+++ b/includes/Classifai/Command/RSSImporterCommand.php
@@ -229,5 +229,4 @@ class RSSImporterCommand extends \WP_CLI_Command {
 			return $response;
 		}
 	}
-
 }

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -163,10 +163,9 @@ class Plugin {
 	/**
 	 * Enqueue the admin scripts.
 	 *
-	 * @param string $hook_suffix The current admin page.
 	 * @since 2.4.0 Use get_asset_info to get the asset version and dependencies.
 	 */
-	public function enqueue_admin_assets( $hook_suffix ) {
+	public function enqueue_admin_assets() {
 		$user_profile     = new Admin\UserProfile();
 		$allowed_features = $user_profile->get_allowed_features( get_current_user_id() );
 

--- a/includes/Classifai/PostClassifier.php
+++ b/includes/Classifai/PostClassifier.php
@@ -180,5 +180,4 @@ class PostClassifier {
 
 		return $features;
 	}
-
 }

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -158,7 +158,7 @@ class ComputerVision extends Provider {
 			'attachment',
 			'classifai_has_ocr',
 			[
-				'get_callback' => function( $params ) {
+				'get_callback' => function ( $params ) {
 					return ! empty( get_post_meta( $params['id'], 'classifai_computer_vision_ocr', true ) );
 				},
 				'schema'       => [

--- a/includes/Classifai/Providers/Azure/OCR.php
+++ b/includes/Classifai/Providers/Azure/OCR.php
@@ -364,5 +364,4 @@ class OCR {
 
 		return $rtn;
 	}
-
 }

--- a/includes/Classifai/Providers/Azure/Personalizer.php
+++ b/includes/Classifai/Providers/Azure/Personalizer.php
@@ -330,14 +330,14 @@ class Personalizer extends Provider {
 			$exclude = $attributes['excludeId'];
 			$actions = array_filter(
 				$actions,
-				function( $ele ) use ( $exclude ) {
+				function ( $ele ) use ( $exclude ) {
 					return $ele['id'] && absint( $ele['id'] ) !== absint( $exclude );
 				}
 			);
 		}
 
 		$action_ids = array_map(
-			function( $ele ) {
+			function ( $ele ) {
 				return $ele['id'];
 			},
 			$actions
@@ -423,20 +423,20 @@ class Personalizer extends Provider {
 			// Sort ranking by probability.
 			usort(
 				$ranking,
-				function( $a, $b ) {
+				function ( $a, $b ) {
 					return $a->probability - $b->probability;
 				}
 			);
 
 			$recommended_ids = array_map(
-				function( $ele ) {
+				function ( $ele ) {
 					return absint( $ele->id );
 				},
 				$ranking
 			);
 			$recommended_ids = array_filter(
 				$recommended_ids,
-				function( $ele ) use ( $rewarded_post ) {
+				function ( $ele ) use ( $rewarded_post ) {
 					return $ele && absint( $ele ) !== absint( $rewarded_post );
 				}
 			);
@@ -652,11 +652,11 @@ class Personalizer extends Provider {
 	/**
 	 * Get array of words from string. Words as key of array.
 	 *
-	 * @param string $string String to get words from.
+	 * @param string $text String of text to get words from.
 	 * @return array
 	 */
-	protected function get_string_words( $string ) {
-		$str_array = preg_split( '/\s+/', $string );
+	protected function get_string_words( $text ) {
+		$str_array = preg_split( '/\s+/', $text );
 		$words     = array();
 		foreach ( $str_array as $str ) {
 			$words[ $str ] = 1;

--- a/includes/Classifai/Providers/Azure/SmartCropping.php
+++ b/includes/Classifai/Providers/Azure/SmartCropping.php
@@ -382,4 +382,3 @@ class SmartCropping {
 		return new \WP_Error( 'classifai_smart_cropping_failed', 'A Smart Cropping error occurred.' );
 	}
 }
-

--- a/includes/Classifai/Providers/Azure/TextToSpeech.php
+++ b/includes/Classifai/Providers/Azure/TextToSpeech.php
@@ -566,11 +566,11 @@ class TextToSpeech extends Provider {
 			$supported_post_types,
 			'classifai_synthesize_speech',
 			array(
-				'get_callback' => function( $object ) {
-					$audio_id = get_post_meta( $object['id'], self::AUDIO_ID_KEY, true );
+				'get_callback' => function ( $data ) {
+					$audio_id = get_post_meta( $data['id'], self::AUDIO_ID_KEY, true );
 					if (
-						( $this->get_audio_generation_initial_state( $object['id'] ) && ! $audio_id ) ||
-						( $this->get_audio_generation_subsequent_state( $object['id'] ) && $audio_id )
+						( $this->get_audio_generation_initial_state( $data['id'] ) && ! $audio_id ) ||
+						( $this->get_audio_generation_subsequent_state( $data['id'] ) && $audio_id )
 					) {
 						return true;
 					} else {
@@ -588,18 +588,18 @@ class TextToSpeech extends Provider {
 			$supported_post_types,
 			'classifai_display_generated_audio',
 			array(
-				'get_callback'    => function( $object ) {
+				'get_callback'    => function ( $data ) {
 					// Default to display the audio if available.
-					if ( metadata_exists( 'post', $object['id'], self::DISPLAY_GENERATED_AUDIO ) ) {
-						return (bool) get_post_meta( $object['id'], self::DISPLAY_GENERATED_AUDIO, true );
+					if ( metadata_exists( 'post', $data['id'], self::DISPLAY_GENERATED_AUDIO ) ) {
+						return (bool) get_post_meta( $data['id'], self::DISPLAY_GENERATED_AUDIO, true );
 					}
 					return true;
 				},
-				'update_callback' => function( $value, $object ) {
+				'update_callback' => function ( $value, $data ) {
 					if ( $value ) {
-						delete_post_meta( $object->ID, self::DISPLAY_GENERATED_AUDIO );
+						delete_post_meta( $data->ID, self::DISPLAY_GENERATED_AUDIO );
 					} else {
-						update_post_meta( $object->ID, self::DISPLAY_GENERATED_AUDIO, false );
+						update_post_meta( $data->ID, self::DISPLAY_GENERATED_AUDIO, false );
 					}
 				},
 				'schema'          => [
@@ -613,8 +613,8 @@ class TextToSpeech extends Provider {
 			$supported_post_types,
 			'classifai_post_audio_id',
 			array(
-				'get_callback' => function( $object ) {
-					$post_audio_id = get_post_meta( $object['id'], self::AUDIO_ID_KEY, true );
+				'get_callback' => function ( $data ) {
+					$post_audio_id = get_post_meta( $data['id'], self::AUDIO_ID_KEY, true );
 					return (int) $post_audio_id;
 				},
 				'schema'       => [
@@ -751,7 +751,6 @@ class TextToSpeech extends Provider {
 
 			<?php
 		}
-
 	}
 
 	/**

--- a/includes/Classifai/Providers/OpenAI/APIRequest.php
+++ b/includes/Classifai/Providers/OpenAI/APIRequest.php
@@ -325,5 +325,4 @@ class APIRequest {
 	public function get_api_key() {
 		return $this->api_key;
 	}
-
 }

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -7,10 +7,9 @@ namespace Classifai\Providers\OpenAI;
 
 use Classifai\Providers\Provider;
 use Classifai\Providers\OpenAI\APIRequest;
+use WP_Error;
 use function Classifai\get_asset_info;
 use function Classifai\render_disable_feature_link;
-
-use WP_Error;
 
 class DallE extends Provider {
 
@@ -574,7 +573,7 @@ class DallE extends Provider {
 		$roles = get_editable_roles() ?? [];
 		$roles = array_filter(
 			$roles,
-			function( $role ) {
+			function ( $role ) {
 				return isset( $role['capabilities'], $role['capabilities']['upload_files'] ) && $role['capabilities']['upload_files'];
 			}
 		);

--- a/includes/Classifai/Providers/OpenAI/EmbeddingCalculations.php
+++ b/includes/Classifai/Providers/OpenAI/EmbeddingCalculations.php
@@ -26,7 +26,7 @@ class EmbeddingCalculations {
 		// Get the combined average between the two embeddings.
 		$combined_average = array_sum(
 			array_map(
-				function( $x, $y ) {
+				function ( $x, $y ) {
 					return (float) $x * (float) $y;
 				},
 				$source_embedding,
@@ -37,7 +37,7 @@ class EmbeddingCalculations {
 		// Get the average of the source embedding.
 		$source_average = array_sum(
 			array_map(
-				function( $x ) {
+				function ( $x ) {
 					return pow( (float) $x, 2 );
 				},
 				$source_embedding
@@ -47,7 +47,7 @@ class EmbeddingCalculations {
 		// Get the average of the compare embedding.
 		$compare_average = array_sum(
 			array_map(
-				function( $x ) {
+				function ( $x ) {
 					return pow( (float) $x, 2 );
 				},
 				$compare_embedding
@@ -60,5 +60,4 @@ class EmbeddingCalculations {
 		// Ensure we are within the range of 0 to 1.0.
 		return max( 0, min( abs( (float) $distance ), 1.0 ) );
 	}
-
 }

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -11,9 +11,9 @@ use Classifai\Providers\OpenAI\Tokenizer;
 use Classifai\Providers\OpenAI\EmbeddingCalculations;
 use Classifai\Providers\Watson\NLU;
 use Classifai\Watson\Normalizer;
+use WP_Error;
 use function Classifai\get_asset_info;
 use function Classifai\language_processing_features_enabled;
-use WP_Error;
 
 class Embeddings extends Provider {
 
@@ -616,7 +616,7 @@ class Embeddings extends Provider {
 					'label' => get_term( $term_id )->name,
 					'score' => $similarity,
 				];
-				$term_added++;
+				++$term_added;
 			}
 
 			// Only add the number of terms specified in settings.
@@ -624,7 +624,7 @@ class Embeddings extends Provider {
 				$terms = array_slice( $terms, 0, $number_to_add, true );
 			}
 
-			$index++;
+			++$index;
 		}
 
 		return $result;
@@ -886,13 +886,13 @@ class Embeddings extends Provider {
 			$supported_post_types,
 			'classifai_process_content',
 			[
-				'get_callback'    => function( $object ) {
-					$process_content = get_post_meta( $object['id'], '_classifai_process_content', true );
+				'get_callback'    => function ( $data ) {
+					$process_content = get_post_meta( $data['id'], '_classifai_process_content', true );
 					return ( 'no' === $process_content ) ? 'no' : 'yes';
 				},
-				'update_callback' => function ( $value, $object ) {
+				'update_callback' => function ( $value, $data ) {
 					$value = ( 'no' === $value ) ? 'no' : 'yes';
-					return update_post_meta( $object->ID, '_classifai_process_content', $value );
+					return update_post_meta( $data->ID, '_classifai_process_content', $value );
 				},
 				'schema'          => [
 					'type'    => 'string',
@@ -994,5 +994,4 @@ class Embeddings extends Provider {
 			update_post_meta( $post_id, '_classifai_process_content', 'yes' );
 		}
 	}
-
 }

--- a/includes/Classifai/Providers/OpenAI/OpenAI.php
+++ b/includes/Classifai/Providers/OpenAI/OpenAI.php
@@ -32,7 +32,7 @@ trait OpenAI {
 		add_settings_section(
 			$this->get_option_name(),
 			$this->provider_service_name,
-			function() {
+			function () {
 				printf(
 					wp_kses(
 						/* translators: %1$s is replaced with the OpenAI sign up URL */
@@ -293,5 +293,4 @@ trait OpenAI {
 
 		return $taxonomies;
 	}
-
 }

--- a/includes/Classifai/Providers/OpenAI/Tokenizer.php
+++ b/includes/Classifai/Providers/OpenAI/Tokenizer.php
@@ -130,5 +130,4 @@ class Tokenizer {
 
 		return trim( $trimmed_content );
 	}
-
 }

--- a/includes/Classifai/Providers/OpenAI/Whisper.php
+++ b/includes/Classifai/Providers/OpenAI/Whisper.php
@@ -7,9 +7,8 @@ namespace Classifai\Providers\OpenAI;
 
 use Classifai\Providers\Provider;
 use Classifai\Providers\OpenAI\Whisper\Transcribe;
-use function Classifai\clean_input;
-
 use WP_Error;
+use function Classifai\clean_input;
 
 class Whisper extends Provider {
 
@@ -337,5 +336,4 @@ class Whisper extends Provider {
 			__( 'Latest response', 'classifai' )      => $this->get_formatted_latest_response( get_transient( 'classifai_openai_whisper_latest_response' ) ),
 		];
 	}
-
 }

--- a/includes/Classifai/Providers/OpenAI/Whisper/Transcribe.php
+++ b/includes/Classifai/Providers/OpenAI/Whisper/Transcribe.php
@@ -141,5 +141,4 @@ class Transcribe {
 			return $text;
 		}
 	}
-
 }

--- a/includes/Classifai/Providers/OpenAI/Whisper/Whisper.php
+++ b/includes/Classifai/Providers/OpenAI/Whisper/Whisper.php
@@ -82,5 +82,4 @@ trait Whisper {
 
 		return $process;
 	}
-
 }

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -638,7 +638,7 @@ abstract class Provider {
 	 *
 	 * @return mixed
 	 */
-	public function rest_endpoint_callback( $post_id, $route_to_call, $args = [] ) {
+	public function rest_endpoint_callback( $post_id, $route_to_call, $args = [] ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		return null;
 	}
 

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -9,12 +9,12 @@ use Classifai\Admin\SavePostHandler;
 use Classifai\Admin\PreviewClassifierData;
 use Classifai\Providers\Provider;
 use Classifai\Taxonomy\TaxonomyFactory;
+use WP_Error;
 use function Classifai\get_plugin_settings;
 use function Classifai\get_post_types_for_language_settings;
 use function Classifai\get_post_statuses_for_language_settings;
 use function Classifai\get_asset_info;
 use function Classifai\get_classification_mode;
-use WP_Error;
 
 class NLU extends Provider {
 
@@ -298,7 +298,7 @@ class NLU extends Provider {
 		add_settings_section(
 			$this->get_option_name(),
 			$this->provider_service_name,
-			function() {
+			function () {
 				printf(
 					wp_kses(
 						/* translators: %1$s is the link to register for an IBM Cloud account, %2$s is the link to setup the NLU service */
@@ -334,7 +334,6 @@ class NLU extends Provider {
 						);
 					echo '</strong></p></div>';
 				}
-
 			},
 			$this->get_option_name()
 		);
@@ -394,7 +393,7 @@ class NLU extends Provider {
 		add_settings_field(
 			'toggle',
 			'',
-			function() {
+			function () {
 				printf(
 					'<a id="classifai-waston-cred-toggle" href="#">%s</a>',
 					$this->use_username_password()
@@ -904,7 +903,7 @@ class NLU extends Provider {
 		$settings_post_types = $settings['post_types'] ?? [];
 		$post_types          = array_filter(
 			array_keys( $settings_post_types ),
-			function( $post_type ) use ( $settings_post_types ) {
+			function ( $post_type ) use ( $settings_post_types ) {
 				return 1 === intval( $settings_post_types[ $post_type ] );
 			}
 		);
@@ -1051,13 +1050,13 @@ class NLU extends Provider {
 			$supported_post_types,
 			'classifai_process_content',
 			array(
-				'get_callback'    => function( $object ) {
-					$process_content = get_post_meta( $object['id'], '_classifai_process_content', true );
+				'get_callback'    => function ( $data ) {
+					$process_content = get_post_meta( $data['id'], '_classifai_process_content', true );
 					return ( 'no' === $process_content ) ? 'no' : 'yes';
 				},
-				'update_callback' => function ( $value, $object ) {
+				'update_callback' => function ( $value, $data ) {
 					$value = ( 'no' === $value ) ? 'no' : 'yes';
-					return update_post_meta( $object->ID, '_classifai_process_content', $value );
+					return update_post_meta( $data->ID, '_classifai_process_content', $value );
 				},
 				'schema'          => [
 					'type'    => 'string',
@@ -1102,5 +1101,4 @@ class NLU extends Provider {
 		/** This filter is documented in includes/Classifai/Providers/Provider.php */
 		return apply_filters( "classifai_is_{$feature}_enabled", $is_enabled, $settings );
 	}
-
 }

--- a/includes/Classifai/Services/ImageProcessing.php
+++ b/includes/Classifai/Services/ImageProcessing.php
@@ -392,5 +392,4 @@ class ImageProcessing extends Service {
 		unset( $form_fields['watson-entity'] );
 		return $form_fields;
 	}
-
 }

--- a/includes/Classifai/Services/LanguageProcessing.php
+++ b/includes/Classifai/Services/LanguageProcessing.php
@@ -6,10 +6,10 @@
 namespace Classifai\Services;
 
 use Classifai\Admin\SavePostHandler;
-use function Classifai\find_provider_class;
 use WP_REST_Server;
 use WP_REST_Request;
 use WP_Error;
+use function Classifai\find_provider_class;
 
 class LanguageProcessing extends Service {
 

--- a/includes/Classifai/Services/Personalizer.php
+++ b/includes/Classifai/Services/Personalizer.php
@@ -5,10 +5,10 @@
 
 namespace Classifai\Services;
 
-use function Classifai\find_provider_class;
 use WP_REST_Server;
 use WP_REST_Request;
 use WP_Error;
+use function Classifai\find_provider_class;
 
 class Personalizer extends Service {
 

--- a/includes/Classifai/Services/Service.php
+++ b/includes/Classifai/Services/Service.php
@@ -5,8 +5,8 @@
 
 namespace Classifai\Services;
 
-use function Classifai\find_provider_class;
 use WP_Error;
+use function Classifai\find_provider_class;
 
 abstract class Service {
 
@@ -253,7 +253,7 @@ abstract class Service {
 	 * @since 1.4.0
 	 */
 	public function get_service_debug_information() {
-		$make_line = function( $provider ) {
+		$make_line = function ( $provider ) {
 			return [
 				'label' => sprintf( '%s: %s', $this->get_display_name(), $provider->get_provider_name() ),
 				'value' => $provider->get_provider_debug_information(),
@@ -284,5 +284,4 @@ abstract class Service {
 
 		return true;
 	}
-
 }

--- a/includes/Classifai/Taxonomy/CategoryTaxonomy.php
+++ b/includes/Classifai/Taxonomy/CategoryTaxonomy.php
@@ -44,5 +44,4 @@ class CategoryTaxonomy extends AbstractTaxonomy {
 		return \Classifai\get_feature_enabled( 'category' ) &&
 			\Classifai\get_feature_taxonomy( 'category' ) === $this->get_name();
 	}
-
 }

--- a/includes/Classifai/Taxonomy/ConceptTaxonomy.php
+++ b/includes/Classifai/Taxonomy/ConceptTaxonomy.php
@@ -44,5 +44,4 @@ class ConceptTaxonomy extends AbstractTaxonomy {
 		return \Classifai\get_feature_enabled( 'concept' ) &&
 			\Classifai\get_feature_taxonomy( 'concept' ) === $this->get_name();
 	}
-
 }

--- a/includes/Classifai/Taxonomy/EntityTaxonomy.php
+++ b/includes/Classifai/Taxonomy/EntityTaxonomy.php
@@ -44,5 +44,4 @@ class EntityTaxonomy extends AbstractTaxonomy {
 		return \Classifai\get_feature_enabled( 'entity' ) &&
 			\Classifai\get_feature_taxonomy( 'entity' ) === $this->get_name();
 	}
-
 }

--- a/includes/Classifai/Taxonomy/KeywordTaxonomy.php
+++ b/includes/Classifai/Taxonomy/KeywordTaxonomy.php
@@ -44,5 +44,4 @@ class KeywordTaxonomy extends AbstractTaxonomy {
 		return \Classifai\get_feature_enabled( 'keyword' ) &&
 			\Classifai\get_feature_taxonomy( 'keyword' ) === $this->get_name();
 	}
-
 }

--- a/includes/Classifai/Taxonomy/TaxonomyFactory.php
+++ b/includes/Classifai/Taxonomy/TaxonomyFactory.php
@@ -96,7 +96,7 @@ class TaxonomyFactory {
 
 			return $instance;
 		} else {
-			throw new \Exception( "Mapping not found for Taxonomy: $taxonomy " );
+			throw new \Exception( esc_html( "Mapping not found for Taxonomy: $taxonomy " ) );
 		}
 	}
 
@@ -118,5 +118,4 @@ class TaxonomyFactory {
 	public function get_supported_taxonomies() {
 		return array_keys( $this->mapping );
 	}
-
 }

--- a/includes/Classifai/Watson/APIRequest.php
+++ b/includes/Classifai/Watson/APIRequest.php
@@ -153,5 +153,4 @@ class APIRequest {
 		$options['headers']['Accept']        = 'application/json';
 		$options['headers']['Content-Type']  = 'application/json';
 	}
-
 }

--- a/includes/Classifai/Watson/Classifier.php
+++ b/includes/Classifai/Watson/Classifier.php
@@ -124,5 +124,4 @@ class Classifier {
 
 		return wp_json_encode( $options );
 	}
-
 }

--- a/includes/Classifai/Watson/Normalizer.php
+++ b/includes/Classifai/Watson/Normalizer.php
@@ -74,5 +74,4 @@ class Normalizer {
 
 		return $post_content;
 	}
-
 }


### PR DESCRIPTION
### Description of the Change

We utilize the `10up/phpcs-composer` package and it recently pushed out a major update to 3.0.0. This update brings in major updates from multiple other packages, including much better support for PHP 8+. As such we should be using this in our projects whenever possible.

In making that update, lots of new issues were getting flagged which I've fixed in this PR. Majority of these are very minor things, like needing an extra space or deleting an extra space. But I know these sorts of fixes have caused problems in the past so definitely need a thorough eye on things here.

### How to test the Change

1. Ensure all changes look correct
2. A thorough top-to-bottom testing of the plugin to ensure things still work as expected

### Changelog Entry

> Changed - Update `10up/phpcs-composer` to version 3.0.0 
> Fixed - Address all new PHPCS issues

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
