### PR TITLE
Add a Snackbar notice to inform users that settings have been saved successfully.

### DIFF
--- a/src/js/settings/components/classifai-registration/index.js
+++ b/src/js/settings/components/classifai-registration/index.js
@@ -201,6 +201,10 @@ export const SaveSettingsButton = ( {
 					);
 					setSettings( res.settings );
 					setIsSaving( false );
+					window.scrollTo( {
+						top: 0,
+						behavior: 'smooth',
+					} );
 					return;
 				}
 
@@ -226,6 +230,10 @@ export const SaveSettingsButton = ( {
 					}
 				);
 				setIsSaving( false );
+				window.scrollTo( {
+					top: 0,
+					behavior: 'smooth',
+				} );
 			} );
 	};
 

--- a/src/js/settings/components/classifai-registration/index.js
+++ b/src/js/settings/components/classifai-registration/index.js
@@ -174,7 +174,8 @@ export const SaveSettingsButton = ( {
 	setSettings,
 	onSaveSuccess = () => {},
 } ) => {
-	const { createErrorNotice, removeNotices } = useDispatch( noticesStore );
+	const { createErrorNotice, createSuccessNotice, removeNotices } =
+		useDispatch( noticesStore );
 	const notices = useSelect( ( select ) =>
 		select( noticesStore ).getNotices()
 	);
@@ -205,6 +206,12 @@ export const SaveSettingsButton = ( {
 
 				setSettings( res.settings );
 				onSaveSuccess();
+				createSuccessNotice(
+					__( 'Settings saved successfully.', 'classifai' ),
+					{
+						type: 'snackbar',
+					}
+				);
 				setIsSaving( false );
 			} )
 			.catch( ( error ) => {

--- a/src/js/settings/components/classifai-settings/index.js
+++ b/src/js/settings/components/classifai-settings/index.js
@@ -129,7 +129,8 @@ export const ServiceNavigation = () => {
  * @return {React.ReactElement} The Snackbar component.
  */
 export const SnackbarNotifications = () => {
-	const { removeNotice } = useDispatch( noticeStore );
+	const { removeNotice, removeNotices } = useDispatch( noticeStore );
+	const location = useLocation();
 
 	const { notices } = useSelect( ( select ) => {
 		const allNotices = select( noticeStore ).getNotices();
@@ -139,6 +140,16 @@ export const SnackbarNotifications = () => {
 			),
 		};
 	}, [] );
+
+	useEffect( () => {
+		// Remove existing snackbar notices on location change.
+		if ( removeNotices ) {
+			removeNotices( notices.map( ( { id } ) => id ) );
+		} else if ( removeNotice ) {
+			notices.forEach( ( { id } ) => removeNotice( id ) );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ location, removeNotice, removeNotices ] );
 
 	return (
 		<SnackbarList

--- a/src/js/settings/components/classifai-settings/index.js
+++ b/src/js/settings/components/classifai-settings/index.js
@@ -14,11 +14,12 @@ import {
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
-import { SlotFillProvider } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { SlotFillProvider, SnackbarList } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { store as noticeStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -28,6 +29,7 @@ import { STORE_NAME } from '../../data/store';
 import { FeatureContext } from '../feature-settings/context';
 import { ClassifAIRegistration } from '../classifai-registration';
 import { ClassifAIWelcomeGuide } from './welcome-guide';
+import { Notices } from '../feature-settings/notices';
 
 const { services, features } = window.classifAISettings;
 
@@ -122,6 +124,32 @@ export const ServiceNavigation = () => {
 };
 
 /**
+ * Snackbar component to render the snackbar notifications.
+ *
+ * @return {React.ReactElement} The Snackbar component.
+ */
+export const SnackbarNotifications = () => {
+	const { removeNotice } = useDispatch( noticeStore );
+
+	const { notices } = useSelect( ( select ) => {
+		const allNotices = select( noticeStore ).getNotices();
+		return {
+			notices: allNotices.filter(
+				( notice ) => notice.type === 'snackbar'
+			),
+		};
+	}, [] );
+
+	return (
+		<SnackbarList
+			className="classifai-settings-snackbar-notices"
+			notices={ notices }
+			onRemove={ ( notice ) => removeNotice( notice ) }
+		/>
+	);
+};
+
+/**
  * Main ClassifAI Settings Component.
  *
  * This component serves as the primary entry point for the ClassifAI settings interface.
@@ -188,6 +216,7 @@ export const ClassifAISettings = () => {
 				<Header />
 				<div className="classifai-settings-wrapper">
 					<div className="classifai-admin-notices wrap"></div>
+					<Notices feature={ 'generic-notices' } />
 					<ServiceNavigation />
 					<Routes>
 						<Route
@@ -211,6 +240,7 @@ export const ClassifAISettings = () => {
 						/>
 					</Routes>
 				</div>
+				<SnackbarNotifications />
 			</HashRouter>
 		</SlotFillProvider>
 	);

--- a/src/js/settings/components/feature-settings/save-settings-button.js
+++ b/src/js/settings/components/feature-settings/save-settings-button.js
@@ -83,6 +83,10 @@ export const SaveSettingsButton = ( {
 					} );
 					setSettings( res.settings );
 					setIsSaving( false );
+					window.scrollTo( {
+						top: 0,
+						behavior: 'smooth',
+					} );
 					return;
 				}
 				onSaveSuccess();
@@ -107,6 +111,10 @@ export const SaveSettingsButton = ( {
 					}
 				);
 				setIsSaving( false );
+				window.scrollTo( {
+					top: 0,
+					behavior: 'smooth',
+				} );
 			} );
 	};
 

--- a/src/js/settings/components/feature-settings/save-settings-button.js
+++ b/src/js/settings/components/feature-settings/save-settings-button.js
@@ -33,8 +33,12 @@ export const SaveSettingsButton = ( {
 	label = __( 'Save Settings', 'classifai' ),
 } ) => {
 	const { featureName } = useFeatureSettings();
-	const { createErrorNotice, removeNotices, removeNotice } =
-		useDispatch( noticesStore );
+	const {
+		createSuccessNotice,
+		createErrorNotice,
+		removeNotices,
+		removeNotice,
+	} = useDispatch( noticesStore );
 	const notices = useSelect( ( select ) =>
 		select( noticesStore ).getNotices()
 	);
@@ -82,6 +86,12 @@ export const SaveSettingsButton = ( {
 					return;
 				}
 				onSaveSuccess();
+				createSuccessNotice(
+					__( 'Settings saved successfully.', 'classifai' ),
+					{
+						type: 'snackbar',
+					}
+				);
 				setSettings( res.settings );
 				setIsSaving( false );
 			} )

--- a/src/js/settings/components/service-settings/index.js
+++ b/src/js/settings/components/service-settings/index.js
@@ -113,6 +113,10 @@ export const ServiceSettings = () => {
 						} );
 					} );
 					setIsSaving( false );
+					window.scrollTo( {
+						top: 0,
+						behavior: 'smooth',
+					} );
 					return;
 				}
 
@@ -138,6 +142,10 @@ export const ServiceSettings = () => {
 					}
 				);
 				setIsSaving( false );
+				window.scrollTo( {
+					top: 0,
+					behavior: 'smooth',
+				} );
 			} );
 	};
 

--- a/src/scss/settings.scss
+++ b/src/scss/settings.scss
@@ -430,6 +430,16 @@
 	.classifai-admin-notices {
 		margin-right: 0px;
 	}
+
+	.classifai-settings-snackbar-notices {
+		position: fixed;
+		left: auto;
+		bottom: 40px;
+
+		@media screen and (max-width: 600px) {
+			padding: 0px 20px 0px 0px;
+		}
+	}
 }
 
 .classifai-onboarding {


### PR DESCRIPTION
### Description of the Change
This PR adds a Snackbar notice to inform users that settings have been saved successfully.

![Dec-23-2024 22-31-06](https://github.com/user-attachments/assets/46a8c1cd-5315-4511-8a1e-9fedb1e2f718)


Closes #837 

### How to test the Change
1. Navigate to the ClassifAI settings page (Tools > ClassifAI).
1. Enable or disable any feature and confirm that the notice is displayed properly.
1. Navigate to the settings page of any feature and save the settings.
1. Validate that the Snackbar notice confirming the settings have been saved is displayed.

### Changelog Entry
> Added - Snackbar notice to inform users that settings have been saved successfully.

### Credits
Props @iamdharmesh @dkotter @jeffpaul 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
