### PR TITLE
Removed type declaration from the `attachment_is_pdf()` parameter.

### DIFF
--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -279,10 +279,10 @@ function get_modified_image_source_url( int $post_id ) {
 /**
  * Check if attachment is PDF document.
  *
- * @param \WP_Post $post Post object for the attachment being viewed.
+ * @param int|\WP_Post $post Post object for the attachment being viewed.
  * @return bool
  */
-function attachment_is_pdf( \WP_Post $post ): bool {
+function attachment_is_pdf( $post ): bool {
 	$mime_type          = get_post_mime_type( $post );
 	$matched_extensions = explode( '|', array_search( $mime_type, wp_get_mime_types(), true ) );
 


### PR DESCRIPTION
### Description of the Change
PR removes type declaration from the `attachment_is_pdf()` parameter. As mentioned on #710 `attachment_is_pdf()` is essentially a wrapper for get_post_mime_type(), it can accept either the post ID as an integer or a post object. Therefore, to accept either the post ID as an integer or a post object in `attachment_is_pdf()` method, type declaration from the parameter has been removed.

Closes #710 

### How to test the Change
1. Confirm type declaration removal from the GH UI.

### Changelog Entry
> Removed - Type declaration from the `attachment_is_pdf()` parameter.

### Credits
Props @peterwilsoncc @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
