### PR TITLE
Ensure we don't run updates more than once

### DIFF
--- a/includes/Classifai/Features/DescriptiveTextGenerator.php
+++ b/includes/Classifai/Features/DescriptiveTextGenerator.php
@@ -263,6 +263,8 @@ class DescriptiveTextGenerator extends Feature {
 			$result = $this->run( $attachment_id, 'descriptive_text' );
 
 			if ( $result && ! is_wp_error( $result ) ) {
+				// Ensure we don't re-run this when the attachment is updated.
+				remove_action( 'edit_attachment', [ $this, 'maybe_rescan_image' ] );
 				$this->save( $result, $attachment_id );
 			}
 		}

--- a/includes/Classifai/Features/ImageCropping.php
+++ b/includes/Classifai/Features/ImageCropping.php
@@ -295,10 +295,8 @@ class ImageCropping extends Feature {
 	 * @param int $attachment_id Attachment ID.
 	 */
 	public function maybe_crop_image( int $attachment_id ) {
-		$metadata = wp_get_attachment_metadata( $attachment_id );
-
 		if ( clean_input( 'rescan-smart-crop' ) ) {
-			$result = $this->run( $attachment_id, 'crop', $metadata );
+			$result = $this->run( $attachment_id, 'crop' );
 
 			if ( ! empty( $result ) && ! is_wp_error( $result ) ) {
 				$meta = $this->save( $result, $attachment_id );

--- a/includes/Classifai/Features/ImageTextExtraction.php
+++ b/includes/Classifai/Features/ImageTextExtraction.php
@@ -301,6 +301,8 @@ class ImageTextExtraction extends Feature {
 			$result = $this->run( $attachment_id, 'ocr' );
 
 			if ( $result && ! is_wp_error( $result ) ) {
+				// Ensure we don't re-run this when the attachment is updated.
+				remove_action( 'edit_attachment', [ $this, 'maybe_rescan_image' ] );
 				$this->save( $result, $attachment_id );
 			}
 		}

--- a/includes/Classifai/Features/PDFTextExtraction.php
+++ b/includes/Classifai/Features/PDFTextExtraction.php
@@ -211,6 +211,9 @@ class PDFTextExtraction extends Feature {
 	 * @param int    $attachment_id The attachment ID.
 	 */
 	public function save( string $result, int $attachment_id ) {
+		// Ensure we don't re-run this when the attachment is updated.
+		remove_action( 'edit_attachment', [ $this, 'maybe_rescan_pdf' ] );
+
 		return wp_update_post(
 			[
 				'ID'           => $attachment_id,

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -723,7 +723,7 @@ class ComputerVision extends Provider {
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
-		if ( ! $metadata ) {
+		if ( ! $metadata || ! is_array( $metadata ) ) {
 			return new WP_Error( 'invalid', esc_html__( 'No valid metadata found.', 'classifai' ) );
 		}
 


### PR DESCRIPTION
### Description of the Change

As mentioned in #623, there's a scenario where manually triggering some of the Azure Image Processing Features from the attachment edit screen can result in an infinite loop.

As part of the refactoring done in #611, this was fixed so that we wouldn't ever encounter an infinite loop but we still end up running those update functions twice, which is not ideal.

This PR fixes that by ensuring we remove the hooked action before we update the attachment.

Closes #623 

### How to test the Change

1. Set up the Descriptive Text Generator Feature
2. Set it up to save the result to either Image caption or Image description (Alt text never had an issue)
3. On an image that has already been uploaded, go to the attachment edit screen
4. Check the box in the ClassifAI Image Processing metabox and save the attachment
5. Ensure the descriptive text is saved

### Changelog Entry

> Fixed - Ensure we only run image updates once.

### Credits

Props @dkotter, @Sidsector9, @sksaju 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
