### PR TITLE
Update the Classification enable text

### DIFF
--- a/includes/Classifai/Features/Classification.php
+++ b/includes/Classifai/Features/Classification.php
@@ -738,7 +738,7 @@ class Classification extends Feature {
 	 * @return string
 	 */
 	public function get_enable_description(): string {
-		return esc_html__( 'Enables automatic content classification.', 'classifai' );
+		return esc_html__( 'Enables content classification.', 'classifai' );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Notice the text below the enable option for the Classification Feature says `Enables automatic content classification`.

This used to be true but the default now is manual classification and automatic classification can be turned on if desired. Not a big deal but figured we might as well remove the word `automatic` from that.

Before:

<img width="524" alt="Enable toggle before changes" src="https://github.com/user-attachments/assets/521f2c0a-468e-4d59-b777-25cb19dc0314">

After:

<img width="461" alt="Enable toggle after changes" src="https://github.com/user-attachments/assets/56e323fc-1ef4-497e-8d74-552d663f0565">

### How to test the Change

1. Checkout this PR
2. Go to `Tools > ClassifAI > Language Processing > Classification`
3. Find the `Enable feature` setting and take note of the text shown there

### Changelog Entry

> Changed - Update helper text for the enable Classification toggle

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
