### PR TITLE
Ensure the `default` key is set before we try accessing it

### DIFF
--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -1137,7 +1137,7 @@ class ChatGPT extends Provider {
 
 		$prompts = array_map(
 			function ( $prompt ) use ( &$has_default ) {
-				$default = $prompt['default'] && ! $has_default;
+				$default = isset( $prompt['default'] ) && $prompt['default'] && ! $has_default;
 
 				if ( $default ) {
 					$has_default = true;


### PR DESCRIPTION
### Description of the Change

When we get our prompts, we check which one is marked as the default. If we try and do this before prompts have been saved though, the `default` key isn't set and will result in an `undefined index` warning. This PR addresses that by checking to ensure that key exists before we access it.

Closes #648

### How to test the Change

1. On a new install, install ClassifAI from the `develop` branch
2. Go to the Site Health screen (`/wp-admin/site-health.php?tab=debug`)
3. You should see a PHP notice
4. Checkout this PR and run the same steps
5. The notice should no longer show

### Changelog Entry

> Fixed - Check for the `default` array key before we access it

### Credits

Props @dkotter, @Sidsector9 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
