### PR TITLE
Show deprecation message on the Recommended Content feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Tap into leading cloud-based services like [OpenAI](https://openai.com/), [Micro
 * Moderate incoming comments for sensitive content using [OpenAI's Moderation API](https://platform.openai.com/docs/guides/moderation)
 * Convert text content into audio and output a "read-to-me" feature on the front-end to play this audio using [Microsoft Azure's Text to Speech API](https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/text-to-speech)
 * Classify post content using [IBM Watson's Natural Language Understanding API](https://www.ibm.com/watson/services/natural-language-understanding/) and [OpenAI's Embedding API](https://platform.openai.com/docs/guides/embeddings)
-* BETA: Recommend content based on overall site traffic via [Microsoft Azure's AI Personalizer API](https://azure.microsoft.com/en-us/services/cognitive-services/personalizer/) _(note that we're gathering feedback on this feature and may significantly iterate depending on community input)_
+* BETA: Recommend content based on overall site traffic via [Microsoft Azure's AI Personalizer API](https://azure.microsoft.com/en-us/services/cognitive-services/personalizer/) _(note that this service has been deprecated by Microsoft and as such, will no longer work. We are looking to replace this with a new provider to maintain the same functionality)_
 * Generate image alt text, image tags, and smartly crop images using [Microsoft Azure's AI Vision API](https://azure.microsoft.com/en-us/services/cognitive-services/computer-vision/)
 * Scan images and PDF files for embedded text and save for use in post meta using [Microsoft Azure's AI Vision API](https://azure.microsoft.com/en-us/services/cognitive-services/computer-vision/)
 * Bulk classify content with [WP-CLI](https://wp-cli.org/)
@@ -392,6 +392,8 @@ Note that [Azure AI Vision](https://docs.microsoft.com/en-us/azure/cognitive-ser
 * Select "Comments" in the "Content to moderate" section.
 
 ## Set Up Recommended Content (via Microsoft Azure AI Personalizer)
+
+Azure AI Personalizer has been retired by Microsoft as of September 2023. The service will continue to work until 2026 but Personalizer resources can no longer be created. As such, consider this provider deprecated and we will be removing this in the near future. We are hoping to replace with a new provider to maintain the same functionality.
 
 Note that [Personalizer](https://azure.microsoft.com/en-us/services/cognitive-services/personalizer/) requires sufficient data volume to enable Personalizer to learn. In general, we recommend a minimum of ~1,000 events per day to ensure Personalizer learns effectively. If Personalizer doesn't receive sufficient data, the service takes longer to determine the best actions.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Tap into leading cloud-based services like [OpenAI](https://openai.com/), [Micro
 * Moderate incoming comments for sensitive content using [OpenAI's Moderation API](https://platform.openai.com/docs/guides/moderation)
 * Convert text content into audio and output a "read-to-me" feature on the front-end to play this audio using [Microsoft Azure's Text to Speech API](https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/text-to-speech)
 * Classify post content using [IBM Watson's Natural Language Understanding API](https://www.ibm.com/watson/services/natural-language-understanding/) and [OpenAI's Embedding API](https://platform.openai.com/docs/guides/embeddings)
-* BETA: Recommend content based on overall site traffic via [Microsoft Azure's AI Personalizer API](https://azure.microsoft.com/en-us/services/cognitive-services/personalizer/) _(note that this service has been deprecated by Microsoft and as such, will no longer work. We are looking to replace this with a new provider to maintain the same functionality)_
+* BETA: Recommend content based on overall site traffic via [Microsoft Azure's AI Personalizer API](https://azure.microsoft.com/en-us/services/cognitive-services/personalizer/) *(note that this service has been [deprecated by Microsoft](https://learn.microsoft.com/en-us/azure/ai-services/personalizer/) and as such, will no longer work. We are looking to replace this with a new provider to maintain the same functionality (see [issue#392](https://github.com/10up/classifai/issues/392))*
 * Generate image alt text, image tags, and smartly crop images using [Microsoft Azure's AI Vision API](https://azure.microsoft.com/en-us/services/cognitive-services/computer-vision/)
 * Scan images and PDF files for embedded text and save for use in post meta using [Microsoft Azure's AI Vision API](https://azure.microsoft.com/en-us/services/cognitive-services/computer-vision/)
 * Bulk classify content with [WP-CLI](https://wp-cli.org/)
@@ -393,7 +393,7 @@ Note that [Azure AI Vision](https://docs.microsoft.com/en-us/azure/cognitive-ser
 
 ## Set Up Recommended Content (via Microsoft Azure AI Personalizer)
 
-Azure AI Personalizer has been retired by Microsoft as of September 2023. The service will continue to work until 2026 but Personalizer resources can no longer be created. As such, consider this provider deprecated and we will be removing this in the near future. We are hoping to replace with a new provider to maintain the same functionality.
+Azure AI Personalizer has been retired by Microsoft [as of September 2023](https://learn.microsoft.com/en-us/azure/ai-services/personalizer/). The service will continue to work until 2026 but Personalizer resources can no longer be created. As such, consider this provider deprecated and be aware that we will be removing this in the near future. We are hoping to replace with a new provider to maintain the same functionality (see [issue#392](https://github.com/10up/classifai/issues/392)).
 
 Note that [Personalizer](https://azure.microsoft.com/en-us/services/cognitive-services/personalizer/) requires sufficient data volume to enable Personalizer to learn. In general, we recommend a minimum of ~1,000 events per day to ensure Personalizer learns effectively. If Personalizer doesn't receive sufficient data, the service takes longer to determine the best actions.
 

--- a/includes/Classifai/Features/RecommendedContent.php
+++ b/includes/Classifai/Features/RecommendedContent.php
@@ -27,7 +27,7 @@ class RecommendedContent extends Feature {
 
 		// Contains just the providers this feature supports.
 		$this->supported_providers = [
-			PersonalizerProvider::ID => __( 'Microsoft AI Personalizer', 'classifai' ),
+			PersonalizerProvider::ID => __( 'Microsoft Azure AI Personalizer', 'classifai' ),
 		];
 	}
 

--- a/includes/Classifai/Providers/Azure/Personalizer.php
+++ b/includes/Classifai/Providers/Azure/Personalizer.php
@@ -70,7 +70,22 @@ class Personalizer extends Provider {
 
 		<div class="notice notice-warning">
 			<p>
-				<?php esc_html_e( 'As of September 2023, new Personalizer resources can no longer be created in Azure. This is currently the only provider available for the Recommended Content feature and as such, this feature will not work unless you had previously created a Personalizer resource. The Azure AI Personalizer provider is deprecated and will be removed in a future release. We hope to replace this provider with another one in a coming release to continue to support this feature.', 'classifai' ); ?>
+				<?php
+				printf(
+					wp_kses(
+						// translators: 1 - link to Personalizer documentation; 2 - link to GitHub issue.
+						__( '<a href="%1$s" target="_blank">As of September 2023</a>, new Personalizer resources can no longer be created in Azure. This is currently the only provider available for the Recommended Content feature and as such, this feature will not work unless you had previously created a Personalizer resource. The Azure AI Personalizer provider is deprecated and will be removed in a future release. We hope to replace this provider with another one in a coming release to continue to support this feature (see <a href="%2$s" target="_blank">issue#392</a>).', 'classifai' ),
+						array(
+							'a' => array(
+								'href'   => array(),
+								'target' => array(),
+							),
+						)
+					),
+					'https://learn.microsoft.com/en-us/azure/ai-services/personalizer/',
+					'https://github.com/10up/classifai/issues/392'
+				)
+				?>
 			</p>
 		</div>
 
@@ -97,8 +112,8 @@ class Personalizer extends Provider {
 				'class'         => 'large-text classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
 				'description'   => sprintf(
 					wp_kses(
-						// translators: 1 - link to create a Personalizer resource.
-						__( 'Azure AI Personalizer Endpoint; <a href="%1$s" target="_blank">create a Personalizer resource</a> in the Azure portal to get your key and endpoint. Note that as of September 2023, it is no longer possible to create this resource. Previously created Personalizer resources can still be used.', 'classifai' ),
+						// translators: 1 - link to create a Personalizer resource; 2 - link to GitHub issue.
+						__( 'Azure AI Personalizer Endpoint; <a href="%1$s" target="_blank">create a Personalizer resource</a> in the Azure portal to get your key and endpoint. Note that <a href="%2$s" target="_blank">as of September 2023</a>, it is no longer possible to create this resource. Previously created Personalizer resources can still be used.', 'classifai' ),
 						array(
 							'a' => array(
 								'href'   => array(),
@@ -106,7 +121,8 @@ class Personalizer extends Provider {
 							),
 						)
 					),
-					esc_url( 'https://portal.azure.com/#create/Microsoft.CognitiveServicesPersonalizer' )
+					'https://portal.azure.com/#create/Microsoft.CognitiveServicesPersonalizer',
+					'https://learn.microsoft.com/en-us/azure/ai-services/personalizer/'
 				),
 			]
 		);

--- a/includes/Classifai/Providers/Azure/Personalizer.php
+++ b/includes/Classifai/Providers/Azure/Personalizer.php
@@ -47,12 +47,34 @@ class Personalizer extends Provider {
 	 * Register the functionality.
 	 */
 	public function register() {
+		add_action( 'classifai_before_feature_nav', [ $this, 'show_deprecation_message' ] );
+
 		if ( ( new RecommendedContent() )->is_feature_enabled() ) {
 			add_action( 'wp_ajax_classifai_render_recommended_content', [ $this, 'ajax_render_recommended_content' ] );
 			add_action( 'wp_ajax_nopriv_classifai_render_recommended_content', [ $this, 'ajax_render_recommended_content' ] );
 			add_action( 'save_post', [ $this, 'maybe_clear_transient' ] );
 			Blocks\setup();
 		}
+	}
+
+	/**
+	 * Show a deprecation message for the provider.
+	 *
+	 * @param string $active_feature Feature currently shown.
+	 */
+	public function show_deprecation_message( string $active_feature ) {
+		if ( 'feature_recommended_content' !== $active_feature ) {
+			return;
+		}
+		?>
+
+		<div class="notice notice-warning">
+			<p>
+				<?php esc_html_e( 'As of September 2023, new Personalizer resources can no longer be created in Azure. This is currently the only provider available for the Recommended Content feature and as such, this feature will not work unless you had previously created a Personalizer resource. The Azure AI Personalizer provider is deprecated and will be removed in a future release. We hope to replace this provider with another one in a coming release to continue to support this feature.', 'classifai' ); ?>
+			</p>
+		</div>
+
+		<?php
 	}
 
 	/**
@@ -76,7 +98,7 @@ class Personalizer extends Provider {
 				'description'   => sprintf(
 					wp_kses(
 						// translators: 1 - link to create a Personalizer resource.
-						__( 'Azure AI Personalizer Endpoint, <a href="%1$s" target="_blank">create a Personalizer resource</a> in the Azure portal to get your key and endpoint.', 'classifai' ),
+						__( 'Azure AI Personalizer Endpoint; <a href="%1$s" target="_blank">create a Personalizer resource</a> in the Azure portal to get your key and endpoint. Note that as of September 2023, it is no longer possible to create this resource. Previously created Personalizer resources can still be used.', 'classifai' ),
 						array(
 							'a' => array(
 								'href'   => array(),

--- a/includes/Classifai/Services/Service.php
+++ b/includes/Classifai/Services/Service.php
@@ -149,6 +149,7 @@ abstract class Service {
 			<?php
 			include_once CLASSIFAI_PLUGIN_DIR . '/includes/Classifai/Admin/templates/classifai-header.php';
 			?>
+
 			<div class="classifai-wrap wrap wrap--nlu">
 				<h2><?php echo esc_html( $this->display_name ); ?></h2>
 
@@ -160,6 +161,18 @@ abstract class Service {
 				}
 				?>
 
+				<?php
+				/**
+				 * Fires before the feature tab navigation.
+				 *
+				 * @since 3.0.0
+				 * @hook classifai_before_feature_nav
+				 *
+				 * @param {string} $active_feature Current active feature.
+				 */
+				do_action( 'classifai_before_feature_nav', $active_feature );
+				?>
+
 				<h2 class="nav-tab-wrapper">
 					<?php foreach ( $this->feature_classes as $feature_class ) : ?>
 						<a href="<?php echo esc_url( add_query_arg( 'feature', $feature_class::ID, $base_url ) ); ?>" class="nav-tab <?php echo $feature_class::ID === $active_feature ? 'nav-tab-active' : ''; ?>"><?php echo esc_html( $feature_class->get_label() ); ?></a>
@@ -169,6 +182,18 @@ abstract class Service {
 				<?php settings_errors(); ?>
 
 				<div class="classifai-nlu-sections">
+					<?php
+					/**
+					 * Fires before the settings form for a feature.
+					 *
+					 * @since 3.0.0
+					 * @hook classifai_before_feature_settings_form
+					 *
+					 * @param {string} $active_feature Current active feature.
+					 */
+					do_action( 'classifai_before_feature_settings_form', $active_feature );
+					?>
+
 					<form method="post" action="options.php">
 					<?php
 						settings_fields( 'classifai_' . $active_feature );
@@ -184,7 +209,7 @@ abstract class Service {
 					 * @since 3.0.0
 					 * @hook classifai_after_feature_settings_form
 					 *
-					 * @param {array} $active_feature Array of active features.
+					 * @param {string} $active_feature Current active feature.
 					 */
 					do_action( 'classifai_after_feature_settings_form', $active_feature );
 					?>

--- a/readme.txt
+++ b/readme.txt
@@ -25,7 +25,7 @@ Tap into leading cloud-based services like [OpenAI](https://openai.com/), [Micro
 * Generate transcripts of audio files using [OpenAI's Whisper API](https://platform.openai.com/docs/guides/speech-to-text)
 * Convert text content into audio and output a "read-to-me" feature on the front-end to play this audio using [Microsoft Azure's Text to Speech API](https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/text-to-speech)
 * Classify post content using [IBM Watson's Natural Language Understanding API](https://www.ibm.com/watson/services/natural-language-understanding/) and [OpenAI's Embedding API](https://platform.openai.com/docs/guides/embeddings)
-* BETA: Recommend content based on overall site traffic via [Microsoft Azure's AI Personalizer API](https://azure.microsoft.com/en-us/services/cognitive-services/personalizer/) _(note that we're gathering feedback on this feature and may significantly iterate depending on community input)_
+* BETA: Recommend content based on overall site traffic via [Microsoft Azure's AI Personalizer API](https://azure.microsoft.com/en-us/services/cognitive-services/personalizer/) _(note that this service has been deprecated by Microsoft and as such, will no longer work. We are looking to replace this with a new provider to maintain the same functionality)_
 * Generate image alt text, image tags, and smartly crop images using [Microsoft Azure's AI Vision API](https://azure.microsoft.com/en-us/services/cognitive-services/computer-vision/)
 * Scan images and PDF files for embedded text and save for use in post meta using [Microsoft Azure's AI Vision API](https://azure.microsoft.com/en-us/services/cognitive-services/computer-vision/)
 * Bulk classify content with [WP-CLI](https://wp-cli.org/)


### PR DESCRIPTION
### Description of the Change

Currently the only Provider for the Recommended Content Feature is Azure AI Personalizer. Microsoft announced that no Personalizer resources can no longer be created and the full resource is being retired in 2026.

We hope to find a replacement Provider for this Feature so for now, instead of completely removing this Provider and Feature, we're leaving things in place but showing a message, letting users know this Feature won't work unless they had previously created a Personalizer resource.

Closes #672 

<img width="1309" alt="Recommended Content deprecation notice" src="https://github.com/10up/classifai/assets/916738/10edb645-b66e-4b75-9bf4-d77b203b70fc">

### How to test the Change

Go to the Recommendation Service settings page and see the notice. Go to other settings pages and make sure the message doesn't show

### Changelog Entry

> Deprecated - Show deprecation notice for the Azure AI Personalizer provider, as this will be removed in a coming release

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
