### PR TITLE
Ensure custom Classification Providers can fully work

### DIFF
--- a/includes/Classifai/Features/Classification.php
+++ b/includes/Classifai/Features/Classification.php
@@ -227,6 +227,21 @@ class Classification extends Feature {
 	public function save( int $post_id, array $results, bool $link = true ) {
 		$provider_instance = $this->get_feature_provider_instance();
 
+		/**
+		 * Filter results to be saved.
+		 *
+		 * @since 3.1.0
+		 * @hook classifai_feature_classification_pre_save_results
+		 *
+		 * @param {array} $supported Term results.
+		 * @param {int} $post_id Post ID.
+		 * @param {bool} $link Whether to link the terms or not.
+		 * @param {object} $this Current instance of the class.
+		 *
+		 * @return {array} Term results.
+		 */
+		$results = apply_filters( 'classifai_' . static::ID . '_pre_save_results', $results, $post_id, $link, $this );
+
 		switch ( $provider_instance::ID ) {
 			case NLU::ID:
 				$results = $provider_instance->link( $post_id, $results, $link );

--- a/src/js/language-processing.js
+++ b/src/js/language-processing.js
@@ -202,7 +202,7 @@ import '../scss/language-processing.scss';
 	previewWatson();
 
 	const previewEmbeddings = () => {
-		if ( 'openai_embeddings' !== provider ) {
+		if ( 'ibm_watson_nlu' === provider ) {
 			return;
 		}
 


### PR DESCRIPTION
### Description of the Change

We recently went through a refactor of ClassifAI to make it easier to add additional Providers and Features. As part of this process, we more fully merged the two Classification approaches we have: classifying by suggesting new terms and classifying based on existing terms.

I recently was trying to add a new 3rd party Classification Provider and ran into a few issues that prevented this from fully working. We have a few places within ClassifAI that are hardcoded based on the two built-in Classification Providers. This means if you add a custom Provider, this code doesn't ever run. The two areas were:

1. The admin preview functionality. This loads some JS code based on if the Provider is one of the two built-in Providers
2. Actually saving results. The code here runs custom save methods based on the Provider, but only accounts for the two built-in Providers

This PR attempts to fix both of these problems. A new filter is introduced (`classifai_feature_classification_pre_save_results`), that allows you to modify the classification results before they're saved. This can be used by a custom Provider to process and save these results however is needed (can also be used to modify the results before a built-in Provider saves them, if desired).

For the previewer, I debated on a few approaches but ended up going pretty simple. If the Provider is IBM Watson, we load some custom code. If the Provider isn't IBM Watson, we load our other code. Previously we were loading this code if the Provider was OpenAI Embeddings. This means for a custom Provider, this second code block will be loaded. As long as the custom Provider follows the approach of our OpenAI Embeddings Provider, this should work fine.

### How to test the Change

Not a whole lot to test here but can test that the preview functionality still works for the two built-in Providers.

### Changelog Entry

> Added - New filter, `classifai_feature_classification_pre_save_results`, that allows you to filter the classification results before they're saved, either modifying those results or running custom save routines.
> Fixed - Ensure the classification admin preview functionality loads for non built-in Providers

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
