### PR TITLE
Ensure we don't throw a fatal error if composer isn't set up correctly

### DIFF
--- a/classifai.php
+++ b/classifai.php
@@ -88,7 +88,7 @@ function classifai_autoload() {
 		return true;
 	} else {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			sprintf( 'Fatal Error: Composer not setup in %s', CLASSIFAI_PLUGIN_DIR )
+			sprintf( 'Warning: Composer not setup in %s', CLASSIFAI_PLUGIN_DIR )
 		);
 
 		return false;

--- a/classifai.php
+++ b/classifai.php
@@ -88,7 +88,7 @@ function classifai_autoload() {
 		return true;
 	} else {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			sprintf( esc_html__( 'Fatal Error: Composer not setup in %', 'classifai' ), CLASSIFAI_PLUGIN_DIR )
+			sprintf( 'Fatal Error: Composer not setup in %s', CLASSIFAI_PLUGIN_DIR )
 		);
 
 		return false;


### PR DESCRIPTION
### Description of the Change

We have some code that outputs an error message if `composer` hasn't been set up correctly but this code has a bug in it that ends up causing a fatal error instead. This PR fixes that issue and also removes the translation of this error message as no real need to translate strings that end up in the error log.

### How to test the Change

1. On the `develop` branch, clone the repo but don't run `composer install`
2. Activate the plugin and notice a fatal error happens
3. Run `composer install` and notice the error goes away
4. Checkout this branch and remove the `vendor` directory
5. Notice the fatal error doesn't happen anymore but an admin error notice shows instead

### Changelog Entry

> Fixed - Fix a fatal error that occurs if `composer install` hasn't been run

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
