### PR TITLE
Improvements to the Embedding functionality

### DIFF
--- a/includes/Classifai/Providers/Azure/Embeddings.php
+++ b/includes/Classifai/Providers/Azure/Embeddings.php
@@ -6,6 +6,7 @@
 namespace Classifai\Providers\Azure;
 
 use Classifai\Providers\OpenAI\EmbeddingCalculations;
+use Classifai\Providers\OpenAI\Tokenizer;
 use Classifai\Normalizer;
 use Classifai\Features\Classification;
 use Classifai\Features\Feature;
@@ -400,11 +401,29 @@ class Embeddings extends OpenAI {
 
 		// Get the embeddings for each chunk.
 		if ( ! empty( $content_chunks ) ) {
-			foreach ( $content_chunks as $chunk ) {
-				$embedding = $this->generate_embedding( $chunk );
+			$tokenizer    = new Tokenizer( $this->get_max_tokens() );
+			$total_tokens = $tokenizer->tokens_in_content( $content );
 
-				if ( $embedding && ! is_wp_error( $embedding ) ) {
-					$embeddings[] = array_map( 'floatval', $embedding );
+			// If we have a lot of tokens, we need to get embeddings for each chunk individually.
+			if ( $this->max_tokens < $total_tokens ) {
+				foreach ( $content_chunks as $chunk ) {
+					$embedding = $this->generate_embedding( $chunk );
+
+					if ( $embedding && ! is_wp_error( $embedding ) ) {
+						$embeddings[] = array_map( 'floatval', $embedding );
+					}
+				}
+			} else {
+				// Otherwise let's get all embeddings in a single request.
+				$all_embeddings = $this->generate_embeddings( $content_chunks );
+
+				if ( $all_embeddings && ! is_wp_error( $all_embeddings ) ) {
+					$embeddings = array_map(
+						function ( $embedding ) {
+							return floatval( $embedding );
+						},
+						$all_embeddings
+					);
 				}
 			}
 		}

--- a/includes/Classifai/Providers/Azure/Embeddings.php
+++ b/includes/Classifai/Providers/Azure/Embeddings.php
@@ -420,7 +420,7 @@ class Embeddings extends OpenAI {
 				if ( $all_embeddings && ! is_wp_error( $all_embeddings ) ) {
 					$embeddings = array_map(
 						function ( $embedding ) {
-							return floatval( $embedding );
+							return array_map( 'floatval', $embedding );
 						},
 						$all_embeddings
 					);

--- a/includes/Classifai/Providers/Azure/Embeddings.php
+++ b/includes/Classifai/Providers/Azure/Embeddings.php
@@ -833,6 +833,7 @@ class Embeddings extends OpenAI {
 					'Content-Type' => 'application/json',
 				],
 				'body'    => wp_json_encode( $body ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			]
 		);
 		$response = $this->get_result( $response );
@@ -911,6 +912,7 @@ class Embeddings extends OpenAI {
 					'Content-Type' => 'application/json',
 				],
 				'body'    => wp_json_encode( $body ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			]
 		);
 		$response = $this->get_result( $response );
@@ -963,7 +965,7 @@ class Embeddings extends OpenAI {
 				array_slice(
 					$words,
 					max( $i - $overlap_size, 0 ),
-					$i + $chunk_size
+					$chunk_size + $overlap_size
 				)
 			);
 

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -533,7 +533,7 @@ class Embeddings extends Provider {
 				if ( $all_embeddings && ! is_wp_error( $all_embeddings ) ) {
 					$embeddings = array_map(
 						function ( $embedding ) {
-							return floatval( $embedding );
+							return array_map( 'floatval', $embedding );
 						},
 						$all_embeddings
 					);

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -1073,7 +1073,7 @@ class Embeddings extends Provider {
 				array_slice(
 					$words,
 					max( $i - $overlap_size, 0 ),
-					$i + $chunk_size
+					$chunk_size + $overlap_size
 				)
 			);
 


### PR DESCRIPTION
### Description of the Change

In testing out another plugin that uses the Embedding functionality from ClassifAI, ran into a few issues that could be improved.

1. The OpenAI API allows you to [generate Embeddings](https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-input) from either a single string or an array of strings. In #758 we made some major improvements to Embeddings, one of which was to break content down into smaller chunks and embed each chunk. This was done with individual API requests as I didn't realize you could send array data. This PR fixes that by checking the size of the content and if it's below the token limit, we send that as a single request. For any bulk processing, this reduces the number of API requests significantly, helping with performance and helping to avoid rate limit errors
2. Also discovered a bug in our chunking code where each chunk would be larger than the last. We want an overlap with each chunk but there was a bug here where each iteration we would increase that overlap. This wasn't noticeable for smaller posts but for long posts, you'd end up with huge chunks that were over the token limit, resulting in API failures. This also meant more tokens were being used that necessary. For any bulk processing, this helps reduce the tokens used significantly
3. Ensure we set a higher timeout for the Azure OpenAI Embedding requests, as these can timeout at the default 5 seconds

### How to test the Change

1. Setup the Classification Feature to use either OpenAI or Azure OpenAI (or try both)
2. Preview a post and ensure results show
3. (Optional) Test classifying a post and ensure results show

### Changelog Entry

> Added - Higher timeout for Azure OpenAI Embedding requests
> Changed - Add the ability to send chunked content in a single request to the Embedding API
> Fixed - Ensure we chunk content correctly, keeping each chunk roughly the same size

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
