### PR TITLE
Conditional Display of Helper Text for AI Provider Account Creation

### DIFF
--- a/includes/Classifai/Features/Feature.php
+++ b/includes/Classifai/Features/Feature.php
@@ -1120,6 +1120,29 @@ abstract class Feature {
 	}
 
 	/**
+	 * Returns whether the feature is configured with the specified provider or not.
+	 *
+	 * @param string $provider The specified provider.
+	 *
+	 * @return bool
+	 */
+	public function is_configured_with_provider( string $provider ): bool {
+		$settings      = $this->get_settings();
+		$provider_id   = $settings['provider'];
+		$is_configured = false;
+
+		if (
+			! empty( $settings ) &&
+			$provider_id === $provider &&
+			! empty( $settings[ $provider_id ]['authenticated'] )
+		) {
+			$is_configured = true;
+		}
+
+		return $is_configured;
+	}
+
+	/**
 	 * Can the feature be initialized?
 	 *
 	 * @return bool

--- a/includes/Classifai/Providers/AWS/AmazonPolly.php
+++ b/includes/Classifai/Providers/AWS/AmazonPolly.php
@@ -47,19 +47,21 @@ class AmazonPolly extends Provider {
 				'input_type'    => 'text',
 				'default_value' => $settings['access_key_id'],
 				'class'         => 'large-text classifai-provider-field hidden provider-scope-' . static::ID,
-				'description'   => sprintf(
-					wp_kses(
-						/* translators: %1$s is replaced with the OpenAI sign up URL */
-						__( 'Enter the AWS access key. Please follow the steps given <a title="AWS documentation" href="%1$s">here</a> to generate AWS credentials.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
-							],
-						]
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							/* translators: %1$s is replaced with the OpenAI sign up URL */
+							__( 'Enter the AWS access key. Please follow the steps given <a title="AWS documentation" href="%1$s">here</a> to generate AWS credentials.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
+							]
+						),
+						esc_url( 'https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey' )
 					),
-					esc_url( 'https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey' )
-				),
 			]
 		);
 
@@ -75,7 +77,9 @@ class AmazonPolly extends Provider {
 				'input_type'    => 'password',
 				'default_value' => $settings['secret_access_key'],
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID,
-				'description'   => esc_html__( 'Enter the AWS secret access key.', 'classifai' ),
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					esc_html__( 'Enter the AWS secret access key.', 'classifai' ),
 			]
 		);
 
@@ -91,12 +95,14 @@ class AmazonPolly extends Provider {
 				'input_type'    => 'text',
 				'default_value' => $settings['aws_region'],
 				'class'         => 'large-text classifai-provider-field hidden provider-scope-' . static::ID,
-				'description'   => wp_kses(
-					__( 'Enter the AWS Region. eg: <code>us-east-1</code>', 'classifai' ),
-					[
-						'code' => [],
-					]
-				),
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					wp_kses(
+						__( 'Enter the AWS Region. eg: <code>us-east-1</code>', 'classifai' ),
+						[
+							'code' => [],
+						]
+					),
 			]
 		);
 
@@ -116,21 +122,23 @@ class AmazonPolly extends Provider {
 				),
 				'default_value' => $settings['voice_engine'],
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID,
-				'description'   => sprintf(
-					wp_kses(
-						/* translators: %1$s is replaced with the OpenAI sign up URL */
-						__( 'Amazon Polly offers <a href="%1$s">Long-Form</a>, <a href="%2$s">Neural</a> and Standard text-to-speech voices. Please check the <a title="Pricing" href="%3$s">documentation</a> to review pricing for Long-Form, Neural and Standard usage.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
-							],
-						]
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							/* translators: %1$s is replaced with the OpenAI sign up URL */
+							__( 'Amazon Polly offers <a href="%1$s">Long-Form</a>, <a href="%2$s">Neural</a> and Standard text-to-speech voices. Please check the <a title="Pricing" href="%3$s">documentation</a> to review pricing for Long-Form, Neural and Standard usage.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
+							]
+						),
+						esc_url( 'https://docs.aws.amazon.com/polly/latest/dg/long-form-voice-overview.html' ),
+						esc_url( 'https://docs.aws.amazon.com/polly/latest/dg/NTTS-main.html' ),
+						esc_url( 'https://aws.amazon.com/polly/pricing/' )
 					),
-					esc_url( 'https://docs.aws.amazon.com/polly/latest/dg/long-form-voice-overview.html' ),
-					esc_url( 'https://docs.aws.amazon.com/polly/latest/dg/NTTS-main.html' ),
-					esc_url( 'https://aws.amazon.com/polly/pricing/' )
-				),
 			]
 		);
 

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -53,7 +53,9 @@ class ComputerVision extends Provider {
 				'label_for'     => 'endpoint_url',
 				'input_type'    => 'text',
 				'default_value' => $settings['endpoint_url'],
-				'description'   => __( 'Supported protocol and hostname endpoints, e.g., <code>https://REGION.api.cognitive.microsoft.com</code> or <code>https://EXAMPLE.cognitiveservices.azure.com</code>. This can look different based on your setting choices in Azure.', 'classifai' ),
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					__( 'Supported protocol and hostname endpoints, e.g., <code>https://REGION.api.cognitive.microsoft.com</code> or <code>https://EXAMPLE.cognitiveservices.azure.com</code>. This can look different based on your setting choices in Azure.', 'classifai' ),
 				'class'         => 'large-text classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
 			]
 		);

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -78,7 +78,9 @@ class OpenAI extends Provider {
 				'label_for'     => 'endpoint_url',
 				'input_type'    => 'text',
 				'default_value' => $settings['endpoint_url'],
-				'description'   => __( 'Supported protocol and hostname endpoints, e.g., <code>https://EXAMPLE.openai.azure.com</code>.', 'classifai' ),
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					__( 'Supported protocol and hostname endpoints, e.g., <code>https://EXAMPLE.openai.azure.com</code>.', 'classifai' ),
 				'class'         => 'large-text classifai-provider-field hidden provider-scope-' . static::ID,
 			]
 		);
@@ -109,7 +111,9 @@ class OpenAI extends Provider {
 				'label_for'     => 'deployment',
 				'input_type'    => 'text',
 				'default_value' => $settings['deployment'],
-				'description'   => __( 'Custom name you chose for your deployment when you deployed a model.', 'classifai' ),
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					__( 'Custom name you chose for your deployment when you deployed a model.', 'classifai' ),
 				'class'         => 'large-text classifai-provider-field hidden provider-scope-' . static::ID,
 			]
 		);

--- a/includes/Classifai/Providers/Azure/Personalizer.php
+++ b/includes/Classifai/Providers/Azure/Personalizer.php
@@ -110,20 +110,22 @@ class Personalizer extends Provider {
 				'input_type'    => 'text',
 				'default_value' => $settings['endpoint_url'],
 				'class'         => 'large-text classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
-				'description'   => sprintf(
-					wp_kses(
-						// translators: 1 - link to create a Personalizer resource; 2 - link to GitHub issue.
-						__( 'Azure AI Personalizer Endpoint; <a href="%1$s" target="_blank">create a Personalizer resource</a> in the Azure portal to get your key and endpoint. Note that <a href="%2$s" target="_blank">as of September 2023</a>, it is no longer possible to create this resource. Previously created Personalizer resources can still be used.', 'classifai' ),
-						array(
-							'a' => array(
-								'href'   => array(),
-								'target' => array(),
-							),
-						)
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							// translators: 1 - link to create a Personalizer resource; 2 - link to GitHub issue.
+							__( 'Azure AI Personalizer Endpoint; <a href="%1$s" target="_blank">create a Personalizer resource</a> in the Azure portal to get your key and endpoint. Note that <a href="%2$s" target="_blank">as of September 2023</a>, it is no longer possible to create this resource. Previously created Personalizer resources can still be used.', 'classifai' ),
+							array(
+								'a' => array(
+									'href'   => array(),
+									'target' => array(),
+								),
+							)
+						),
+						'https://portal.azure.com/#create/Microsoft.CognitiveServicesPersonalizer',
+						'https://learn.microsoft.com/en-us/azure/ai-services/personalizer/'
 					),
-					'https://portal.azure.com/#create/Microsoft.CognitiveServicesPersonalizer',
-					'https://learn.microsoft.com/en-us/azure/ai-services/personalizer/'
-				),
 			]
 		);
 

--- a/includes/Classifai/Providers/Azure/Speech.php
+++ b/includes/Classifai/Providers/Azure/Speech.php
@@ -57,7 +57,9 @@ class Speech extends Provider {
 				'label_for'     => 'endpoint_url',
 				'input_type'    => 'text',
 				'default_value' => $settings['endpoint_url'],
-				'description'   => __( 'Text to Speech region endpoint, e.g., <code>https://LOCATION.tts.speech.microsoft.com/</code>. Replace <code>LOCATION</code> with the Location/Region you selected for the resource in Azure.', 'classifai' ),
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					__( 'Text to Speech region endpoint, e.g., <code>https://LOCATION.tts.speech.microsoft.com/</code>. Replace <code>LOCATION</code> with the Location/Region you selected for the resource in Azure.', 'classifai' ),
 				'class'         => 'large-text classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
 			]
 		);

--- a/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
+++ b/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
@@ -63,19 +63,21 @@ class GeminiAPI extends Provider {
 				'input_type'    => 'password',
 				'default_value' => $settings['api_key'],
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
-				'description'   => sprintf(
-					wp_kses(
-						/* translators: %1$s is replaced with the OpenAI sign up URL */
-						__( 'Don\'t have an Google AI (Gemini API) key? <a title="Get an API key" href="%1$s">Get an API key</a> now.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
-							],
-						]
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							/* translators: %1$s is replaced with the OpenAI sign up URL */
+							__( 'Don\'t have an Google AI (Gemini API) key? <a title="Get an API key" href="%1$s">Get an API key</a> now.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
+							]
+						),
+						esc_url( 'https://makersuite.google.com/app/apikey' )
 					),
-					esc_url( 'https://makersuite.google.com/app/apikey' )
-				),
 			]
 		);
 

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -69,19 +69,21 @@ class ChatGPT extends Provider {
 				'input_type'    => 'password',
 				'default_value' => $settings['api_key'],
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
-				'description'   => sprintf(
-					wp_kses(
-						/* translators: %1$s is replaced with the OpenAI sign up URL */
-						__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
-							],
-						]
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							/* translators: %1$s is replaced with the OpenAI sign up URL */
+							__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
+							]
+						),
+						esc_url( 'https://platform.openai.com/signup' )
 					),
-					esc_url( 'https://platform.openai.com/signup' )
-				),
 			]
 		);
 

--- a/includes/Classifai/Providers/OpenAI/DallE.php
+++ b/includes/Classifai/Providers/OpenAI/DallE.php
@@ -67,19 +67,21 @@ class DallE extends Provider {
 				'input_type'    => 'password',
 				'default_value' => $settings['api_key'],
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID,
-				'description'   => sprintf(
-					wp_kses(
-						/* translators: %1$s is replaced with the OpenAI sign up URL */
-						__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
-							],
-						]
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							/* translators: %1$s is replaced with the OpenAI sign up URL */
+							__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
+							]
+						),
+						esc_url( 'https://platform.openai.com/signup' )
 					),
-					esc_url( 'https://platform.openai.com/signup' )
-				),
 			]
 		);
 

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -215,19 +215,21 @@ class Embeddings extends Provider {
 				'input_type'    => 'password',
 				'default_value' => $settings['api_key'],
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
-				'description'   => sprintf(
-					wp_kses(
-						/* translators: %1$s is replaced with the OpenAI sign up URL */
-						__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
-							],
-						]
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							/* translators: %1$s is replaced with the OpenAI sign up URL */
+							__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
+							]
+						),
+						esc_url( 'https://platform.openai.com/signup' )
 					),
-					esc_url( 'https://platform.openai.com/signup' )
-				),
 			]
 		);
 

--- a/includes/Classifai/Providers/OpenAI/Moderation.php
+++ b/includes/Classifai/Providers/OpenAI/Moderation.php
@@ -55,19 +55,21 @@ class Moderation extends Provider {
 				'input_type'    => 'password',
 				'default_value' => $settings['api_key'],
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
-				'description'   => sprintf(
-					wp_kses(
-						/* translators: %1$s is replaced with the OpenAI sign up URL */
-						__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
-							],
-						]
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							/* translators: %1$s is replaced with the OpenAI sign up URL */
+							__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
+							]
+						),
+						esc_url( 'https://platform.openai.com/signup' )
 					),
-					esc_url( 'https://platform.openai.com/signup' )
-				),
 			]
 		);
 

--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -48,19 +48,21 @@ class TextToSpeech extends Provider {
 				'input_type'    => 'password',
 				'default_value' => $settings['api_key'],
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID,
-				'description'   => sprintf(
-					wp_kses(
-						/* translators: %1$s is replaced with the OpenAI sign up URL */
-						__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
-							],
-						]
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							/* translators: %1$s is replaced with the OpenAI sign up URL */
+							__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
+							]
+						),
+						esc_url( 'https://platform.openai.com/signup' )
 					),
-					esc_url( 'https://platform.openai.com/signup' )
-				),
 			]
 		);
 
@@ -78,18 +80,20 @@ class TextToSpeech extends Provider {
 					'tts-1-hd' => __( 'Text-to-speech 1 HD (Optimized for quality)', 'classifai' ),
 				],
 				'default_value' => $settings['tts_model'],
-				'description'   => sprintf(
-					wp_kses(
-						__( 'Select a <a href="%s" title="OpenAI Text to Speech models" target="_blank">model</a> depending on your requirement.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							__( 'Select a <a href="%s" title="OpenAI Text to Speech models" target="_blank">model</a> depending on your requirement.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
 							],
-						],
+						),
+						esc_url( 'https://platform.openai.com/docs/models/tts' )
 					),
-					esc_url( 'https://platform.openai.com/docs/models/tts' )
-				),
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID,
 			]
 		);
@@ -112,18 +116,20 @@ class TextToSpeech extends Provider {
 					'shimmer' => __( 'Shimmer (female)', 'classifai' ),
 				],
 				'default_value' => $settings['voice'],
-				'description'   => sprintf(
-					wp_kses(
-						__( 'Select the speech <a href="%s" title="OpenAI Text to Speech models" target="_blank">voice</a>.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							__( 'Select the speech <a href="%s" title="OpenAI Text to Speech models" target="_blank">voice</a>.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
 							],
-						],
+						),
+						esc_url( 'https://platform.openai.com/docs/guides/text-to-speech/voice-options' )
 					),
-					esc_url( 'https://platform.openai.com/docs/guides/text-to-speech/voice-options' )
-				),
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID,
 			]
 		);

--- a/includes/Classifai/Providers/OpenAI/Whisper.php
+++ b/includes/Classifai/Providers/OpenAI/Whisper.php
@@ -93,19 +93,21 @@ class Whisper extends Provider {
 				'input_type'    => 'password',
 				'default_value' => $settings['api_key'],
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
-				'description'   => sprintf(
-					wp_kses(
-						/* translators: %1$s is replaced with the OpenAI sign up URL */
-						__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
-							],
-						]
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
+					'' :
+					sprintf(
+						wp_kses(
+							/* translators: %1$s is replaced with the OpenAI sign up URL */
+							__( 'Don\'t have an OpenAI account yet? <a title="Sign up for an OpenAI account" href="%1$s">Sign up for one</a> in order to get your API key.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
+							]
+						),
+						esc_url( 'https://platform.openai.com/signup' )
 					),
-					esc_url( 'https://platform.openai.com/signup' )
-				),
 			]
 		);
 

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -121,7 +121,7 @@ class NLU extends Provider {
 				'input_type'    => 'password',
 				'large'         => true,
 				'class'         => 'classifai-provider-field provider-scope-' . static::ID, // Important to add this.
-				'description'   => $this->feature_instance->is_feature_enabled() ?
+				'description'   => $this->feature_instance->is_configured() ?
 					'' :
 					sprintf(
 						wp_kses(
@@ -140,26 +140,24 @@ class NLU extends Provider {
 			]
 		);
 
-		if ( ! $this->feature_instance->is_feature_enabled() ) {
-			add_settings_field(
-				static::ID . '_toggle',
-				'',
-				function ( $args = [] ) {
-					printf(
-						'<a id="classifai-waston-cred-toggle" href="#" class="%s">%s</a>',
-						$args['class'] ? esc_attr( $args['class'] ) : '', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						$this->use_username_password() // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							? esc_html__( 'Use a username/password instead?', 'classifai' )
-							: esc_html__( 'Use an API Key instead?', 'classifai' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					);
-				},
-				$this->feature_instance->get_option_name(),
-				$this->feature_instance->get_option_name() . '_section',
-				[
-					'class' => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
-				]
-			);
-		}
+		add_settings_field(
+			static::ID . '_toggle',
+			'',
+			function ( $args = [] ) {
+				printf(
+					'<a id="classifai-waston-cred-toggle" href="#" class="%s">%s</a>',
+					$args['class'] ? esc_attr( $args['class'] ) : '', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					$this->use_username_password() // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						? esc_html__( 'Use a username/password instead?', 'classifai' )
+						: esc_html__( 'Use an API Key instead?', 'classifai' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				);
+			},
+			$this->feature_instance->get_option_name(),
+			$this->feature_instance->get_option_name() . '_section',
+			[
+				'class' => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
+			]
+		);
 
 		do_action( 'classifai_' . static::ID . '_render_provider_fields', $this );
 	}

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -121,7 +121,7 @@ class NLU extends Provider {
 				'input_type'    => 'password',
 				'large'         => true,
 				'class'         => 'classifai-provider-field provider-scope-' . static::ID, // Important to add this.
-				'description'   => $this->feature_instance->is_configured() ?
+				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
 					'' :
 					sprintf(
 						wp_kses(

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -121,41 +121,45 @@ class NLU extends Provider {
 				'input_type'    => 'password',
 				'large'         => true,
 				'class'         => 'classifai-provider-field provider-scope-' . static::ID, // Important to add this.
-				'description'   => sprintf(
-					wp_kses(
-						/* translators: %1$s is the link to register for an IBM Cloud account, %2$s is the link to setup the NLU service */
-						__( 'Don\'t have an IBM Cloud account yet? <a title="Register for an IBM Cloud account" href="%1$s">Register for one</a> and set up a <a href="%2$s">Natural Language Understanding</a> Resource to get your API key.', 'classifai' ),
-						[
-							'a' => [
-								'href'  => [],
-								'title' => [],
-							],
-						]
+				'description'   => $this->feature_instance->is_feature_enabled() ?
+					'' :
+					sprintf(
+						wp_kses(
+							/* translators: %1$s is the link to register for an IBM Cloud account, %2$s is the link to setup the NLU service */
+							__( 'Don\'t have an IBM Cloud account yet? <a title="Register for an IBM Cloud account" href="%1$s">Register for one</a> and set up a <a href="%2$s">Natural Language Understanding</a> Resource to get your API key.', 'classifai' ),
+							[
+								'a' => [
+									'href'  => [],
+									'title' => [],
+								],
+							]
+						),
+						esc_url( 'https://cloud.ibm.com/registration' ),
+						esc_url( 'https://cloud.ibm.com/catalog/services/natural-language-understanding' )
 					),
-					esc_url( 'https://cloud.ibm.com/registration' ),
-					esc_url( 'https://cloud.ibm.com/catalog/services/natural-language-understanding' )
-				),
 			]
 		);
 
-		add_settings_field(
-			static::ID . '_toggle',
-			'',
-			function ( $args = [] ) {
-				printf(
-					'<a id="classifai-waston-cred-toggle" href="#" class="%s">%s</a>',
-					$args['class'] ? esc_attr( $args['class'] ) : '', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					$this->use_username_password() // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						? esc_html__( 'Use a username/password instead?', 'classifai' )
-						: esc_html__( 'Use an API Key instead?', 'classifai' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				);
-			},
-			$this->feature_instance->get_option_name(),
-			$this->feature_instance->get_option_name() . '_section',
-			[
-				'class' => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
-			]
-		);
+		if ( ! $this->feature_instance->is_feature_enabled() ) {
+			add_settings_field(
+				static::ID . '_toggle',
+				'',
+				function ( $args = [] ) {
+					printf(
+						'<a id="classifai-waston-cred-toggle" href="#" class="%s">%s</a>',
+						$args['class'] ? esc_attr( $args['class'] ) : '', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						$this->use_username_password() // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							? esc_html__( 'Use a username/password instead?', 'classifai' )
+							: esc_html__( 'Use an API Key instead?', 'classifai' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					);
+				},
+				$this->feature_instance->get_option_name(),
+				$this->feature_instance->get_option_name() . '_section',
+				[
+					'class' => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
+				]
+			);
+		}
 
 		do_action( 'classifai_' . static::ID . '_render_provider_fields', $this );
 	}


### PR DESCRIPTION
### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #715

### How to test the Change
* Enable/disable the several features with all the available providers and verify that help texts related to the configuration of each provider are hidden/displayed respectively.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Hide the provider's configuration help text when the provider is configured, for all providers.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
