### PR TITLE
[Classification] Ensure that the classification feature suggests or sets terms for enabled taxonomies only.

### DIFF
--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -589,10 +589,7 @@ function sanitize_number_of_responses_field( string $key, array $new_settings, a
 function get_classification_feature_enabled( string $classify_by ): bool {
 	$settings = ( new Classification() )->get_settings();
 
-	return filter_var(
-		isset( $settings[ $classify_by ] ) ?? false,
-		FILTER_VALIDATE_BOOLEAN
-	);
+	return ( ! empty( $settings[ $classify_by ] ) );
 }
 
 /**


### PR DESCRIPTION
### Description of the Change
While testing PR https://github.com/10up/classifai/pull/804, I noticed that the plugin suggests (for manual mode) or sets (for automatic classification mode) terms for posts on all taxonomies for OpenAI Embeddings and Azure OpenAI Embeddings providers, terms should be suggested/set only for enabled taxonomies.

This PR fixes this issue by suggesting or setting terms for enabled taxonomies only.

### How to Test the Change
1. Checkout to the `trunk` branch.
2. Set the classification feature using OpenAI Embeddings or Azure OpenAI Embeddings.
3. Disable Classification for the Post Tag Taxonomy.
4. Create a post, add some content, and click on the "Suggest terms & tags" button (for Manual mode) or save the post (for Automatic mode).
5. Notice that terms are suggested or set for all taxonomies (categories and tags) even if tags are disabled.
6. Checkout to this PR branch.
7. Create a post, add some content, and click on the "Suggest terms & tags" button (for Manual mode) or save the post (for Automatic mode).
8. Notice that terms are suggested or set for only the enabled taxonomies.
 

### Changelog Entry
> Fixed - Ensure that the classification feature suggests or sets terms for enabled taxonomies only.

### Credits
Props @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
