### PR TITLE
FE fixes for the Text to Speech controls

### DIFF
--- a/includes/Classifai/Features/TextToSpeech.php
+++ b/includes/Classifai/Features/TextToSpeech.php
@@ -66,6 +66,10 @@ class TextToSpeech extends Feature {
 	public function setup() {
 		parent::setup();
 		add_action( 'rest_api_init', [ $this, 'register_endpoints' ] );
+
+		if ( $this->is_enabled() ) {
+			add_filter( 'the_content', [ $this, 'render_post_audio_controls' ] );
+		}
 	}
 
 	/**
@@ -81,10 +85,6 @@ class TextToSpeech extends Feature {
 
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_box' ] );
 		add_action( 'save_post', [ $this, 'save_post_metadata' ], 5 );
-
-		if ( $this->is_enabled() ) {
-			add_filter( 'the_content', [ $this, 'render_post_audio_controls' ] );
-		}
 	}
 
 	/**
@@ -621,7 +621,7 @@ class TextToSpeech extends Feature {
 		wp_enqueue_style(
 			'classifai-post-audio-player-css',
 			CLASSIFAI_PLUGIN_URL . 'dist/post-audio-controls.css',
-			array(),
+			array( 'dashicons' ),
 			get_asset_info( 'post-audio-controls', 'version' ),
 			'all'
 		);


### PR DESCRIPTION
### Description of the Change

In #666, it was reported that the play icon wasn't showing in Safari for the Text to Speech FE controls. I tested and was able to reproduce but I found additional issues. The audio block wasn't rendering in any browser for user's that weren't logged in (which is a newly introduced issue out of #611) and the icon wasn't showing for me in any browser if I wasn't logged in.

This PR fixes both of those issues by ensuring the block is rendered even if we don't have a logged in user and ensuring the dashicon font is loaded with our custom CSS.

Closes #666

### How to test the Change

1. Turn on the Text to Speech feature
2. Ensure a piece of content has speech generated
3. View that content on the front-end and ensure the audio block is showing for both logged-in and non-logged in users
4. Ensure the play and pause icons are showing in Safari and other browsers

### Changelog Entry

> Fixed - Load the dashicon font when the Text to Speech block is used to ensure icons display.
> Fixed - Ensure the Text to Speech block is rendered for non-logged in users.

### Credits

Props @dkotter, @QAharshalkadu 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
