### PR TITLE
For super admins with no role set, treat them as administrators

### DIFF
--- a/includes/Classifai/Admin/UserProfile.php
+++ b/includes/Classifai/Admin/UserProfile.php
@@ -158,13 +158,19 @@ class UserProfile {
 
 				// Check if user has access to the feature by role.
 				$allowed_roles = $settings['roles'] ?? [];
-				if (
-					$role_based_access_enabled &&
-					! empty( $allowed_roles ) &&
-					! empty( array_intersect( $user_roles, $allowed_roles ) )
-				) {
-					$allowed_features[ $feature_class::ID ] = $feature_class->get_label();
-					continue;
+				if ( $role_based_access_enabled ) {
+					// For super admins that don't have a specific role on a site, treat them as admins.
+					if ( is_multisite() && is_super_admin( $user_id ) && empty( $user_roles ) ) {
+						$user_roles = [ 'administrator' ];
+					}
+
+					if (
+						! empty( $allowed_roles ) &&
+						! empty( array_intersect( $user_roles, $allowed_roles ) )
+					) {
+						$allowed_features[ $feature_class::ID ] = $feature_class->get_label();
+						continue;
+					}
 				}
 
 				// Check if user has access to the feature.

--- a/includes/Classifai/Features/Feature.php
+++ b/includes/Classifai/Features/Feature.php
@@ -938,6 +938,11 @@ abstract class Feature {
 		 * Checks if Role-based access is enabled and user role has access to the feature.
 		 */
 		if ( $role_based_access_enabled ) {
+			// For super admins that don't have a specific role on a site, treat them as admins.
+			if ( is_multisite() && is_super_admin( $user_id ) && empty( $user_roles ) ) {
+				$user_roles = [ 'administrator' ];
+			}
+
 			$access = ( ! empty( $feature_roles ) && ! empty( array_intersect( $user_roles, $feature_roles ) ) );
 		}
 


### PR DESCRIPTION
### Description of the Change

As discussed in #658, there's currently no option to set Super Admins in our role-based access for individual Features. This can result in Super Admins not having access to Features if they haven't been added as an administrator (or other allowed role) on a specific site.

We could allow Super Admins to have access to all Features but this feels a little heavy-handed. The approach we landed on and what is implemented in this PR is that anytime we check if a user has access based on their role, if we are on a multisite and the current user is a Super Admin and that user has no specific role set for that site, we set their role to administrator for checking purposes.

If a Super Admin has already been granted a specific role on a site, we use that role for checking and don't add an additional role on top of that. In addition, if a Feature has not granted access to administrators, Super Admins also won't have access.

Closes #658 

### How to test the Change

1. Set up a multisite install with ClassifAI installed on at least one site in the network
2. Set up a feature and enable role-based access, giving at least Administrators access
3. Test with a Super Admin account that hasn't been added to that particular site; ensure whatever Feature you enabled works for them
5. Enable user opt-out for that Feature; go to your profile and ensure you can opt-out of that Feature
6. Change the access level for the Feature to not include administrators
7. Ensure the Feature is no longer accessible and you don't see the option to opt out on their profile
8. Change the access level for the Feature back to include administrators
9. Add that Super Admin user to the site but give them Editor access
10. Ensure the Feature no longer works for them and they no longer see the opt-out option on their profile

### Changelog Entry

> Changed - If on a multisite install, when handling user access based on role, if a Super Admin does not have a specific role on a site, treat that user as an administrator.

### Credits

Props @dkotter, @jeffpaul, @gsarig 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
