### PR TITLE
Remove Subscriber from the list of allowed roles

### DIFF
--- a/includes/Classifai/Features/Feature.php
+++ b/includes/Classifai/Features/Feature.php
@@ -75,6 +75,9 @@ abstract class Feature {
 		$this->roles      = get_editable_roles() ?? [];
 		$this->roles      = array_combine( array_keys( $this->roles ), array_column( $this->roles, 'name' ) );
 
+		// Remove subscriber from the list of roles.
+		unset( $this->roles['subscriber'] );
+
 		/**
 		 * Filter the allowed WordPress roles for a feature.
 		 *

--- a/tests/cypress/integration/admin/common-feature-fields.test.js
+++ b/tests/cypress/integration/admin/common-feature-fields.test.js
@@ -18,13 +18,7 @@ describe('Common Feature Fields', () => {
 		feature_pdf_to_text_generation: 'PDF Text Extraction',
 	};
 
-	const allowedRoles = [
-		'administrator',
-		'editor',
-		'author',
-		'contributor',
-		'subscriber',
-	];
+	const allowedRoles = [ 'administrator', 'editor', 'author', 'contributor' ];
 
 	Object.keys( features ).forEach( ( feature ) => {
 		it( `"${ features[ feature ] }" feature common fields`, () => {
@@ -62,7 +56,7 @@ describe('Common Feature Fields', () => {
 			for ( const role of allowedRoles ) {
 				if (
 					'feature_image_generation' === feature &&
-					( 'contributor' === role || 'subscriber' === role )
+					'contributor' === role
 				) {
 					continue;
 				}


### PR DESCRIPTION
### Description of the Change

As detailed in #645, we currently show `Subscriber` in our list of Allowed roles when seeing up role-based access for all of our Features. Since this role can't do anything with content, there's no real reason to show it, so this PR removes that.

Closes #645 

### How to test the Change

Go to any Feature and ensure `Subscriber` no longer shows in the Allowed roles list

### Changelog Entry

> Changed - Remove Subscriber for the allowed roles list.

### Credits

Props @dkotter, @ankitguptaindia 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
