### PR TITLE
Ensure both arguments passed to `merge_settings` are an `array`

### DIFF
--- a/includes/Classifai/Features/DescriptiveTextGenerator.php
+++ b/includes/Classifai/Features/DescriptiveTextGenerator.php
@@ -357,7 +357,7 @@ class DescriptiveTextGenerator extends Feature {
 			[
 				'label_for'      => 'descriptive_text_fields',
 				'options'        => $checkbox_options,
-				'default_values' => is_array( $settings['descriptive_text_fields'] ) ? $settings['descriptive_text_fields'] : [],
+				'default_values' => $settings['descriptive_text_fields'],
 				'description'    => __( 'Choose image fields where the generated text should be applied.', 'classifai' ),
 			]
 		);

--- a/includes/Classifai/Features/DescriptiveTextGenerator.php
+++ b/includes/Classifai/Features/DescriptiveTextGenerator.php
@@ -307,12 +307,13 @@ class DescriptiveTextGenerator extends Feature {
 		$settings       = $this->get_settings();
 		$enabled_fields = array();
 
-		if (
-			! isset( $settings['descriptive_text_fields'] ) ||
-			! is_array( $settings['descriptive_text_fields'] )
-		) {
+		if ( ! isset( $settings['descriptive_text_fields'] ) ) {
+			return array();
+		}
+
+		if ( ! is_array( $settings['descriptive_text_fields'] ) ) {
 			return array(
-				'alt'         => 0,
+				'alt'         => 'no' === $settings['descriptive_text_fields'] ? 0 : 'alt',
 				'caption'     => 0,
 				'description' => 0,
 			);

--- a/includes/Classifai/Features/DescriptiveTextGenerator.php
+++ b/includes/Classifai/Features/DescriptiveTextGenerator.php
@@ -307,13 +307,12 @@ class DescriptiveTextGenerator extends Feature {
 		$settings       = $this->get_settings();
 		$enabled_fields = array();
 
-		if ( ! isset( $settings['descriptive_text_fields'] ) ) {
-			return array();
-		}
-
-		if ( ! is_array( $settings['descriptive_text_fields'] ) ) {
+		if (
+			! isset( $settings['descriptive_text_fields'] ) ||
+			! is_array( $settings['descriptive_text_fields'] )
+		) {
 			return array(
-				'alt'         => 'no' === $settings['descriptive_text_fields']['caption'] ? 0 : 'alt',
+				'alt'         => 0,
 				'caption'     => 0,
 				'description' => 0,
 			);
@@ -357,7 +356,7 @@ class DescriptiveTextGenerator extends Feature {
 			[
 				'label_for'      => 'descriptive_text_fields',
 				'options'        => $checkbox_options,
-				'default_values' => $settings['descriptive_text_fields'],
+				'default_values' => is_array( $settings['descriptive_text_fields'] ) ? $settings['descriptive_text_fields'] : [],
 				'description'    => __( 'Choose image fields where the generated text should be applied.', 'classifai' ),
 			]
 		);

--- a/includes/Classifai/Features/Feature.php
+++ b/includes/Classifai/Features/Feature.php
@@ -311,12 +311,12 @@ abstract class Feature {
 	 * Returns the settings for the feature.
 	 *
 	 * @param string $index The index of the setting to return.
-	 * @return array|string
+	 * @return array|mixed
 	 */
 	public function get_settings( $index = false ) {
 		$defaults = $this->get_default_settings();
 		$settings = get_option( $this->get_option_name(), [] );
-		$settings = $this->merge_settings( $settings, $defaults );
+		$settings = $this->merge_settings( (array) $settings, (array) $defaults );
 
 		if ( $index && isset( $settings[ $index ] ) ) {
 			return $settings[ $index ];
@@ -395,7 +395,7 @@ abstract class Feature {
 		foreach ( $defaults as $key => $value ) {
 			if ( ! isset( $settings[ $key ] ) ) {
 				$settings[ $key ] = $defaults[ $key ];
-			} elseif ( is_array( $value ) ) {
+			} elseif ( is_array( $settings[ $key ] ) && is_array( $value ) ) {
 				$settings[ $key ] = $this->merge_settings( $settings[ $key ], $defaults[ $key ] );
 			}
 		}

--- a/includes/Classifai/Features/Feature.php
+++ b/includes/Classifai/Features/Feature.php
@@ -395,8 +395,12 @@ abstract class Feature {
 		foreach ( $defaults as $key => $value ) {
 			if ( ! isset( $settings[ $key ] ) ) {
 				$settings[ $key ] = $defaults[ $key ];
-			} elseif ( is_array( $settings[ $key ] ) && is_array( $value ) ) {
-				$settings[ $key ] = $this->merge_settings( $settings[ $key ], $defaults[ $key ] );
+			} elseif ( is_array( $value ) ) {
+				if ( is_array( $settings[ $key ] ) ) {
+					$settings[ $key ] = $this->merge_settings( $settings[ $key ], $defaults[ $key ] );
+				} else {
+					$settings[ $key ] = $defaults[ $key ];
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description of the Change

We have a `merge_settings` method that takes in stored settings as well as the default settings and merges those together. This method expects both of these values to be an `array`, so if non-array data is passed in, a PHP error occurs.

This method is called recursively to merge settings that contain array data. This was throwing a fatal error in #732 because the passed in settings were not an array but the default settings were.

This PR adds additional checks here to ensure we only ever call `merge_settings` if both the stored settings and default settings are an array. For instances were the stored settings aren't an array but the defaults are, we override the stored settings with the defaults as it seems the only time this happens is when data has been stored improperly (or not migrated properly in v3.0.0).

In addition, some followup in #732 pointed to some additional issues in the descriptive text generator feature where it expects array data but is instead passed in non-array data. In theory this should never happen but again, in scenarios where data is stored improperly or migrated wrong, I've added additional checks to avoid PHP errors and warnings.

Closes #732 

### How to test the Change

There are good details in #732 but I've not been able to replicate the problem yet without manually manipulating data.

Here's the steps I followed:

1. Install the 2.5.1 version of ClassifAI
2. Configure settings as seen in the screenshots from #732 
3. Deactivate the plugin and install and activate the 3.0.0 version of the plugin
4. Go to the ClassifAI settings screens and note the settings that have been migrated over and should see no errors
5. Manually change the `classifai_feature_descriptive_text_generator` option in the database. Change the `descriptive_text_fields` item to be the value `1` instead of an array
6. Go back to the settings you should now see the same errors as reported in #732 
7. Check out this branch and refresh, you should no longer see the errors

### Changelog Entry

> Fixed - Ensure we only pass in array data to our `merge_settings` method
> Fixed - Handle scenario where non-array data is passed into our descriptive text generator feature

### Credits

Props @ajaxthemestudios, @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
