### PR TITLE
Update to the new GPT-4o mini model

### DIFF
--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -33,14 +33,14 @@ class ChatGPT extends Provider {
 	 *
 	 * @var string
 	 */
-	protected $chatgpt_model = 'gpt-3.5-turbo';
+	protected $chatgpt_model = 'gpt-4o-mini';
 
 	/**
 	 * Maximum number of tokens our model supports
 	 *
 	 * @var int
 	 */
-	protected $max_tokens = 16385;
+	protected $max_tokens = 128000;
 
 	/**
 	 * OpenAI ChatGPT constructor.


### PR DESCRIPTION
### Description of the Change

OpenAI recently introduced a new model, [GPT-4o mini](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/). They recommend using this model anywhere you were previously using the GPT-3.5 Turbo model, which is the model we use for excerpt generation, title generation and content resizing.

This PR updates that model and updates the number of tokens available, as this new model has a much higher limit.

Some of the main benefits from this model switch:

- More than 60% cheaper
- Context window increases from 16,385 tokens to 128,000 tokens
- Training data up to Oct 2023, increased from Sep 2021
- Better benchmarks across the board compared to GPT-3.5 Turbo
- It's a multi-modal model so could look in the future to use it for image, video or audio tasks

### How to test the Change

Ensure the Title Generation, Excerpt Generation and Content Resizing Features all still work when set to use OpenAI as the Provider

### Changelog Entry

> Changed - Switch from the `gpt-3.5-turbo` model to the new `gpt-4o-mini` model.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
