### PR TITLE
Fixed IBM Waston NLU Credentials toggle link in the ClassifAI setup.

### DIFF
--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -33,6 +33,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 ( () => {
 	const $toggler = document.getElementById( 'classifai-waston-cred-toggle' );
 	const $userField = document.getElementById( 'username' );
+	const isSetupPage = document.querySelector( '.classifai-setup-form' )
+		? true
+		: false;
 
 	if ( $toggler === null || $userField === null ) {
 		return;
@@ -42,8 +45,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	let $passwordFieldTitle = null;
 	if ( $userField.closest( 'tr' ) ) {
 		$userFieldWrapper = $userField.closest( 'tr' );
-	} else if ( $userField.closest( '.classifai-setup-form-field' ) ) {
-		$userFieldWrapper = $userField.closest( '.classifai-setup-form-field' );
+		if ( isSetupPage ) {
+			$userFieldWrapper = $userField.closest( 'td' );
+		}
 	}
 
 	if ( document.getElementById( 'password' ).closest( 'tr' ) ) {
@@ -51,20 +55,27 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			.getElementById( 'password' )
 			.closest( 'tr' )
 			.getElementsByTagName( 'label' );
-	} else if (
-		document
-			.getElementById( 'password' )
-			.closest( '.classifai-setup-form-field' )
-	) {
-		[ $passwordFieldTitle ] = document
-			.getElementById( 'password' )
-			.closest( '.classifai-setup-form-field' )
-			.getElementsByTagName( 'label' );
+
+		if ( isSetupPage ) {
+			$passwordFieldTitle = document.querySelector(
+				'label[for="password"]'
+			);
+		}
 	}
 
 	$toggler.addEventListener( 'click', ( e ) => {
 		e.preventDefault();
 		$userFieldWrapper.classList.toggle( 'hide-username' );
+
+		if (
+			isSetupPage &&
+			document.querySelector( 'label[for="username"]' )
+		) {
+			document
+				.querySelector( 'label[for="username"]' )
+				.closest( 'th' )
+				.classList.toggle( 'hide-username' );
+		}
 
 		if ( $userFieldWrapper.classList.contains( 'hide-username' ) ) {
 			$toggler.innerText = ClassifAI.use_password;


### PR DESCRIPTION
### Description of the Change
As reported in #696, the toggle link for the NLU Credentials toggle link not working in the ClassifAI setup. PR fixes the toggle link and ensures it works properly in the ClassifAI setup.

Closes #696 

### How to test the Change
1. Go to ClassifAI setup
2. Enable the "Classification" feature in step 1, Click "Start Setup"
3. Navigate to Step 3 (Set up AI Providers)
4. Select (IBM Waston NLU) as a provider
5. Click on `Use a username/password instead?`/`Use an API Key instead?` links
6. Verify that the toggle link works properly.

### Changelog Entry
> Fixed - Ensure that the IBM Watson NLU Credentials toggle link works properly in the ClassifAI setup.

### Credits
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
