### PR TITLE
Ensure the jQuery UI Dialog CSS is loaded properly

### DIFF
--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -159,13 +159,8 @@ class Plugin {
 		wp_enqueue_style(
 			'classifai-admin-style',
 			CLASSIFAI_PLUGIN_URL . 'dist/admin.css',
-			array( 'wp-components' ),
-			array(
-				get_asset_info( 'admin', 'version' ),
-				array(
-					'wp-jquery-ui-dialog',
-				),
-			),
+			array( 'wp-components', 'wp-jquery-ui-dialog' ),
+			get_asset_info( 'admin', 'version' ),
 			'all'
 		);
 


### PR DESCRIPTION
### Description of the Change

As reported in #685, the prompt deletion confirmation dialog isn't styled correctly. This is a bug introduced here https://github.com/10up/classifai/pull/611/commits/f1b82fc858e2bd4625031afe03c46ea0b589434b#diff-ed720e40678c281c5ddb72aabfca42eb33c7cf8ce9734673a3e5f9b0fd0dd2c0R166, where we added the dependency at the wrong place. This PR fixes that.

Closes #685 

### How to test the Change

1. Visit Language Processing > Title Generation
2. Add new prompt
3. Click the trash button
4. Ensure it displays correctly

### Changelog Entry

> Fixed - Ensure the jQuery UI Dialog CSS is loaded properly

### Credits

Props @dkotter, @faisal-alvi 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
