### PR TITLE
Ensure the request to authenticate Azure AI Vision credentials works

### DIFF
--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -749,7 +749,7 @@ class ComputerVision extends Provider {
 	protected function authenticate_credentials( string $url, string $api_key ) {
 		$rtn     = false;
 		$request = wp_remote_post(
-			trailingslashit( $url ) . $this->analyze_url,
+			trailingslashit( $url ) . $this->analyze_url . '&features=caption',
 			[
 				'headers' => [
 					'Ocp-Apim-Subscription-Key' => $api_key,

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -749,7 +749,7 @@ class ComputerVision extends Provider {
 	protected function authenticate_credentials( string $url, string $api_key ) {
 		$rtn     = false;
 		$request = wp_remote_post(
-			trailingslashit( $url ) . $this->analyze_url . '&features=caption',
+			add_query_arg( 'features', 'caption', trailingslashit( $url ) . $this->analyze_url ),
 			[
 				'headers' => [
 					'Ocp-Apim-Subscription-Key' => $api_key,


### PR DESCRIPTION
### Description of the Change

In trying to set up a new site using Azure AI Vision for some of our image processing functionality, ran into an error when first authenticating: `Either 'features' or 'model-name' needs to be specified in the query parameter`

This isn't an issue I've seen before so I'm assuming they changed something within their API to require one of those two fields. We currently don't pass either when validating credentials and thus our validation never passes and Azure AI Vision can never be set up.

This PR fixes that by passing in `?features=caption` to ensure that value exists.

### How to test the Change

1. In a new environment, setup the Descriptive Text Generator Feature
2. Choose Microsoft Azure AI Vision as the Provider
3. Enter valid credentials and ensure things save successfully

### Changelog Entry

> Fixed - Ensure the Azure AI Vision Provider authenticates properly

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
