### PR TITLE
Add a bottom margin to the Classify button if needed

### DIFF
--- a/src/scss/language-processing.scss
+++ b/src/scss/language-processing.scss
@@ -187,3 +187,13 @@
         }
     }
 }
+
+.classifai-panel {
+	#classify-post-component {
+		margin-bottom: 12px;
+	}
+
+	div:last-of-type {
+		margin-bottom: 0!important;
+	}
+}


### PR DESCRIPTION
### Description of the Change

When the Classification feature is turned on but the toggle is turned off, a button is shown. If the Text to Speech Feature is turned on, it renders toggles within the same panel and the classification button collides, as it doesn't have any bottom spacing (see screenshot on #664).

This PR fixes that by adding some CSS that adds a bottom margin to the button container but removes that spacing if the button is the last element in the list (to avoid extra spacing when it isn't needed).

<img width="292" alt="Classification button with bottom margin" src="https://github.com/10up/classifai/assets/916738/774d329f-9e4d-47fd-9190-3e2c7153f7bd">

Closes #664

### How to test the Change

1. Turn on both the Classification Feature and Text to Speech Feature
2. Edit an item that supports both
3. Turn off the `Automatically tag content on update` toggle
4. Ensure the button that shows has proper bottom spacing

### Changelog Entry

> Fixed - Ensure the classification button has proper bottom spacing

### Credits

Props @dkotter, @QAharshalkadu 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
