### PR TITLE
Replace URL & Add Notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![ClassifAI](https://classifaiplugin.com/wp-content/themes/classifai-theme/assets/img/logo.svg "ClassifAI")
+# ![ClassifAI](https://classifaiplugin.com/wp-content/themes/fse-classifai-theme/assets/img/logo.svg "ClassifAI")
 
 > Supercharge WordPress Content Workflows and Engagement with Artificial Intelligence.
 

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -692,7 +692,7 @@ class ComputerVision extends Provider {
 					'Ocp-Apim-Subscription-Key' => $api_key,
 					'Content-Type'              => 'application/json',
 				],
-				'body'    => '{"url":"https://classifaiplugin.com/wp-content/themes/classifai-theme/assets/img/header.png"}',
+				'body'    => '{"url":"https://classifaiplugin.com/wp-content/themes/fse-classifai-theme/assets/img/header.png"}',
 			]
 		);
 

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -206,6 +206,16 @@ class ComputerVision extends Provider {
 
 				if ( is_wp_error( $auth_check ) ) {
 					$new_settings[ static::ID ]['authenticated'] = false;
+
+					$error_message = $auth_check->get_error_message();
+
+					// Add an error message.
+					add_settings_error(
+						'api_key',
+						'classifai-auth',
+						$error_message,
+						'error'
+					);
 				} else {
 					$new_settings[ static::ID ]['authenticated'] = true;
 				}


### PR DESCRIPTION
### Description of the Change

- This PR fixes 
- Also adds an error notice to the ComputerVision provider.

![image](https://github.com/user-attachments/assets/85a959d5-70c3-4362-bdc5-bcec37001148)

### How to test the Change

In `develop` branch, try to add an invalid API key and see it does not show any error notice. This PR shows it.

### Changelog Entry
> Added - An error notice for ComputerVision provider
> Changed - URLs replaced from the Old ClassifAI theme with the new FSE-based theme

### Credits
Props @dkotter @faisal-alvi 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
