### PR TITLE
Show error message if title or excerpt generation fails in Classic Editor

### DIFF
--- a/src/js/openai/classic-editor-excerpt-generator.js
+++ b/src/js/openai/classic-editor-excerpt-generator.js
@@ -40,6 +40,12 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 			)
 			.insertAfter( excerptContainer );
 
+		$( '<p>', {
+			class: 'classifai-openai__excerpt-generate-error',
+		} ).insertAfter(
+			document.getElementById( 'classifai-openai__excerpt-generate-btn' )
+		);
+
 		// Append disable feature link.
 		if (
 			ClassifAI?.opt_out_enabled_features?.includes(
@@ -79,25 +85,34 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 			const spinnerEl = $(
 				'.classifai-openai__excerpt-generate-btn--spinner'
 			);
+			const errorEl = $( '.classifai-openai__excerpt-generate-error' );
 
 			generateTextEl.css( 'opacity', '0' );
 			spinnerEl.show();
+			errorEl.text( '' ).hide();
 			isProcessing = true;
 
 			const path = classifaiExcerptData?.path + postId;
 
 			apiFetch( {
 				path,
-			} ).then( ( result ) => {
-				generateTextEl.css( 'opacity', '1' );
-				spinnerEl.hide();
-				isProcessing = false;
+			} )
+				.then( ( result ) => {
+					generateTextEl.css( 'opacity', '1' );
+					spinnerEl.hide();
+					isProcessing = false;
 
-				$( excerptContainer ).val( result ).trigger( 'input' );
-				generateTextEl.text(
-					classifaiExcerptData?.regenerateText ?? ''
-				);
-			} );
+					$( excerptContainer ).val( result ).trigger( 'input' );
+					generateTextEl.text(
+						classifaiExcerptData?.regenerateText ?? ''
+					);
+				} )
+				.catch( ( error ) => {
+					generateTextEl.css( 'opacity', '1' );
+					spinnerEl.hide();
+					isProcessing = false;
+					errorEl.text( error?.message ).show();
+				} );
 		};
 
 		// Event handler registration to generate the excerpt.

--- a/src/js/openai/classic-editor-title-generator.js
+++ b/src/js/openai/classic-editor-title-generator.js
@@ -104,54 +104,71 @@ const scriptData = classifaiChatGPTData.enabledFeatures.reduce(
 
 			apiFetch( {
 				path,
-			} ).then( ( result ) => {
-				generateTextEl.css( 'opacity', '1' );
-				spinnerEl.hide();
-				isProcessing = false;
+			} )
+				.then( ( result ) => {
+					generateTextEl.css( 'opacity', '1' );
+					spinnerEl.hide();
+					isProcessing = false;
 
-				result.forEach( ( title ) => {
-					$( '<textarea>', {
-						text: title,
-					} )
+					result.forEach( ( title ) => {
+						$( '<textarea>', {
+							text: title,
+						} )
+							.wrap(
+								`<div class="classifai-openai__result-item" />`
+							)
+							.parent()
+							.append(
+								$( '<button />', {
+									text: scriptData.title.selectBtnText,
+									type: 'button',
+									class: 'button classifai-openai__select-title',
+								} )
+							)
+							.appendTo( '#classifai-openai__results-content' );
+					} );
+
+					// Append disable feature link.
+					if (
+						ClassifAI?.opt_out_enabled_features?.includes(
+							'feature_title_generation'
+						)
+					) {
+						$( '<a>', {
+							text: __(
+								'Disable this ClassifAI feature',
+								'classifai'
+							),
+							href: ClassifAI?.profile_url,
+							target: '_blank',
+							rel: 'noopener noreferrer',
+							class: 'classifai-disable-feature-link',
+						} )
+							.wrap(
+								`<div class="classifai-openai__result-disable-link" />`
+							)
+							.parent()
+							.appendTo( '#classifai-openai__modal' );
+					}
+
+					$( '#classifai-openai__results' )
+						.show()
+						.addClass( 'classifai-openai--fade-in' );
+				} )
+				.catch( ( error ) => {
+					generateTextEl.css( 'opacity', '1' );
+					spinnerEl.hide();
+					isProcessing = false;
+
+					$( '<span class="error">' )
+						.text( error?.message )
 						.wrap( `<div class="classifai-openai__result-item" />` )
-						.parent()
-						.append(
-							$( '<button />', {
-								text: scriptData.title.selectBtnText,
-								type: 'button',
-								class: 'button classifai-openai__select-title',
-							} )
-						)
 						.appendTo( '#classifai-openai__results-content' );
+
+					$( '#classifai-openai__results' )
+						.show()
+						.addClass( 'classifai-openai--fade-in' );
 				} );
-
-				// Append disable feature link.
-				if (
-					ClassifAI?.opt_out_enabled_features?.includes(
-						'feature_title_generation'
-					)
-				) {
-					$( '<a>', {
-						text: __(
-							'Disable this ClassifAI feature',
-							'classifai'
-						),
-						href: ClassifAI?.profile_url,
-						target: '_blank',
-						rel: 'noopener noreferrer',
-						class: 'classifai-disable-feature-link',
-					} )
-						.wrap(
-							`<div class="classifai-openai__result-disable-link" />`
-						)
-						.parent()
-						.appendTo( '#classifai-openai__modal' );
-				}
-
-				$( '#classifai-openai__results' )
-					.show()
-					.addClass( 'classifai-openai--fade-in' );
-			} );
 		};
 
 		// Event handler registration to generate the title.

--- a/src/scss/openai/classic-editor-title-generator.scss
+++ b/src/scss/openai/classic-editor-title-generator.scss
@@ -81,6 +81,11 @@
 		padding: 1rem;
 		padding-bottom: 1.5rem;
 		gap: 1rem;
+
+		& .error {
+			color: #dc3232;
+			font-size: 1rem;
+		}
 	}
 
 	&__close-modal-button {

--- a/src/scss/openai/classic-editor-title-generator.scss
+++ b/src/scss/openai/classic-editor-title-generator.scss
@@ -37,6 +37,12 @@
 		}
 	}
 
+	.classifai-openai__excerpt-generate-error {
+		display: none;
+		color: #dc3232;
+		text-align: right;
+	}
+
 	.classifai-openai__excerpt-generate-disable-link {
 		text-align: right;
 		margin-top: 6px;


### PR DESCRIPTION
### Description of the Change

If using either Excerpt Generation or Title Generation and you're on a site that uses the Classic Editor, if either of those features fails (for instance, if API limits are reached) the error message doesn't show. If using the Block Editor, the error messages will show.

This PR fixes that by add a `catch` statement to our API requests to ensure we output the error message when needed for both of those features.

Closes #686 

### How to test the Change

1. Enable both Title Generation and Excerpt Generation under Tools > ClassifAI > Language Processing
2. Install and activate the Classic Editor plugin
3. To easily trigger an error state, edit the `generate_excerpt` and `generate_titles` methods in the `includes/ClassifAI/Providers/OpenAI/ChatGPT.php` file, adding `$post = null` to the top of both of those
4. Edit a piece of content that supports both titles and excerpts (like a Post)
5. Click the Generate Titles button and ensure an error message is shown
6. Click the Generate Excerpt button and ensure an error message is shown
7. Remove the test changes made above and try the buttons again, ensuring a proper response is no shown

### Changelog Entry

> Added - Show error message if generating excerpts or titles fails in the Classic Editor

### Credits

Props @dkotter, @faisal-alvi 

### Checklist:

- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
