### PR TITLE
Ensure the stand-alone Generate Image page loads under the media grid mode

### DIFF
--- a/includes/Classifai/Features/ImageGeneration.php
+++ b/includes/Classifai/Features/ImageGeneration.php
@@ -137,7 +137,7 @@ class ImageGeneration extends Feature {
 			$number_of_images > 1 ? esc_html__( 'Generate Images', 'classifai' ) : esc_html__( 'Generate Image', 'classifai' ),
 			$number_of_images > 1 ? esc_html__( 'Generate Images', 'classifai' ) : esc_html__( 'Generate Image', 'classifai' ),
 			'upload_files',
-			esc_url( admin_url( 'upload.php?action=classifai-generate-image' ) ),
+			esc_url( admin_url( 'upload.php?action=classifai-generate-image&mode=grid' ) ),
 			''
 		);
 	}


### PR DESCRIPTION
### Description of the Change

As reported in #703, if you go to the Media Library and switch that to display in the List mode instead of the default Grid mode, if you then go to the stand-alone Generate Image page, you'll get an access error.

It seems that that Generate Image page requires some things that the Grid mode view loads. This PR fixes that by ensuring the link for the Generate Image page loads under the Grid mode.

Closes #703 

### How to test the Change

Follow the steps from the issue and ensure the problem no longer happens

### Changelog Entry

> Fixed - Ensure the stand-alone Generate Image page works if the Media Library is loaded in list mode

### Credits

Props @dkotter, @Sidsector9, @qasumitbagthariya 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
