### PR TITLE
add banner image, remove TOC as GH autogenerates this now

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,14 @@
-# ![ClassifAI](https://classifaiplugin.com/wp-content/themes/fse-classifai-theme/assets/img/logo.svg "ClassifAI")
+# ClassifAI
 
-> Supercharge WordPress Content Workflows and Engagement with Artificial Intelligence.
+![ClassifAI](https://github.com/10up/classifai/blob/develop/assets/img/banner-1544x500.png)
 
 [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/classifai.svg)](https://github.com/10up/classifai/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.6%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/classifai.svg)](https://github.com/10up/classifai/blob/develop/LICENSE.md)
 
 [![E2E Testing](https://github.com/10up/classifai/actions/workflows/cypress.yml/badge.svg)](https://github.com/10up/classifai/actions/workflows/cypress.yml) [![PHPUnit Testing](https://github.com/10up/classifai/actions/workflows/test.yml/badge.svg)](https://github.com/10up/classifai/actions/workflows/test.yml) [![Linting](https://github.com/10up/classifai/actions/workflows/lint.yml/badge.svg)](https://github.com/10up/classifai/actions/workflows/lint.yml) [![CodeQL](https://github.com/10up/classifai/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/10up/classifai/actions/workflows/codeql-analysis.yml) [![Dependency Review](https://github.com/10up/classifai/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/classifai/actions/workflows/dependency-review.yml)
 
+> Supercharge WordPress Content Workflows and Engagement with Artificial Intelligence.
+
 *You can learn more about ClassifAI's features at [ClassifAIPlugin.com](https://classifaiplugin.com/) and documentation at the [ClassifAI documentation site](https://10up.github.io/classifai/).*
-
-## Table of Contents
-
-* [Overview](#overview)
-* [Features](#features)
-* [Requirements](#requirements)
-* [Pricing](#pricing)
-* [Installation](#installation)
-* [Register ClassifAI account](#register-classifai-account)
-* [Set Up IBM Watson NLU Language Processing](#set-up-classification-via-ibm-watson)
-* [Set Up OpenAI ChatGPT Language Processing](#set-up-language-processing-features-via-openai-chatgpt)
-* [Set Up Azure OpenAI Language Processing](#set-up-language-processing-features-via-azure-openai)
-* [Set Up Google AI (Gemini API) Language Processing](#set-up-language-processing-features-via-google-ai-gemini-api)
-* [Set Up OpenAI Embeddings Language Processing](#set-up-classification-via-openai-embeddings)
-* [Set Up OpenAI Whisper Language Processing](#set-up-audio-transcripts-generation-via-openai-whisper)
-* [Set Up Azure AI Language Processing](#set-up-text-to-speech-via-microsoft-azure)
-* [Set Up OpenAI Text to Speech Processing](#set-up-text-to-speech-via-openai)
-* [Set Up AWS Language Processing](#set-up-text-to-speech-via-amazon-polly)
-* [Set Up Azure AI Vision Image Processing](#set-up-image-processing-features-via-microsoft-azure)
-* [Set Up OpenAI DALL·E Image Processing](#set-up-image-generation-via-openai)
-* [Set Up OpenAI Moderation Language Processing](#set-up-comment-moderation-via-openai-moderation)
-* [Set Up Azure AI Personalizer Recommended Content](#set-up-recommended-content-via-microsoft-azure-ai-personalizer)
-* [WP CLI Commands](#wp-cli-commands)
-* [FAQs](#frequently-asked-questions)
-* [Support](#support-level)
-* [Changelog](#changelog)
-* [Contributing](#contributing)
 
 ## Overview
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR adds in the plugin banner image to the readme to give a bit more visual appear to the readme intro to new plugin users/developers. Also removes the table of contents as GitHub now auto-generates that (and it otherwise was a wall-of-text blocking out more helpful info further into the readme).

### How to test the Change
Preview via the GitHub markdown previewer.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
n/a

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
