### PR TITLE
Removed "Enable role-based access" and "Enable user-based access" settings options from the feature settings and set to be enabled by default.

### DIFF
--- a/includes/Classifai/Admin/UserProfile.php
+++ b/includes/Classifai/Admin/UserProfile.php
@@ -147,7 +147,6 @@ class UserProfile {
 					continue;
 				}
 
-				$role_based_access_enabled  = isset( $settings['role_based_access'] ) && 1 === (int) $settings['role_based_access'];
 				$user_based_access_enabled  = isset( $settings['user_based_access'] ) && 1 === (int) $settings['user_based_access'];
 				$user_based_opt_out_enabled = isset( $settings['user_based_opt_out'] ) && 1 === (int) $settings['user_based_opt_out'];
 
@@ -158,19 +157,17 @@ class UserProfile {
 
 				// Check if user has access to the feature by role.
 				$allowed_roles = $settings['roles'] ?? [];
-				if ( $role_based_access_enabled ) {
-					// For super admins that don't have a specific role on a site, treat them as admins.
-					if ( is_multisite() && is_super_admin( $user_id ) && empty( $user_roles ) ) {
-						$user_roles = [ 'administrator' ];
-					}
+				// For super admins that don't have a specific role on a site, treat them as admins.
+				if ( is_multisite() && is_super_admin( $user_id ) && empty( $user_roles ) ) {
+					$user_roles = [ 'administrator' ];
+				}
 
-					if (
-						! empty( $allowed_roles ) &&
-						! empty( array_intersect( $user_roles, $allowed_roles ) )
-					) {
-						$allowed_features[ $feature_class::ID ] = $feature_class->get_label();
-						continue;
-					}
+				if (
+					! empty( $allowed_roles ) &&
+					! empty( array_intersect( $user_roles, $allowed_roles ) )
+				) {
+					$allowed_features[ $feature_class::ID ] = $feature_class->get_label();
+					continue;
 				}
 
 				// Check if user has access to the feature.

--- a/includes/Classifai/Admin/UserProfile.php
+++ b/includes/Classifai/Admin/UserProfile.php
@@ -147,7 +147,6 @@ class UserProfile {
 					continue;
 				}
 
-				$user_based_access_enabled  = isset( $settings['user_based_access'] ) && 1 === (int) $settings['user_based_access'];
 				$user_based_opt_out_enabled = isset( $settings['user_based_opt_out'] ) && 1 === (int) $settings['user_based_opt_out'];
 
 				// Bail if user opt-out is not enabled.
@@ -173,7 +172,6 @@ class UserProfile {
 				// Check if user has access to the feature.
 				$allowed_users = $settings['users'] ?? [];
 				if (
-					$user_based_access_enabled &&
 					! empty( $allowed_users ) &&
 					in_array( $user_id, $allowed_users, true )
 				) {

--- a/includes/Classifai/Features/Feature.php
+++ b/includes/Classifai/Features/Feature.php
@@ -179,7 +179,6 @@ abstract class Feature {
 		$shared_defaults   = [
 			'status'             => '0',
 			'roles'              => array_combine( array_keys( $this->roles ), array_keys( $this->roles ) ),
-			'user_based_access'  => 'no',
 			'users'              => [],
 			'user_based_opt_out' => 'no',
 		];
@@ -226,12 +225,6 @@ abstract class Feature {
 			$new_settings['roles'] = array_map( 'sanitize_text_field', $settings['roles'] );
 		} else {
 			$new_settings['roles'] = $current_settings['roles'];
-		}
-
-		if ( empty( $settings['user_based_access'] ) || 1 !== (int) $settings['user_based_access'] ) {
-			$new_settings['user_based_access'] = 'no';
-		} else {
-			$new_settings['user_based_access'] = '1';
 		}
 
 		// Allowed users.
@@ -457,27 +450,6 @@ abstract class Feature {
 		);
 
 		add_settings_field(
-			'user_based_access',
-			esc_html__( 'Enable user-based access', 'classifai' ),
-			[ $this, 'render_input' ],
-			$this->get_option_name(),
-			$this->get_option_name() . '_section',
-			[
-				'label_for'     => 'user_based_access',
-				'input_type'    => 'checkbox',
-				'default_value' => $settings['user_based_access'],
-				'description'   => __( 'Enables ability to select which users can access this feature.', 'classifai' ),
-				'class'         => 'classifai-user-based-access',
-			]
-		);
-
-		// Add hidden class if user-based access is disabled.
-		$users_class = 'allowed_users_row';
-		if ( ! isset( $settings['user_based_access'] ) || '1' !== $settings['user_based_access'] ) {
-			$users_class .= ' hidden';
-		}
-
-		add_settings_field(
 			'users',
 			esc_html__( 'Allowed users', 'classifai' ),
 			[ $this, 'render_allowed_users' ],
@@ -487,7 +459,7 @@ abstract class Feature {
 				'label_for'     => 'users',
 				'default_value' => $settings['users'],
 				'description'   => __( 'Users who have access to this feature.', 'classifai' ),
-				'class'         => $users_class,
+				'class'         => 'allowed_users_row',
 			]
 		);
 
@@ -902,7 +874,6 @@ abstract class Feature {
 		$feature_roles = $settings['roles'] ?? [];
 		$feature_users = array_map( 'absint', $settings['users'] ?? [] );
 
-		$user_based_access_enabled  = isset( $settings['user_based_access'] ) && 1 === (int) $settings['user_based_access'];
 		$user_based_opt_out_enabled = isset( $settings['user_based_opt_out'] ) && 1 === (int) $settings['user_based_opt_out'];
 
 		/*
@@ -916,9 +887,9 @@ abstract class Feature {
 		$access = ( ! empty( $feature_roles ) && ! empty( array_intersect( $user_roles, $feature_roles ) ) );
 
 		/*
-		 * Checks if User-based access is enabled and user has access to the feature.
+		 * Checks if has access to the feature.
 		 */
-		if ( ! $access && $user_based_access_enabled ) {
+		if ( ! $access ) {
 			$access = ( ! empty( $feature_users ) && ! empty( in_array( $user_id, $feature_users, true ) ) );
 		}
 
@@ -1130,7 +1101,6 @@ abstract class Feature {
 			__( 'Authenticated', 'classifai' )          => self::get_debug_value_text( $this->is_configured() ),
 			__( 'Status', 'classifai' )                 => self::get_debug_value_text( $feature_settings['status'], 1 ),
 			__( 'Allowed roles (titles)', 'classifai' ) => implode( ', ', $roles ?? [] ),
-			__( 'User-based access', 'classifai' )      => self::get_debug_value_text( $feature_settings['user_based_access'], 1 ),
 			__( 'Allowed users (titles)', 'classifai' ) => implode( ', ', $feature_settings['users'] ?? [] ),
 			__( 'User based opt-out', 'classifai' )     => self::get_debug_value_text( $feature_settings['user_based_opt_out'], 1 ),
 			__( 'Provider', 'classifai' )               => $feature_settings['provider'],

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -78,60 +78,6 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	} );
 } )();
 
-// Role and user based access.
-document.addEventListener( 'DOMContentLoaded', function () {
-	function toogleAllowedRolesRow( e ) {
-		const checkbox = e.target;
-		const parentTr = checkbox.closest( 'tr.classifai-role-based-access' );
-		const allowedRoles = parentTr.nextElementSibling.classList.contains(
-			'allowed_roles_row'
-		)
-			? parentTr.nextElementSibling
-			: null;
-		if ( checkbox.checked ) {
-			allowedRoles.classList.remove( 'hidden' );
-		} else {
-			allowedRoles.classList.add( 'hidden' );
-		}
-	}
-
-	function toogleAllowedUsersRow( e ) {
-		const checkbox = e.target;
-		const parentTr = checkbox.closest( 'tr.classifai-user-based-access' );
-		const allowedUsers = parentTr.nextElementSibling.classList.contains(
-			'allowed_users_row'
-		)
-			? parentTr.nextElementSibling
-			: null;
-		if ( checkbox.checked ) {
-			allowedUsers.classList.remove( 'hidden' );
-		} else {
-			allowedUsers.classList.add( 'hidden' );
-		}
-	}
-
-	const roleBasedAccessCheckBoxes = document.querySelectorAll(
-		'tr.classifai-role-based-access input[type="checkbox"]'
-	);
-	const userBasedAccessCheckBoxes = document.querySelectorAll(
-		'tr.classifai-user-based-access input[type="checkbox"]'
-	);
-
-	if ( roleBasedAccessCheckBoxes ) {
-		roleBasedAccessCheckBoxes.forEach( function ( e ) {
-			e.addEventListener( 'change', toogleAllowedRolesRow );
-			e.dispatchEvent( new Event( 'change' ) );
-		} );
-	}
-
-	if ( userBasedAccessCheckBoxes ) {
-		userBasedAccessCheckBoxes.forEach( function ( e ) {
-			e.addEventListener( 'change', toogleAllowedUsersRow );
-			e.dispatchEvent( new Event( 'change' ) );
-		} );
-	}
-} );
-
 // User Selector.
 ( () => {
 	const userSearches = document.querySelectorAll(

--- a/tests/Classifai/Providers/Azure/ComputerVisionTest.php
+++ b/tests/Classifai/Providers/Azure/ComputerVisionTest.php
@@ -72,7 +72,6 @@ class ComputerVisionTest extends WP_UnitTestCase {
 			$defaults,
 			[
 				'status' => '0',
-				'role_based_access'  => '1',
 				'roles' => [],
 				'user_based_access' => 'no',
 				'users' => [],

--- a/tests/Classifai/Providers/Azure/ComputerVisionTest.php
+++ b/tests/Classifai/Providers/Azure/ComputerVisionTest.php
@@ -73,7 +73,6 @@ class ComputerVisionTest extends WP_UnitTestCase {
 			[
 				'status' => '0',
 				'roles' => [],
-				'user_based_access' => 'no',
 				'users' => [],
 				'user_based_opt_out' => 'no',
 				'descriptive_text_fields' => [

--- a/tests/cypress/integration/admin/common-feature-fields.test.js
+++ b/tests/cypress/integration/admin/common-feature-fields.test.js
@@ -37,16 +37,6 @@ describe('Common Feature Fields', () => {
 				'name',
 				`classifai_${ feature }[status]`
 			);
-			cy.get( '#role_based_access' ).should(
-				'have.attr',
-				'name',
-				`classifai_${ feature }[role_based_access]`
-			);
-			cy.get( '#user_based_access' ).should(
-				'have.attr',
-				'name',
-				`classifai_${ feature }[user_based_access]`
-			);
 			cy.get( '#user_based_opt_out' ).should(
 				'have.attr',
 				'name',
@@ -57,7 +47,6 @@ describe('Common Feature Fields', () => {
 				'name',
 				`classifai_${ feature }[provider]`
 			);
-			cy.get( '#role_based_access' ).check();
 
 			for ( const role of allowedRoles ) {
 				if (
@@ -79,14 +68,8 @@ describe('Common Feature Fields', () => {
 				);
 			}
 
-			cy.get( '#role_based_access' ).uncheck();
-			cy.get( '.allowed_roles_row' ).should( 'not.be.visible' );
-
-			cy.get( '#user_based_access' ).check();
 			cy.get( '.allowed_users_row' ).should( 'be.visible' );
 
-			cy.get( '#user_based_access' ).uncheck();
-			cy.get( '.allowed_users_row' ).should( 'not.be.visible' );
 		} );
 	} );
 } );

--- a/tests/cypress/integration/language-processing/classify-content-ibm-watson.test.js
+++ b/tests/cypress/integration/language-processing/classify-content-ibm-watson.test.js
@@ -467,7 +467,6 @@ describe( '[Language processing] Classify content (IBM Watson - NLU) Tests', () 
 		cy.visit(
 			'/wp-admin/tools.php?page=classifai&tab=language_processing&feature=feature_classification'
 		);
-		cy.get( '#role_based_access' ).check();
 		cy.get(
 			'#classifai_feature_classification_roles_administrator'
 		).uncheck();
@@ -482,7 +481,6 @@ describe( '[Language processing] Classify content (IBM Watson - NLU) Tests', () 
 		cy.visit(
 			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=watson_nlu'
 		);
-		cy.get( '#role_based_access' ).check();
 		cy.get(
 			'#classifai_feature_classification_roles_administrator'
 		).check();
@@ -499,8 +497,15 @@ describe( '[Language processing] Classify content (IBM Watson - NLU) Tests', () 
 		cy.visit(
 			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=watson_nlu'
 		);
-		cy.get( '#role_based_access' ).uncheck();
-		cy.get( '#user_based_access' ).uncheck();
+
+		// Disable access for all roles.
+		cy.get( '.allowed_roles_row input[type="checkbox"]' ).uncheck( {
+			multiple: true,
+		} );
+
+		// Disable access for all users.
+		cy.disableFeatureForUsers();
+
 		cy.get( '#submit' ).click();
 		cy.get( '.notice' ).contains( 'Settings saved.' );
 
@@ -511,8 +516,12 @@ describe( '[Language processing] Classify content (IBM Watson - NLU) Tests', () 
 		cy.visit(
 			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=watson_nlu'
 		);
-		cy.get( '#role_based_access' ).uncheck();
-		cy.get( '#user_based_access' ).check();
+
+		// Disable access for all roles.
+		cy.get( '.allowed_roles_row input[type="checkbox"]' ).uncheck( {
+			multiple: true,
+		} );
+
 		cy.get( 'body' ).then( ( $body ) => {
 			if (
 				$body.find(
@@ -543,8 +552,14 @@ describe( '[Language processing] Classify content (IBM Watson - NLU) Tests', () 
 		cy.visit(
 			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=watson_nlu'
 		);
-		cy.get( '#role_based_access' ).check();
-		cy.get( '#user_based_access' ).uncheck();
+
+		// Enable access for all roles.
+		cy.get( '.allowed_roles_row input[type="checkbox"]' ).check( {
+			multiple: true,
+		} );
+
+		// Disable access for all users.
+		cy.disableFeatureForUsers();
 
 		cy.get( '#submit' ).click();
 		cy.get( '.notice' ).contains( 'Settings saved.' );
@@ -555,8 +570,13 @@ describe( '[Language processing] Classify content (IBM Watson - NLU) Tests', () 
 		cy.visit(
 			'/wp-admin/tools.php?page=classifai&tab=language_processing&provider=watson_nlu'
 		);
-		cy.get( '#role_based_access' ).check();
-		cy.get( '#user_based_access' ).check();
+		// Enable access for all roles.
+		cy.get( '.allowed_roles_row input[type="checkbox"]' ).check( {
+			multiple: true,
+		} );
+
+		// Disable access for all users.
+		cy.disableFeatureForUsers();
 		cy.get( '#user_based_opt_out' ).check();
 
 		cy.get( '#submit' ).click();

--- a/tests/cypress/integration/language-processing/classify-content-openapi-embeddings.test.js
+++ b/tests/cypress/integration/language-processing/classify-content-openapi-embeddings.test.js
@@ -223,8 +223,8 @@ describe( '[Language processing] Classify Content (OpenAI) Tests', () => {
 			'/wp-admin/tools.php?page=classifai&tab=language_processing'
 		);
 
-		// Disable user-based access.
-		cy.get( '#user_based_access' ).uncheck();
+		// Disable access for all users.
+		cy.disableFeatureForUsers();
 
 		cy.get( '#submit' ).click();
 

--- a/tests/cypress/integration/language-processing/excerpt-generation-openapi-chatgpt.test.js
+++ b/tests/cypress/integration/language-processing/excerpt-generation-openapi-chatgpt.test.js
@@ -27,7 +27,6 @@ describe( '[Language processing] Excerpt Generation Tests', () => {
 		cy.get( '#api_key' ).clear().type( 'password' );
 
 		cy.get( '#status' ).check();
-		cy.get( '#role_based_access' ).check();
 		cy.get(
 			'#classifai_feature_excerpt_generation_roles_administrator'
 		).check();

--- a/tests/cypress/integration/language-processing/moderation-openai-moderation.test.js
+++ b/tests/cypress/integration/language-processing/moderation-openai-moderation.test.js
@@ -23,7 +23,6 @@ describe( '[Language processing] Moderation Tests', () => {
 		cy.get(
 			'#classifai_feature_moderation_content_types_comments'
 		).check();
-		cy.get( '#role_based_access' ).check();
 		cy.get( '#classifai_feature_moderation_roles_administrator' ).check();
 		cy.get( '#submit' ).click();
 	} );


### PR DESCRIPTION
### Description of the Change
As described in #691, PR removes the "Enable role-based access" and "Enable user-based access" options and sets them to be enabled by default, aiming to eliminate confusion among users.

| Before | After |
| --- | --- |
| ![image](https://github.com/10up/classifai/assets/10613171/fbcf7bf6-5811-4af2-8fa7-cc785f997078) | ![image](https://github.com/10up/classifai/assets/10613171/8d6525d4-b6f8-456d-a3ee-974aa0b8523f) |

Closes #691 

### How to test the Change
1. Go to ClassifAI feature settings.
1. Select roles in the allowed roles to provide access to that feature.
1. Verify that only the selected roles have access to that feature.
1. Select the user in the allowed users to provide access to that feature.
1. Verify that the selected user has access to that feature.
1. Enable user-based opt-out for the feature.
1. Go to the user profile and verify that you see the checkbox for that feature to opt out of using it.
1. Check the opt-out checkbox and save.
1. Verify that access to that feature has been disabled.
1. Uncheck the opt-out checkbox to opt back in to the feature.
1. Verify that the user now has access to that feature.
1. Follow these steps for each ClassifAI feature.


### Changelog Entry
> Removed - "Enable role-based access" and "Enable user-based access" settings options have been removed from the feature settings and set to be enabled by default.


### Credits
Props @jeffpaul @dkotter @jeffpaul 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
