### PR TITLE
Ensure the excerpt length setting saves properly

### DIFF
--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -361,7 +361,7 @@ class ExcerptGeneration extends Feature {
 
 		$new_settings['generate_excerpt_prompt'] = sanitize_prompts( 'generate_excerpt_prompt', $new_settings );
 
-		$new_settings['length'] = absint( $settings['length'] ?? $new_settings['length'] );
+		$new_settings['length'] = absint( $new_settings['length'] ?? $settings['length'] );
 
 		foreach ( $post_types as $post_type ) {
 			if ( ! post_type_supports( $post_type->name, 'excerpt' ) ) {


### PR DESCRIPTION
### Description of the Change

While testing something else, noticed that when updating the `Excerpt length` setting for the Excerpt Generation Feature, the value I set never saved and always reverted to the default.

Looking into it, found that we were relying on the existing setting value and only using the new value if the existing didn't exist (which I think it will always exist). This conditional needed flipped around.

I worried this may be an issue in other places but in doing a spot check, didn't see this same problem anywhere else.

### How to test the Change

Try changing the `Excerpt length` setting in the Excerpt Generation Feature and ensure the value saves

### Changelog Entry

> Fixed - Ensure the `Excerpt length` setting for the Excerpt Generation Feature can be changed.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
