### PR TITLE
Add a PHPStan configuration and run it as a GitHub Action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -36,6 +36,7 @@ LICENSE.md export-ignore
 package-lock.json export-ignore
 package.json export-ignore
 phpcs.xml.dist export-ignore
+phpstan.neon.dist export-ignore
 phpunit.xml.dist export-ignore
 README.md export-ignore
 webpack.config.js export-ignore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,24 +105,3 @@ jobs:
         enable_warnings: true
         standard: 'WordPress-VIP-Go'
         excludes: 'tests'
-
-  phpstan:
-    name: PHPStan
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set PHP version
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: none
-          tools: composer:v2
-
-      - name: Install dependencies
-        run: composer install
-
-      - name: PHPStan
-        run: composer phpstan

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,18 +21,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup node v16 and npm cache
+    - name: Setup node
       uses: actions/setup-node@v4
       with:
         node-version-file: .nvmrc
         cache: npm
 
-    - name: Install Node dependencies
+    - name: Install node dependencies
       run: npm ci --no-optional
 
     - name: Get updated JS files
       id: changed-files
-      uses: tj-actions/changed-files@v42
+      uses: tj-actions/changed-files@v45
       with:
         files: |
           **/*.js
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Set standard 10up cache directories
+    - name: Set standard cache directories
       run: |
         composer config -g cache-dir "${{ env.COMPOSER_CACHE }}"
 
@@ -78,7 +78,7 @@ jobs:
 
     - name: Get updated PHP files
       id: changed-files
-      uses: tj-actions/changed-files@v42
+      uses: tj-actions/changed-files@v45
       with:
         files: |
           **/*.php
@@ -105,3 +105,24 @@ jobs:
         enable_warnings: true
         standard: 'WordPress-VIP-Go'
         excludes: 'tests'
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set PHP version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: PHPStan
+        run: composer phpstan

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,33 @@
+name: PHPStan
+
+on:
+  push:
+    branches:
+      - develop
+      - trunk
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set PHP version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: PHPStan
+        run: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -28,17 +28,22 @@
   },
   "require-dev": {
     "10up/phpcs-composer": "^3.0",
-    "yoast/phpunit-polyfills": "^1.0.0"
+    "yoast/phpunit-polyfills": "^1.0.0",
+    "szepeviktor/phpstan-wordpress": "dev-master",
+    "phpstan/extension-installer": "1.4.x-dev",
+    "php-stubs/wp-cli-stubs": "dev-master"
   },
   "scripts": {
     "lint": "phpcs -s . --runtime-set testVersion 7.4-",
     "lint-fix": "phpcbf .",
+    "phpstan": "phpstan analyse --memory-limit=2048M",
     "pre-autoload-dump": "Aws\\Script\\Composer\\Composer::removeUnusedServices"
   },
   "minimum-stability": "dev",
   "config": {
     "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "phpstan/extension-installer": true
     }
   },
   "archive": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,9 @@
     "yoast/phpunit-polyfills": "^1.0.0",
     "szepeviktor/phpstan-wordpress": "dev-master",
     "phpstan/extension-installer": "1.4.x-dev",
-    "php-stubs/wp-cli-stubs": "dev-master"
+    "php-stubs/wp-cli-stubs": "dev-master",
+    "johnbillion/wp-compat": "dev-trunk",
+    "phpstan/phpstan-deprecation-rules": "1.2.x-dev"
   },
   "scripts": {
     "lint": "phpcs -s . --runtime-set testVersion 7.4-",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
   "scripts": {
     "lint": "phpcs -s . --runtime-set testVersion 7.4-",
     "lint-fix": "phpcbf .",
-    "phpstan": "phpstan analyse --memory-limit=2048M",
+    "phpstan": "phpstan analyse --memory-limit=2048M -v",
     "pre-autoload-dump": "Aws\\Script\\Composer\\Composer::removeUnusedServices"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03778b3283f192d1c1736b533930b225",
+    "content-hash": "7fb63a9a16fb49a1fbca1dc3f5ecb3cd",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1622,6 +1622,99 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "86e8753e89d59849276dcdd91b9a7dd78bb4abe2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/86e8753e89d59849276dcdd91b9a7dd78bb4abe2",
+                "reference": "86e8753e89d59849276dcdd91b9a7dd78bb4abe2",
+                "shasum": ""
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^4.13",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^5.4.1",
+                "phpstan/phpstan": "^1.10.49",
+                "phpunit/phpunit": "^9.5",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.6.0"
+            },
+            "time": "2024-07-17T08:50:38+00:00"
+        },
+        {
+            "name": "php-stubs/wp-cli-stubs",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wp-cli-stubs.git",
+                "reference": "dd9efeb1e1449a57fbdc80c967935659436716a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wp-cli-stubs/zipball/dd9efeb1e1449a57fbdc80c967935659436716a3",
+                "reference": "dd9efeb1e1449a57fbdc80c967935659436716a3",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
+            },
+            "require-dev": {
+                "php": "~7.3 || ~8.0",
+                "php-stubs/generator": "^0.8.0"
+            },
+            "suggest": {
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "default-branch": true,
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WP-CLI function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wp-cli-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress",
+                "wp-cli"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wp-cli-stubs/issues",
+                "source": "https://github.com/php-stubs/wp-cli-stubs/tree/master"
+            },
+            "time": "2024-07-30T02:38:17+00:00"
+        },
+        {
             "name": "phpcompatibility/php-compatibility",
             "version": "9.3.5",
             "source": {
@@ -1962,6 +2055,113 @@
                 }
             ],
             "time": "2024-03-04T08:00:16+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "e7bd2bf9662c96368303a284be3f2079e204b341"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/e7bd2bf9662c96368303a284be3f2079e204b341",
+                "reference": "e7bd2bf9662c96368303a284be3f2079e204b341",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.12.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "default-branch": true,
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.x"
+            },
+            "time": "2024-09-06T14:27:20+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "eb78fe30b1adbc3294c306925f359bd83c311153"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/eb78fe30b1adbc3294c306925f359bd83c311153",
+                "reference": "eb78fe30b1adbc3294c306925f359bd83c311153",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-26T18:32:52+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3490,6 +3690,153 @@
             "time": "2024-03-07T21:48:16+00:00"
         },
         {
+            "name": "symfony/polyfill-php73",
+            "version": "1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "fdc31b2a37515acbe03069baf46489f88d0a4821"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/fdc31b2a37515acbe03069baf46489f88d0a4821",
+                "reference": "fdc31b2a37515acbe03069baf46489f88d0a4821",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
+                "phpstan/phpstan": "^1.11.0",
+                "symfony/polyfill-php73": "^1.12.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.2",
+                "phpunit/phpunit": "^8.0 || ^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "default-branch": true,
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/szepeviktor",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-05T18:13:37+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.3",
             "source": {
@@ -3672,7 +4019,9 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "ua-parser/uap-php": 20
+        "ua-parser/uap-php": 20,
+        "szepeviktor/phpstan-wordpress": 20,
+        "phpstan/extension-installer": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7fb63a9a16fb49a1fbca1dc3f5ecb3cd",
+    "content-hash": "2f9c2cc632c25b6e192ec4d8273e23a7",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1383,6 +1383,83 @@
             "time": "2023-12-09T14:16:53+00:00"
         },
         {
+            "name": "johnbillion/wp-compat",
+            "version": "dev-trunk",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnbillion/wp-compat.git",
+                "reference": "580cc09bdadd0922bd9de5d4e02fcc39c2ad342c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnbillion/wp-compat/zipball/580cc09bdadd0922bd9de5d4e02fcc39c2ad342c",
+                "reference": "580cc09bdadd0922bd9de5d4e02fcc39c2ad342c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7.4",
+                "phpstan/phpstan": "^1.12"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "johnbillion/plugin-infrastructure": "dev-trunk",
+                "nikic/php-parser": "^5.1",
+                "php-stubs/wordpress-stubs": "^6.6",
+                "phpstan/phpstan-deprecation-rules": "1.2.0",
+                "phpstan/phpstan-phpunit": "1.3.15",
+                "phpstan/phpstan-strict-rules": "1.6.0",
+                "phpunit/phpunit": "^9.0",
+                "roots/wordpress-core-installer": "1.100.0",
+                "roots/wordpress-full": "dev-main",
+                "wp-coding-standards/wpcs": "3.1.0"
+            },
+            "suggest": {
+                "phpstan/phpstan-deprecation-rules": "PHPStan rules for detecting usage of deprecated symbols",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "default-branch": true,
+            "type": "phpstan-extension",
+            "extra": {
+                "wordpress-install-dir": "vendor/wordpress/wordpress",
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "WPCompat\\PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Blackbourn",
+                    "homepage": "https://johnblackbourn.com/"
+                }
+            ],
+            "description": "PHPStan extension to help verify that your PHP code is compatible with a given version of WordPress",
+            "keywords": [
+                "PHPStan",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/johnbillion/wp-compat/issues",
+                "source": "https://github.com/johnbillion/wp-compat"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/johnbillion",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-09T23:34:34+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.x-dev",
             "source": {
@@ -2162,6 +2239,53 @@
                 }
             ],
             "time": "2024-09-26T18:32:52+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "1.2.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "0ccccb19bfe6fa72f0129b903fd468dd566fc050"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/0ccccb19bfe6fa72f0129b903fd468dd566fc050",
+                "reference": "0ccccb19bfe6fa72f0129b903fd468dd566fc050",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.12.5"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.x"
+            },
+            "time": "2024-09-26T12:32:25+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4021,7 +4145,9 @@
     "stability-flags": {
         "ua-parser/uap-php": 20,
         "szepeviktor/phpstan-wordpress": 20,
-        "phpstan/extension-installer": 20
+        "phpstan/extension-installer": 20,
+        "php-stubs/wp-cli-stubs": 20,
+        "johnbillion/wp-compat": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/includes/Classifai/Admin/BulkActions.php
+++ b/includes/Classifai/Admin/BulkActions.php
@@ -154,6 +154,8 @@ class BulkActions {
 			return $redirect_to;
 		}
 
+		$action = '';
+
 		foreach ( $post_ids as $post_id ) {
 			switch ( $doaction ) {
 				case Classification::ID:
@@ -262,6 +264,8 @@ class BulkActions {
 		) {
 			return $redirect_to;
 		}
+
+		$action = '';
 
 		foreach ( $comment_ids as $comment_id ) {
 			switch ( $doaction ) {
@@ -573,6 +577,7 @@ class BulkActions {
 	public function bulk_action_admin_notice() {
 		$post_count      = 0;
 		$action          = '';
+		$action_text     = '';
 		$post_type       = ! empty( $_GET['post_type'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) : 'post'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$all_feature_ids = array_map(
 			function ( $feature ) {
@@ -580,6 +585,10 @@ class BulkActions {
 			},
 			array_merge( $this->language_processing_features, $this->media_processing_features )
 		);
+
+		if ( empty( $all_feature_ids ) ) {
+			return;
+		}
 
 		foreach ( $all_feature_ids as $feature_id ) {
 			$post_count = ! empty( $_GET[ "bulk_{$feature_id}" ] ) ? intval( wp_unslash( $_GET[ "bulk_{$feature_id}" ] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/includes/Classifai/Admin/DebugInfo.php
+++ b/includes/Classifai/Admin/DebugInfo.php
@@ -57,6 +57,7 @@ class DebugInfo {
 		 *
 		 * @param {array} 'debug_info' Array of associative arrays corresponding to lines shown on the Site Health screen. Each array
 		 *              requires a `label` and a `value` field. Other accepted fields are `debug` and `private`.
+		 * @param {array} $information The full array of site debug information.
 		 *
 		 * @return {array} Filtered array of debug information.
 		 */

--- a/includes/Classifai/Admin/templates/onboarding-footer.php
+++ b/includes/Classifai/Admin/templates/onboarding-footer.php
@@ -5,6 +5,7 @@
  * @package ClassifAI
  */
 
+/** @var array $args Arguments coming from the included file. */
 ?>
 				<div class="classifai-setup-footer">
 					<span class="classifai-setup-footer__left">

--- a/includes/Classifai/Admin/templates/onboarding-header.php
+++ b/includes/Classifai/Admin/templates/onboarding-header.php
@@ -5,6 +5,7 @@
  * @package ClassifAI
  */
 
+/** @var array $args Arguments coming from the included file. */
 ?>
 <h1 class="classifai-setup-heading">
 	<?php echo esc_html( $args['title'] ?? __( 'Welcome to ClassifAI', 'classifai' ) ); ?>

--- a/includes/Classifai/Command/RSSImporterCommand.php
+++ b/includes/Classifai/Command/RSSImporterCommand.php
@@ -191,7 +191,7 @@ class RSSImporterCommand extends \WP_CLI_Command {
 	/**
 	 * Get meta for a URL.
 	 *
-	 * @param $string $url The URL.
+	 * @param string $url The URL.
 	 */
 	public function get_url_meta( $url ) {
 		$options = [];
@@ -200,7 +200,7 @@ class RSSImporterCommand extends \WP_CLI_Command {
 			$options['headers'] = [];
 		}
 
-		$options['headers']['x-api-key'] = MERCURY_PARSER_API_KEY;
+		$options['headers']['x-api-key'] = defined( MERCURY_PARSER_API_KEY ) ?? ''; /** @phpstan-ignore constant.notFound (If constant not defined, will use empty string instead) */
 		$options['timeout']              = 60; // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 
 		$request_url = 'https://mercury.postlight.com/parser?url=' . rawurlencode( $url );

--- a/includes/Classifai/Command/RSSImporterCommand.php
+++ b/includes/Classifai/Command/RSSImporterCommand.php
@@ -200,8 +200,11 @@ class RSSImporterCommand extends \WP_CLI_Command {
 			$options['headers'] = [];
 		}
 
-		$options['headers']['x-api-key'] = defined( MERCURY_PARSER_API_KEY ) ?? ''; /** @phpstan-ignore constant.notFound (If constant not defined, will use empty string instead) */
-		$options['timeout']              = 60; // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+		if ( defined( \MERCURY_PARSER_API_KEY ) && \MERCURY_PARSER_API_KEY ) {
+			$options['headers']['x-api-key'] = \MERCURY_PARSER_API_KEY;
+		}
+
+		$options['timeout'] = 60; // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 
 		$request_url = 'https://mercury.postlight.com/parser?url=' . rawurlencode( $url );
 		$response    = wp_remote_get( $request_url, $options ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get

--- a/includes/Classifai/Features/AudioTranscriptsGeneration.php
+++ b/includes/Classifai/Features/AudioTranscriptsGeneration.php
@@ -53,8 +53,8 @@ class AudioTranscriptsGeneration extends Feature {
 	public function feature_setup() {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 		add_action( 'add_meta_boxes_attachment', [ $this, 'setup_attachment_meta_box' ] );
-		add_action( 'edit_attachment', [ $this, 'maybe_transcribe_audio' ] );
-		add_action( 'add_attachment', [ $this, 'transcribe_audio' ] );
+		add_action( 'edit_attachment', [ $this, 'maybe_transcribe_audio' ] ); /** @phpstan-ignore return.void (function is used in multiple contexts and needs to return data if called directly) */
+		add_action( 'add_attachment', [ $this, 'transcribe_audio' ] ); /** @phpstan-ignore return.void (function is used in multiple contexts and needs to return data if called directly) */
 
 		add_filter( 'attachment_fields_to_edit', [ $this, 'add_buttons_to_media_modal' ], 10, 2 );
 	}

--- a/includes/Classifai/Features/DescriptiveTextGenerator.php
+++ b/includes/Classifai/Features/DescriptiveTextGenerator.php
@@ -192,6 +192,8 @@ class DescriptiveTextGenerator extends Feature {
 	 * @param \WP_Post $post The post object.
 	 */
 	public function setup_attachment_meta_box( \WP_Post $post ) {
+		global $wp_meta_boxes;
+
 		if ( ! wp_attachment_is_image( $post ) || ! $this->is_feature_enabled() ) {
 			return;
 		}

--- a/includes/Classifai/Features/ImageCropping.php
+++ b/includes/Classifai/Features/ImageCropping.php
@@ -230,6 +230,8 @@ class ImageCropping extends Feature {
 	 * @param \WP_Post $post The post object.
 	 */
 	public function setup_attachment_meta_box( \WP_Post $post ) {
+		global $wp_meta_boxes;
+
 		if ( ! wp_attachment_is_image( $post ) || ! $this->is_feature_enabled() ) {
 			return;
 		}

--- a/includes/Classifai/Features/ImageTextExtraction.php
+++ b/includes/Classifai/Features/ImageTextExtraction.php
@@ -180,8 +180,7 @@ class ImageTextExtraction extends Feature {
 		 *
 		 * @param {string} $post_args     Array of post data for the attachment post update. Defaults to `ID` and `post_content`.
 		 * @param {int}    $attachment_id ID of the attachment post.
-		 * @param {object} $scan          The full scan results from the API.
-		 * @param {string} $text          The text data to be saved.
+		 * @param {object} $result        The full scan results from the API.
 		 *
 		 * @return {string} The filtered text data.
 		 */
@@ -230,6 +229,8 @@ class ImageTextExtraction extends Feature {
 	 * @param \WP_Post $post The post object.
 	 */
 	public function setup_attachment_meta_box( \WP_Post $post ) {
+		global $wp_meta_boxes;
+
 		if ( ! wp_attachment_is_image( $post ) || ! $this->is_feature_enabled() ) {
 			return;
 		}

--- a/includes/Classifai/Features/Smart404EPIntegration.php
+++ b/includes/Classifai/Features/Smart404EPIntegration.php
@@ -243,7 +243,7 @@ class Smart404EPIntegration {
 		}
 
 		// If we still don't have embeddings, return early.
-		if ( ! $embeddings || empty( $embeddings ) ) {
+		if ( empty( $embeddings ) ) {
 			if ( is_indexing_wpcli() ) {
 				WP_CLI::warning(
 					sprintf(

--- a/includes/Classifai/Providers/AWS/AmazonPolly.php
+++ b/includes/Classifai/Providers/AWS/AmazonPolly.php
@@ -480,7 +480,7 @@ class AmazonPolly extends Provider {
 		// Handle all of our routes.
 		switch ( $route_to_call ) {
 			case 'synthesize':
-				$return = $this->synthesize_speech( $post_id, $args );
+				$return = $this->synthesize_speech( $post_id );
 				break;
 		}
 

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -724,7 +724,7 @@ class ComputerVision extends Provider {
 	 * @param int    $attachment_id The attachment ID we're processing.
 	 * @param string $route_to_call The name of the route we're going to be processing.
 	 * @param array  $args          Optional arguments to pass to the route.
-	 * @return array|string|WP_Error
+	 * @return array|string|WP_Error|null
 	 */
 	public function rest_endpoint_callback( $attachment_id, string $route_to_call = '', array $args = [] ) {
 		// Check to be sure the post both exists and is an attachment.

--- a/includes/Classifai/Providers/Azure/Embeddings.php
+++ b/includes/Classifai/Providers/Azure/Embeddings.php
@@ -184,9 +184,9 @@ class Embeddings extends OpenAI {
 			return;
 		}
 
-		add_action( 'created_term', [ $this, 'generate_embeddings_for_term' ] );
-		add_action( 'edited_terms', [ $this, 'generate_embeddings_for_term' ] );
-		add_action( 'wp_ajax_get_post_classifier_embeddings_preview_data', array( $this, 'get_post_classifier_embeddings_preview_data' ) );
+		add_action( 'created_term', [ $this, 'generate_embeddings_for_term' ] ); /** @phpstan-ignore return.void (function is used in multiple contexts and needs to return data if called directly) */
+		add_action( 'edited_terms', [ $this, 'generate_embeddings_for_term' ] ); /** @phpstan-ignore return.void (function is used in multiple contexts and needs to return data if called directly) */
+		add_action( 'wp_ajax_get_post_classifier_embeddings_preview_data', array( $this, 'get_post_classifier_embeddings_preview_data' ) ); /** @phpstan-ignore return.void (function is used in an ajax context and does need to return data) */
 	}
 
 	/**
@@ -197,7 +197,7 @@ class Embeddings extends OpenAI {
 	 * @return array
 	 */
 	public function modify_default_feature_settings( array $settings, $feature_instance ): array {
-		remove_filter( 'classifai_feature_classification_get_default_settings', [ $this, 'modify_default_feature_settings' ], 10, 2 );
+		remove_filter( 'classifai_feature_classification_get_default_settings', [ $this, 'modify_default_feature_settings' ], 10 );
 
 		if ( $feature_instance->get_settings( 'provider' ) !== static::ID ) {
 			return $settings;
@@ -1103,6 +1103,7 @@ class Embeddings extends OpenAI {
 	 */
 	public function get_normalized_content( int $id = 0, string $type = 'post' ): string {
 		$normalizer = new Normalizer();
+		$content    = '';
 
 		// Get the content depending on the type.
 		switch ( $type ) {

--- a/includes/Classifai/Providers/Azure/OCR.php
+++ b/includes/Classifai/Providers/Azure/OCR.php
@@ -192,7 +192,7 @@ class OCR {
 
 		$url = get_largest_size_and_dimensions_image_url(
 			get_attached_file( $attachment_id ),
-			wp_get_attachment_url( $attachment_id, 'full' ),
+			wp_get_attachment_url( $attachment_id ),
 			$metadata,
 			[ 50, 4200 ],
 			[ 50, 4200 ],

--- a/includes/Classifai/Providers/Azure/Personalizer.php
+++ b/includes/Classifai/Providers/Azure/Personalizer.php
@@ -394,6 +394,7 @@ class Personalizer extends Provider {
 
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$event_id        = $response->eventId;
+		$rewarded_post   = 0;
 		$number_of_posts = isset( $attributes['numberOfItems'] ) ? absint( $attributes['numberOfItems'] ) : 3;
 
 		if ( ! empty( $response ) && ! empty( $response->rewardActionId ) ) {

--- a/includes/Classifai/Providers/Azure/Read.php
+++ b/includes/Classifai/Providers/Azure/Read.php
@@ -114,7 +114,7 @@ class Read {
 			return $this->log_error( new WP_Error( 'auth', esc_html__( 'Please set up valid authentication with Azure.', 'classifai' ) ) );
 		}
 
-		if ( ! $this->should_process( $this->attachment_id ) ) {
+		if ( ! $this->should_process() ) {
 			return $this->log_error( new WP_Error( 'process_error', esc_html__( 'Document does not meet processing requirements.', 'classifai' ) ) );
 		}
 
@@ -277,7 +277,7 @@ class Read {
 	 * Update document description using text received from Read API.
 	 *
 	 * @param array $data Read result.
-	 * @return WP_Error|array
+	 * @return WP_Error|array|null
 	 */
 	public function update_document_description( array $data ) {
 		if ( empty( $data['analyzeResult'] ) || empty( $data['analyzeResult']['readResults'] ) ) {

--- a/includes/Classifai/Providers/Azure/SmartCropping.php
+++ b/includes/Classifai/Providers/Azure/SmartCropping.php
@@ -185,7 +185,7 @@ class SmartCropping {
 		if ( empty( $url ) ) {
 			$url = get_largest_acceptable_image_url(
 				get_attached_file( $attachment_id ),
-				wp_get_attachment_url( $attachment_id, 'full' ),
+				wp_get_attachment_url( $attachment_id ),
 				$size_data,
 				computer_vision_max_filesize()
 			);

--- a/includes/Classifai/Providers/Azure/Speech.php
+++ b/includes/Classifai/Providers/Azure/Speech.php
@@ -430,7 +430,7 @@ class Speech extends Provider {
 		// Handle all of our routes.
 		switch ( $route_to_call ) {
 			case 'synthesize':
-				$return = $this->synthesize_speech( $post_id, $args );
+				$return = $this->synthesize_speech( $post_id );
 				break;
 		}
 

--- a/includes/Classifai/Providers/GoogleAI/APIRequest.php
+++ b/includes/Classifai/Providers/GoogleAI/APIRequest.php
@@ -87,6 +87,7 @@ class APIRequest {
 		 * @since 3.0.0
 		 * @hook classifai_googleai_api_response_get
 		 *
+		 * @param {array|WP_Error} $response API response.
 		 * @param {string} $url Request URL.
 		 * @param {array} $options Request body options.
 		 * @param {string} $this->feature Feature name.
@@ -153,6 +154,7 @@ class APIRequest {
 		 * @since 3.0.0
 		 * @hook classifai_googleai_api_response_post
 		 *
+		 * @param {array|WP_Error} $response API response.
 		 * @param {string} $url Request URL.
 		 * @param {array} $options Request body options.
 		 * @param {string} $this->feature Feature name.

--- a/includes/Classifai/Providers/OpenAI/APIRequest.php
+++ b/includes/Classifai/Providers/OpenAI/APIRequest.php
@@ -87,6 +87,7 @@ class APIRequest {
 		 * @since 2.4.0
 		 * @hook classifai_openai_api_response_get
 		 *
+		 * @param {array|WP_Error} $response The API response.
 		 * @param {string} $url Request URL.
 		 * @param {array} $options Request body options.
 		 * @param {string} $this->feature Feature name.
@@ -153,6 +154,7 @@ class APIRequest {
 		 * @since 2.4.0
 		 * @hook classifai_openai_api_response_post
 		 *
+		 * @param {array|WP_Error} $response The API response.
 		 * @param {string} $url Request URL.
 		 * @param {array} $options Request body options.
 		 * @param {string} $this->feature Feature name.
@@ -247,6 +249,7 @@ class APIRequest {
 		 * @since 2.4.0
 		 * @hook classifai_openai_api_response_post_form
 		 *
+		 * @param {array|WP_Error} $response The API response.
 		 * @param {string} $url Request URL.
 		 * @param {array} $options Request body options.
 		 * @param {string} $this->feature Feature name.
@@ -273,7 +276,7 @@ class APIRequest {
 			$headers      = wp_remote_retrieve_headers( $response );
 			$content_type = false;
 
-			if ( ! is_wp_error( $headers ) ) {
+			if ( ! empty( $headers ) ) {
 				$content_type = isset( $headers['content-type'] ) ? $headers['content-type'] : false;
 			}
 

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -308,9 +308,9 @@ class Embeddings extends Provider {
 			return;
 		}
 
-		add_action( 'created_term', [ $this, 'generate_embeddings_for_term' ] );
-		add_action( 'edited_terms', [ $this, 'generate_embeddings_for_term' ] );
-		add_action( 'wp_ajax_get_post_classifier_embeddings_preview_data', array( $this, 'get_post_classifier_embeddings_preview_data' ) );
+		add_action( 'created_term', [ $this, 'generate_embeddings_for_term' ] ); /** @phpstan-ignore return.void (function is used in multiple contexts and needs to return data if called directly) */
+		add_action( 'edited_terms', [ $this, 'generate_embeddings_for_term' ] ); /** @phpstan-ignore return.void (function is used in multiple contexts and needs to return data if called directly) */
+		add_action( 'wp_ajax_get_post_classifier_embeddings_preview_data', array( $this, 'get_post_classifier_embeddings_preview_data' ) ); /** @phpstan-ignore return.void (function is called via ajax and does need to return data) */
 	}
 
 	/**
@@ -321,7 +321,7 @@ class Embeddings extends Provider {
 	 * @return array
 	 */
 	public function modify_default_feature_settings( array $settings, $feature_instance ): array {
-		remove_filter( 'classifai_feature_classification_get_default_settings', [ $this, 'modify_default_feature_settings' ], 10, 2 );
+		remove_filter( 'classifai_feature_classification_get_default_settings', [ $this, 'modify_default_feature_settings' ], 10 );
 
 		if ( $feature_instance->get_settings( 'provider' ) !== static::ID ) {
 			return $settings;
@@ -1210,6 +1210,7 @@ class Embeddings extends Provider {
 	 */
 	public function get_normalized_content( int $id = 0, string $type = 'post' ): string {
 		$normalizer = new Normalizer();
+		$content    = '';
 
 		// Get the content depending on the type.
 		switch ( $type ) {

--- a/includes/Classifai/Providers/OpenAI/Moderation.php
+++ b/includes/Classifai/Providers/OpenAI/Moderation.php
@@ -132,7 +132,7 @@ class Moderation extends Provider {
 		// Handle all of our routes.
 		switch ( $route_to_call ) {
 			case 'comment':
-				$return = $this->moderate_comment( $item_id, $args );
+				$return = $this->moderate_comment( $item_id );
 				break;
 			case 'post':
 				$return = [];

--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -144,8 +144,8 @@ class TextToSpeech extends Provider {
 				'option_index'  => static::ID,
 				'label_for'     => 'format',
 				'options'       => [
-					'mp3'  => __( '.mp3', 'classifai' ),
-					'wav'  => __( '.wav', 'classifai' ),
+					'mp3' => __( '.mp3', 'classifai' ),
+					'wav' => __( '.wav', 'classifai' ),
 				],
 				'default_value' => $settings['format'],
 				'description'   => __( 'Select the desired audio format.', 'classifai' ),
@@ -254,7 +254,7 @@ class TextToSpeech extends Provider {
 		// Handle all of our routes.
 		switch ( $route_to_call ) {
 			case 'synthesize':
-				$return = $this->synthesize_speech( $post_id, $args );
+				$return = $this->synthesize_speech( $post_id );
 				break;
 		}
 
@@ -349,9 +349,9 @@ class TextToSpeech extends Provider {
 		$debug_info        = [];
 
 		if ( $this->feature_instance instanceof FeatureTextToSpeech ) {
-			$debug_info[ __( 'Model', 'classifai' ) ]          = $provider_settings['tts_model'] ?? '';
-			$debug_info[ __( 'Voice', 'classifai' ) ]          = $provider_settings['voice'] ?? '';
-			$debug_info[ __( 'Audio format', 'classifai' ) ]   = $provider_settings['format'] ?? '';
+			$debug_info[ __( 'Model', 'classifai' ) ]        = $provider_settings['tts_model'] ?? '';
+			$debug_info[ __( 'Voice', 'classifai' ) ]        = $provider_settings['voice'] ?? '';
+			$debug_info[ __( 'Audio format', 'classifai' ) ] = $provider_settings['format'] ?? '';
 
 			// We don't save the response transient because WP does not support serialized binary data to be inserted to the options.
 		}

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -24,7 +24,7 @@ abstract class Provider {
 	/**
 	 * Format the result of most recent request.
 	 *
-	 * @param array|WP_Error $data Response data to format.
+	 * @param array|\WP_Error $data Response data to format.
 	 * @return string
 	 */
 	protected function get_formatted_latest_response( $data ): string {

--- a/includes/Classifai/Providers/Watson/Classifier.php
+++ b/includes/Classifai/Providers/Watson/Classifier.php
@@ -49,7 +49,7 @@ class Classifier {
 	 * @param string $text The plain text to classify
 	 * @param array  $options NLU classification options
 	 * @param array  $request_options Extra options to pass to the underlying HTTP request
-	 * @return array|WP_Error
+	 * @return array|\WP_Error
 	 */
 	public function classify( string $text, array $options = [], array $request_options = [] ) {
 		$body = $this->get_body( $text, $options );

--- a/includes/Classifai/Providers/Watson/Linker.php
+++ b/includes/Classifai/Providers/Watson/Linker.php
@@ -374,12 +374,10 @@ class Linker {
 	 * @return bool
 	 */
 	public function can_link_keyword( $keyword ): bool {
-		if ( ! empty( $keyword['text'] ) ) {
-			if ( ! empty( $keyword['relevance'] ) ) {
-				$relevance = floatval( $keyword['relevance'] );
-				$threshold = get_feature_threshold( 'keyword' );
-				return $relevance >= $threshold;
-			}
+		if ( ! empty( $keyword['text'] ) && ! empty( $keyword['relevance'] ) ) {
+			$relevance = floatval( $keyword['relevance'] );
+			$threshold = get_feature_threshold( 'keyword' );
+			return $relevance >= $threshold;
 		} else {
 			return false;
 		}
@@ -392,12 +390,10 @@ class Linker {
 	 * @return bool
 	 */
 	public function can_link_concept( $concept ): bool {
-		if ( ! empty( $concept['text'] ) ) {
-			if ( ! empty( $concept['relevance'] ) ) {
-				$relevance = floatval( $concept['relevance'] );
-				$threshold = get_feature_threshold( 'concept' );
-				return $relevance >= $threshold;
-			}
+		if ( ! empty( $concept['text'] ) && ! empty( $concept['relevance'] ) ) {
+			$relevance = floatval( $concept['relevance'] );
+			$threshold = get_feature_threshold( 'concept' );
+			return $relevance >= $threshold;
 		} else {
 			return false;
 		}
@@ -410,12 +406,10 @@ class Linker {
 	 * @return bool
 	 */
 	public function can_link_entity( $entity ): bool {
-		if ( ! empty( $entity['text'] ) ) {
-			if ( ! empty( $entity['relevance'] ) ) {
-				$relevance = floatval( $entity['relevance'] );
-				$threshold = get_feature_threshold( 'entity' );
-				return $relevance >= $threshold;
-			}
+		if ( ! empty( $entity['text'] ) && ! empty( $entity['relevance'] ) ) {
+			$relevance = floatval( $entity['relevance'] );
+			$threshold = get_feature_threshold( 'entity' );
+			return $relevance >= $threshold;
 		} else {
 			return false;
 		}

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -170,7 +170,7 @@ class NLU extends Provider {
 	 * @return array
 	 */
 	public function modify_default_feature_settings( array $settings, $feature_instance ): array {
-		remove_filter( 'classifai_feature_classification_get_default_settings', [ $this, 'modify_default_feature_settings' ], 10, 2 );
+		remove_filter( 'classifai_feature_classification_get_default_settings', [ $this, 'modify_default_feature_settings' ], 10 );
 
 		if ( $feature_instance->get_settings( 'provider' ) !== static::ID ) {
 			return $settings;
@@ -264,10 +264,10 @@ class NLU extends Provider {
 	/**
 	 * Filter classifier preview based on the feature settings.
 	 *
-	 * @param array $classified_data The classified data.
+	 * @param array|WP_Error $classified_data The classified data.
 	 * @return array
 	 */
-	public function filter_classify_preview_data( array $classified_data ): array {
+	public function filter_classify_preview_data( $classified_data ): array {
 		if ( is_wp_error( $classified_data ) ) {
 			return $classified_data;
 		}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,7 +12,7 @@ parameters:
 	ignoreErrors:
 		# The JSDoc standard we use on hooks is not compatible with PHPStan.
 		- '#One or more @param tags has an invalid name or invalid syntax#'
-		- '#PHPDoc tag @(.+) has invalid value \({(.+)}(.*)\): Unexpected token "{"#'
+		# - '#PHPDoc tag @(.+) has invalid value \({(.+)}(.*)\): Unexpected token "{"#'
 		# Could look to fix this in the future.
 		- '#@param tag must not be named \$this. Choose a descriptive alias, for example \$instance#'
 		# Ignore ElasticPress for now, as we'll need to stub this.
@@ -20,5 +20,6 @@ parameters:
 		# These constants are defined but we'd need to stub them for PHPStan to know.
 		- '#Constant CLASSIFAI_.+ not found#'
 		- '#Constant WATSON_.+ not found#'
+		- '#Constant MERCURY_PARSER_API_KEY not found#'
 	WPCompat:
 		requiresAtLeast: '6.1'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,6 +12,7 @@ parameters:
 	ignoreErrors:
 		# The JSDoc standard we use on hooks is not compatible with PHPStan.
 		- '#One or more @param tags has an invalid name or invalid syntax#'
+		- '#PHPDoc tag @(.+) has invalid value \({(.+)}(.*)\): Unexpected token "{"#'
 		# Could look to fix this in the future.
 		- '#@param tag must not be named \$this. Choose a descriptive alias, for example \$instance#'
 		# Ignore ElasticPress for now, as we'll need to stub this.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,3 +19,5 @@ parameters:
 		# These constants are defined but we'd need to stub them for PHPStan to know.
 		- '#Constant CLASSIFAI_.+ not found#'
 		- '#Constant WATSON_.+ not found#'
+	WPCompat:
+		requiresAtLeast: '6.1'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,21 @@
+parameters:
+	level: 1
+	scanFiles:
+		- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-stubs.php
+		- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php
+		- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-i18n-stubs.php
+		- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-tools-stubs.php
+	paths:
+		- includes/
+		- classifai.php
+		- config.php
+	ignoreErrors:
+		# The JSDoc standard we use on hooks is not compatible with PHPStan.
+		- '#One or more @param tags has an invalid name or invalid syntax#'
+		# Could look to fix this in the future.
+		- '#@param tag must not be named \$this. Choose a descriptive alias, for example \$instance#'
+		# Ignore ElasticPress for now, as we'll need to stub this.
+		- '#ElasticPress#'
+		# These constants are defined but we'd need to stub them for PHPStan to know.
+		- '#Constant CLASSIFAI_.+ not found#'
+		- '#Constant WATSON_.+ not found#'


### PR DESCRIPTION
### Description of the Change

This PR adds in PHPStan as a dev dependency, along with the configuration to run that and a GitHub Action Workflow that will run on all PRs. I've also fixed up all issues that have been reported.

Right now I have this set to level 1 (lowest is 0, highest is 9). If I change this to level 2, there are 85 new things that get flagged (though most look to be pretty similar so solving a few should solve most of them). Ideally we bump this up to a higher level but I think starting at 1 is better than nothing.

### How to test the Change

Verify the PHPStan Action [runs and passes on this PR](https://github.com/10up/classifai/actions/runs/11061912553?pr=808)

### Changelog Entry

> Fixed - Addressed all issues raised by running PHPStan
> Developer - Added PHPStan into our workflow with the ability to run that locally and in a GitHub Action

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
