### PR TITLE
Fix fatal error in the PDF text extraction from the media row actions.

### DIFF
--- a/includes/Classifai/Admin/BulkActions.php
+++ b/includes/Classifai/Admin/BulkActions.php
@@ -446,7 +446,8 @@ class BulkActions {
 					break;
 
 				case PDFTextExtraction::ID:
-					if ( attachment_is_pdf( $attachment_id ) ) {
+					$attachment = get_post( $attachment_id );
+					if ( attachment_is_pdf( $attachment ) ) {
 						( new PDFTextExtraction() )->run( $attachment_id, 'read_pdf' );
 					}
 					break;

--- a/includes/Classifai/Features/PDFTextExtraction.php
+++ b/includes/Classifai/Features/PDFTextExtraction.php
@@ -73,7 +73,7 @@ class PDFTextExtraction extends Feature {
 						'required'          => true,
 						'type'              => 'integer',
 						'sanitize_callback' => 'absint',
-						'description'       => esc_html__( 'Image ID to generate alt text for.', 'classifai' ),
+						'description'       => esc_html__( 'Attachment ID to extact text from the PDF file.', 'classifai' ),
 					],
 				],
 				'permission_callback' => [ $this, 'read_pdf_permissions_check' ],


### PR DESCRIPTION
### Description of the Change
PR fixes the fatal error reported in #701. Currrently, when we try to extract text from PDF using the media list table row actions. it throws a fatal error. This PR fixes it.

Closes #701 

### How to test the Change
1. Go to Media > Add New Media File
2. Upload PDF file
3. Go to Media > Library
4. Switch view mode to list, it will change media view to list table view.
5. Click on the "Extract text from PDF" action of uploaded PDF file
6. Verify there is no fatal error and text extracted from the PDF.

### Changelog Entry
> Fixed - Ensure that the "Extract text from PDF" row action works properly in the media list table.


### Credits
Props @qasumitbagthariya @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
