### PR TITLE
Switch from the deprecated Completions API to the Models API

### DIFF
--- a/includes/Classifai/Providers/OpenAI/OpenAI.php
+++ b/includes/Classifai/Providers/OpenAI/OpenAI.php
@@ -13,11 +13,11 @@ use function Classifai\get_all_post_statuses;
 trait OpenAI {
 
 	/**
-	 * OpenAI completions URL
+	 * OpenAI model URL
 	 *
 	 * @var string
 	 */
-	protected $completions_url = 'https://api.openai.com/v1/completions';
+	protected $model_url = 'https://api.openai.com/v1/models';
 
 	/**
 	 * Add our OpenAI API settings field.
@@ -139,18 +139,7 @@ trait OpenAI {
 
 		// Make request to ensure credentials work.
 		$request  = new APIRequest( $api_key );
-		$response = $request->post(
-			$this->completions_url,
-			[
-				'body' => wp_json_encode(
-					[
-						'model'      => 'ada',
-						'prompt'     => 'hi',
-						'max_tokens' => 1,
-					]
-				),
-			]
-		);
+		$response = $request->get( $this->model_url );
 
 		return ! is_wp_error( $response ) ? true : $response;
 	}

--- a/tests/test-plugin/e2e-test-plugin.php
+++ b/tests/test-plugin/e2e-test-plugin.php
@@ -19,6 +19,8 @@ function classifai_test_mock_http_requests( $preempt, $parsed_args, $url ) {
 
 	if ( strpos( $url, 'http://e2e-test-nlu-server.test/v1/analyze' ) !== false ) {
 		$response = file_get_contents( __DIR__ . '/nlu.json' );
+	} elseif ( strpos( $url, 'https://api.openai.com/v1/models' ) !== false ) {
+		$response = file_get_contents( __DIR__ . '/models.json' );
 	} elseif ( strpos( $url, 'https://api.openai.com/v1/completions' ) !== false ) {
 		$response = file_get_contents( __DIR__ . '/chatgpt.json' );
 	} elseif ( strpos( $url, 'https://api.openai.com/v1/chat/completions' ) !== false ) {

--- a/tests/test-plugin/models.json
+++ b/tests/test-plugin/models.json
@@ -1,0 +1,23 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "model-id-0",
+      "object": "model",
+      "created": 1686935002,
+      "owned_by": "organization-owner"
+    },
+    {
+      "id": "model-id-1",
+      "object": "model",
+      "created": 1686935002,
+      "owned_by": "organization-owner"
+    },
+    {
+      "id": "model-id-2",
+      "object": "model",
+      "created": 1686935002,
+      "owned_by": "openai"
+    }
+  ]
+}


### PR DESCRIPTION
### Description of the Change

We currently make a request to the [Completions API](https://platform.openai.com/docs/api-reference/completions) when OpenAI settings are saved to verify the credentials are valid. This API is deprecated and was shut down January 4th. This PR switches from using that API to using the [Models API](https://platform.openai.com/docs/api-reference/models) for the same purpose.

### How to test the Change

1. With the current `develop` branch checked out, enter in valid credentials on the OpenAI ChatGPT settings page
2. Save the page and notice a warning shows about a deprecated model
3. Checkout this branch and save the settings again
4. Notice a success message is shown

### Changelog Entry

> Changed - Switch from using the Completions API to the Models API to verify credentials.

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
