### PR TITLE
Add the WordPress Plugin Check Action

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -46,7 +46,6 @@ jobs:
       run: npm ci --no-optional
 
     - name: Install composer dependencies
-      if: steps.cache-composer.outputs.cache-hit != 'true'
       run: composer install --no-dev -o
 
     - name: Build

--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -2,25 +2,59 @@ name: Build release zip
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build_zip:
     name: Build release zip
     runs-on: ubuntu-latest
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: Set Node.js 16.x
+
+    - name: Setup node
       uses: actions/setup-node@v4
       with:
+        cache: 'npm'
         node-version-file: .nvmrc
-    - name: npm install and build
+
+    - name: Cache node_modules
+      id: cache-node-modules
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-node-modules
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Get composer cache directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache dependencies
+      id: cache-composer
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-composer
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
+
+    - name: Install node dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: npm ci --no-optional
+
+    - name: Install composer dependencies
+      if: steps.cache-composer.outputs.cache-hit != 'true'
+      run: composer install --no-dev -o
+
+    - name: Build
       run: |
-        npm install
         npm run build
         npm run makepot
-        composer install --no-dev
         npm run archive
+
     - name: Upload the ZIP file as an artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -1,0 +1,42 @@
+name: WordPress Plugin Checks
+
+on:
+  push:
+    branches:
+      - develop
+      - trunk
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set PHP version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies and build
+        run: |
+          npm ci --no-optional
+          npm run build
+          composer install
+
+      - name: Run plugin check
+        uses: wordpress/plugin-check-action@v1
+        with:
+          exclude-directories: 'node_modules,vendor'

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    uses: 10up/classifai/.github/workflows/build-release-zip.yml@feature/plugin-check-action # TODO: Update branch before merge.
+    uses: 10up/classifai/.github/workflows/build-release-zip.yml@develop
 
   test:
     needs: build

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -35,3 +35,5 @@ jobs:
         uses: wordpress/plugin-check-action@v1
         with:
           build-dir: ${{ github.event.repository.name }}
+          exclude-checks: 'plugin_readme,plugin_updater' # Plugin isn't on .org so excluding these for now.
+          exclude-directories: 'assets,dist,vendor'

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -10,33 +10,28 @@ on:
       - develop
 
 jobs:
+  build:
+    uses: 10up/classifai/.github/workflows/build-release-zip.yml@feature/plugin-check-action # TODO: Update branch before merge.
+
   test:
+    needs: build
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set PHP version
-        uses: shivammathur/setup-php@v2
+      - name: Download built zip
+        uses: actions/download-artifact@v4
         with:
-          php-version: '7.4'
-          coverage: none
-          tools: composer:v2
+          name: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}
 
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-
-      - name: Install dependencies and build
-        run: |
-          npm ci --no-optional
-          npm run build
-          composer install
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: ${{ github.event.repository.name }}
 
       - name: Run plugin check
         uses: wordpress/plugin-check-action@v1
         with:
-          exclude-directories: 'node_modules,vendor'
+          build-dir: ${{ github.event.repository.name }}

--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -84,6 +84,7 @@ class TextToSpeech extends Provider {
 					'' :
 					sprintf(
 						wp_kses(
+							/* translators: %s is replaced with the OpenAI Text to Speech models URL */
 							__( 'Select a <a href="%s" title="OpenAI Text to Speech models" target="_blank">model</a> depending on your requirement.', 'classifai' ),
 							[
 								'a' => [
@@ -120,7 +121,8 @@ class TextToSpeech extends Provider {
 					'' :
 					sprintf(
 						wp_kses(
-							__( 'Select the speech <a href="%s" title="OpenAI Text to Speech models" target="_blank">voice</a>.', 'classifai' ),
+							/* translators: %s is replaced with the OpenAI Text to Speech voice options URL */
+							__( 'Select the speech <a href="%s" title="OpenAI Text to Speech voice options" target="_blank">voice</a>.', 'classifai' ),
 							[
 								'a' => [
 									'href'  => [],
@@ -144,8 +146,8 @@ class TextToSpeech extends Provider {
 				'option_index'  => static::ID,
 				'label_for'     => 'format',
 				'options'       => [
-					'mp3'  => __( '.mp3', 'classifai' ),
-					'wav'  => __( '.wav', 'classifai' ),
+					'mp3' => __( '.mp3', 'classifai' ),
+					'wav' => __( '.wav', 'classifai' ),
 				],
 				'default_value' => $settings['format'],
 				'description'   => __( 'Select the desired audio format.', 'classifai' ),
@@ -349,9 +351,9 @@ class TextToSpeech extends Provider {
 		$debug_info        = [];
 
 		if ( $this->feature_instance instanceof FeatureTextToSpeech ) {
-			$debug_info[ __( 'Model', 'classifai' ) ]          = $provider_settings['tts_model'] ?? '';
-			$debug_info[ __( 'Voice', 'classifai' ) ]          = $provider_settings['voice'] ?? '';
-			$debug_info[ __( 'Audio format', 'classifai' ) ]   = $provider_settings['format'] ?? '';
+			$debug_info[ __( 'Model', 'classifai' ) ]        = $provider_settings['tts_model'] ?? '';
+			$debug_info[ __( 'Voice', 'classifai' ) ]        = $provider_settings['voice'] ?? '';
+			$debug_info[ __( 'Audio format', 'classifai' ) ] = $provider_settings['format'] ?? '';
 
 			// We don't save the response transient because WP does not support serialized binary data to be inserted to the options.
 		}


### PR DESCRIPTION
### Description of the Change

WordPress has an official Plugin Check plugin that runs a handful of different checks. They've brought the same functionality into a [GitHub Action](https://github.com/wordpress/plugin-check-action/) and this PR adds that as a workflow.

Also made some minor updates to our Build Release Zip Action (which we use here to run tests on the final build) and fix the few issues the Plugin Check found.

Note there are quite a [few checks](https://github.com/wordpress/plugin-check-action/?tab=readme-ov-file#supported-checks) the Plugin Check does, some of which we already do separately (like PHPCS). For now I've left all checks in place other than the Plugin Readme and Plugin Updater checks (both fail here) but we may want to trim the list down if we think some of these are overkill, though they run fast enough I think it's fine. 

### How to test the Change

Verify the [Plugin Check Action](https://github.com/10up/classifai/actions/runs/11060040009?pr=806) is passing on this PR

### Changelog Entry

> Fixed - Ensure all strings have translator comments
> Developer - Add the WordPress Plugin Check GitHub Action

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
