### PR TITLE
Allow the embeddings provider to be used by features other than classification.

### DIFF
--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -901,12 +901,13 @@ class Embeddings extends Provider {
 	/**
 	 * Generate an embedding for a particular piece of text.
 	 *
-	 * @param string $text Text to generate the embedding for.
+	 * @param string       $text    Text to generate the embedding for.
+	 * @param Feature|null $feature Feature instance.
 	 * @return array|boolean|WP_Error
 	 */
 	public function generate_embedding( string $text = '', $feature = null ) {
 		if ( ! $feature ) {
-			$feature  = new Classification();
+			$feature = new Classification();
 		}
 		$settings = $feature->get_settings();
 

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -814,11 +814,12 @@ class Embeddings extends Provider {
 	/**
 	 * Trigger embedding generation for term being saved.
 	 *
-	 * @param int  $term_id ID of term being saved.
-	 * @param bool $force Whether to force generation of embeddings even if they already exist. Default false.
+	 * @param int     $term_id ID of term being saved.
+	 * @param bool    $force Whether to force generation of embeddings even if they already exist. Default false.
+	 * @param Feature $feature The feature instance.
 	 * @return array|WP_Error
 	 */
-	public function generate_embeddings_for_term( int $term_id, bool $force = false ) {
+	public function generate_embeddings_for_term( int $term_id, bool $force = false, Feature $feature = null ) {
 		// Ensure the user has permissions to edit.
 		if ( ! current_user_can( 'edit_term', $term_id ) ) {
 			return new WP_Error( 'invalid', esc_html__( 'User does not have valid permissions to edit this term.', 'classifai' ) );
@@ -830,7 +831,9 @@ class Embeddings extends Provider {
 			return new WP_Error( 'invalid', esc_html__( 'This is not a valid term.', 'classifai' ) );
 		}
 
-		$feature    = new Classification();
+		if ( ! $feature ) {
+			$feature = new Classification();
+		}
 		$taxonomies = $feature->get_all_feature_taxonomies();
 
 		if ( in_array( 'tags', $taxonomies, true ) ) {
@@ -879,7 +882,7 @@ class Embeddings extends Provider {
 		// Get the embeddings for each chunk.
 		if ( ! empty( $content_chunks ) ) {
 			foreach ( $content_chunks as $chunk ) {
-				$embedding = $this->generate_embedding( $chunk );
+				$embedding = $this->generate_embedding( $chunk, $feature );
 
 				if ( $embedding && ! is_wp_error( $embedding ) ) {
 					$embeddings[] = array_map( 'floatval', $embedding );
@@ -901,8 +904,10 @@ class Embeddings extends Provider {
 	 * @param string $text Text to generate the embedding for.
 	 * @return array|boolean|WP_Error
 	 */
-	public function generate_embedding( string $text = '' ) {
-		$feature  = new Classification();
+	public function generate_embedding( string $text = '', $feature = null ) {
+		if ( ! $feature ) {
+			$feature  = new Classification();
+		}
 		$settings = $feature->get_settings();
 
 		// Ensure the feature is enabled.


### PR DESCRIPTION
### Description of the Change
PR makes some minor necessary changes to allow the embedding provider to be used by features other than classification.

### How to test the Change
Nothing specific to test here, confirming the Classification feature works as expected would be enough.

### Changelog Entry
> Changed - Allow the embeddings provider to be used by features other than classification.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
