### PR TITLE
fix/659: strip off HTML subscript and superscript tags for Text to Speech

### DIFF
--- a/includes/Classifai/Features/TextToSpeech.php
+++ b/includes/Classifai/Features/TextToSpeech.php
@@ -859,11 +859,11 @@ class TextToSpeech extends Feature {
 	 * @return string The normalized post content.
 	 */
 	public function normalize_post_content( int $post_id ): string {
-		add_filter( 'classifai_normalize_content_before_strip_all_tags', [ $this, 'strip_sub_sup_tags' ] );
+		add_filter( 'classifai_pre_normalize', [ $this, 'strip_sub_sup_tags' ] );
 		$normalizer   = new Normalizer();
 		$post         = get_post( $post_id );
 		$post_content = $normalizer->normalize_content( $post->post_content, $post->post_title, $post_id );
-		remove_filter( 'classifai_normalize_content_before_strip_all_tags', [ $this, 'strip_sub_sup_tags' ] );
+		remove_filter( 'classifai_pre_normalize', [ $this, 'strip_sub_sup_tags' ] );
 
 		return $post_content;
 	}
@@ -876,7 +876,7 @@ class TextToSpeech extends Feature {
 	 *
 	 * @return string The filtered post content.
 	 */
-	public function strip_sub_sup_tags( $post_content ) {
+	public function strip_sub_sup_tags( string $post_content ): string {
 		$post_content = preg_replace( '/<sub>.*?<\/sub>|<sup>.*?<\/sup>/', '', $post_content );
 		return $post_content;
 	}

--- a/includes/Classifai/Features/TextToSpeech.php
+++ b/includes/Classifai/Features/TextToSpeech.php
@@ -859,10 +859,17 @@ class TextToSpeech extends Feature {
 	 * @return string The normalized post content.
 	 */
 	public function normalize_post_content( int $post_id ): string {
+		add_filter( 'classifai_normalize_content_before_strip_all_tags', [ $this, 'strip_sub_sup_tags' ] );
 		$normalizer   = new Normalizer();
 		$post         = get_post( $post_id );
 		$post_content = $normalizer->normalize_content( $post->post_content, $post->post_title, $post_id );
+		remove_filter( 'classifai_normalize_content_before_strip_all_tags', [ $this, 'strip_sub_sup_tags' ] );
 
+		return $post_content;
+	}
+
+	public function strip_sub_sup_tags( $post_content ) {
+		$post_content = preg_replace( '/<sub>.*?<\/sub>|<sup>.*?<\/sup>/', '', $post_content );
 		return $post_content;
 	}
 

--- a/includes/Classifai/Features/TextToSpeech.php
+++ b/includes/Classifai/Features/TextToSpeech.php
@@ -868,6 +868,14 @@ class TextToSpeech extends Feature {
 		return $post_content;
 	}
 
+	/**
+	 * Filters the post content by stripping off HTML subscript and superscript tags
+	 * with its content for text to speech generation.
+	 *
+	 * @param string $post_content The post content.
+	 *
+	 * @return string The filtered post content.
+	 */
 	public function strip_sub_sup_tags( $post_content ) {
 		$post_content = preg_replace( '/<sub>.*?<\/sub>|<sup>.*?<\/sup>/', '', $post_content );
 		return $post_content;

--- a/includes/Classifai/Normalizer.php
+++ b/includes/Classifai/Normalizer.php
@@ -49,6 +49,17 @@ class Normalizer {
 		/* Replace HTML linebreaks with newlines */
 		$post_content = preg_replace( '#<br\s?/?>#', "\n\n", $post_content );
 
+		/**
+		 * Hook to filter post content before stripping HTML tags.
+		 *
+		 * @hook classifai_normalize_content_before_strip_all_tags
+		 *
+		 * @param {string} $post_content The post content.
+		 *
+		 * @return {string} The filtered Post content.
+		 */
+		$post_content = apply_filters( 'classifai_normalize_content_before_strip_all_tags', $post_content );
+
 		/* Strip all HTML tags */
 		$post_content = wp_strip_all_tags( $post_content );
 

--- a/includes/Classifai/Normalizer.php
+++ b/includes/Classifai/Normalizer.php
@@ -62,7 +62,6 @@ class Normalizer {
 		/* Replace HTML linebreaks with newlines */
 		$post_content = preg_replace( '#<br\s?/?>#', "\n\n", $post_content );
 
-
 		/* Strip all HTML tags */
 		$post_content = wp_strip_all_tags( $post_content );
 

--- a/includes/Classifai/Normalizer.php
+++ b/includes/Classifai/Normalizer.php
@@ -43,22 +43,25 @@ class Normalizer {
 	 * @param int    $post_id      The post id. Optional.
 	 */
 	public function normalize_content( $post_content, $post_title = '', $post_id = false ) {
+
+		/**
+		 * Hook to filter post content before stripping HTML tags.
+		 *
+		 * @since 3.1.0
+		 * @hook classifai_pre_normalize
+		 *
+		 * @param {string} $post_content The post content.
+		 *
+		 * @return {string} The filtered Post content.
+		 */
+		$post_content = apply_filters( 'classifai_pre_normalize', $post_content );
+
 		/* Strip HTML entities */
 		$post_content = preg_replace( '/&#?[a-z0-9]{2,8};/i', '', $post_content );
 
 		/* Replace HTML linebreaks with newlines */
 		$post_content = preg_replace( '#<br\s?/?>#', "\n\n", $post_content );
 
-		/**
-		 * Hook to filter post content before stripping HTML tags.
-		 *
-		 * @hook classifai_normalize_content_before_strip_all_tags
-		 *
-		 * @param {string} $post_content The post content.
-		 *
-		 * @return {string} The filtered Post content.
-		 */
-		$post_content = apply_filters( 'classifai_normalize_content_before_strip_all_tags', $post_content );
 
 		/* Strip all HTML tags */
 		$post_content = wp_strip_all_tags( $post_content );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Added logic to strip off HTML subscript and superscript tags, along with its content for text-to-speech generation.
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #659

### How to test the Change

1. Add or Edit a post.
2. Add text which contains subscript or superscript.
<img width="663" alt="ClassifAI" src="https://github.com/10up/classifai/assets/64858136/2f8c2a2e-f4c9-47ed-a13f-5f80fb92bbe7">

3. Click on "Generate Audio".
4. Publish or update the post.
5. Preview the generated audio. The subscript and superscript content should be skipped in the audio.

<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - `classifai_normalize_content_before_strip_all_tags` filter hook.
> Fixed - Stripped off superscript and subscript tags with content for text to speech generation.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
