### PR TITLE
Skip Repo Automator on forks

### DIFF
--- a/.github/workflows/repo-automator.yml
+++ b/.github/workflows/repo-automator.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   Validate:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork }}
+    if: "${{ github.event_name == 'push' || github.event_name == 'issues' || ( github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork ) }}"
 
     steps:
       - uses: 10up/action-repo-automator@trunk

--- a/.github/workflows/repo-automator.yml
+++ b/.github/workflows/repo-automator.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   Validate:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork }}
 
     steps:
       - uses: 10up/action-repo-automator@trunk


### PR DESCRIPTION
### Description of the Change

In case of forks Repo Automator has permission problems.

Please see https://github.com/10up/classifai/actions/runs/12604306218/job/35130956002?pr=839