### PR TITLE
Ensure the ClassifAI Registration settings can be saved properly

### DIFF
--- a/includes/Classifai/Services/ServicesManager.php
+++ b/includes/Classifai/Services/ServicesManager.php
@@ -140,7 +140,7 @@ class ServicesManager {
 	 * @return mixed
 	 */
 	public function get_settings( $index = false ) {
-		$settings = get_option( 'classifai_settings' );
+		$settings = get_option( 'classifai_settings', [] );
 
 		// Special handling polyfill for pre-1.3 settings which were nested
 		if ( ! isset( $settings['email'] ) && isset( $settings['registration']['email'] ) ) {


### PR DESCRIPTION
### Description of the Change

In setting up a new environment, I was getting an error when trying to save the ClassifAI Registration settings. In looking at the code, the problem is we grab the existing settings and merge those in to the saved settings. But if no settings exist yet, we end up trying to merge a string into an array, which throws a PHP error.

This PR fixes that by ensuring the default for our settings is an array.

### How to test the Change

1. Set up a new environment or in an existing environment, delete the `classifai_settings` option
2. If not on this branch, try saving the ClassifAI Registration settings and see you'll get an error
3. Check out this branch and try again, settings should now save

### Changelog Entry

> Fixed - Ensure the ClassifAI Registration settings save correctly

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
