### PR TITLE
Add embedding similarity hooks

### DIFF
--- a/includes/Classifai/Providers/Azure/Embeddings.php
+++ b/includes/Classifai/Providers/Azure/Embeddings.php
@@ -481,6 +481,19 @@ class Embeddings extends OpenAI {
 			return new WP_Error( 'invalid', esc_html__( 'No matching terms found.', 'classifai' ) );
 		}
 
+		/**
+		 * Fires after the embeddings similarity has been run but before results are sorted.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_azure_openai_embeddings_pre_sort_embeddings_similarity
+		 *
+		 * @param {array} $embeddings_similarity The embeddings similarity results.
+		 * @param {int} $post_id ID of post to set terms on.
+		 * @param {array} $embeddings Embeddings data.
+		 * @param {bool} $link Whether to link the terms or not.
+		 */
+		do_action( 'classifai_azure_openai_embeddings_pre_sort_embeddings_similarity', $embeddings_similarity, $post_id, $embeddings, $link );
+
 		// Sort the results by similarity.
 		usort(
 			$embeddings_similarity,
@@ -499,6 +512,20 @@ class Embeddings extends OpenAI {
 		foreach ( $embeddings_similarity as $item ) {
 			$sorted_results[ $item['taxonomy'] ][] = $item;
 		}
+
+		/**
+		 * Fires after the embeddings similarity has been run and sorted.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_azure_openai_embeddings_post_sort_embeddings_similarity
+		 *
+		 * @param {array} $sorted_results The sorted embeddings similarity results.
+		 * @param {array} $embeddings_similarity The embeddings similarity results.
+		 * @param {int} $post_id ID of post to set terms on.
+		 * @param {array} $embeddings Embeddings data.
+		 * @param {bool} $link Whether to link the terms or not.
+		 */
+		do_action( 'classifai_azure_openai_embeddings_post_sort_embeddings_similarity', $sorted_results, $embeddings_similarity, $post_id, $embeddings, $link );
 
 		$return = [];
 

--- a/includes/Classifai/Providers/Azure/Embeddings.php
+++ b/includes/Classifai/Providers/Azure/Embeddings.php
@@ -708,7 +708,7 @@ class Embeddings extends OpenAI {
 						 * @param {string} $tax Taxonomy of term.
 						 * @param {bool} $consider_threshold Whether to consider the threshold or not.
 						 */
-						do_action( 'classifai_azure_openai_embeddings_single_embedding_similarity', $similarity, $embedding, $chunk, $term_id, $tax );
+						do_action( 'classifai_azure_openai_embeddings_single_embedding_similarity', $similarity, $embedding, $chunk, $term_id, $tax, $consider_threshold );
 
 						if ( false !== $similarity && ( ! $consider_threshold || $similarity <= $threshold ) ) {
 							$embedding_similarity[] = [

--- a/includes/Classifai/Providers/Azure/Embeddings.php
+++ b/includes/Classifai/Providers/Azure/Embeddings.php
@@ -695,6 +695,21 @@ class Embeddings extends OpenAI {
 					foreach ( $term_embedding as $chunk ) {
 						$similarity = $calculations->cosine_similarity( $embedding, $chunk );
 
+						/**
+						 * Fires after the embeddings similarity has been run for a single chunk.
+						 *
+						 * @since x.x.x
+						 * @hook classifai_azure_openai_embeddings_single_embedding_similarity
+						 *
+						 * @param {bool|float} $similarity The embeddings similarity result.
+						 * @param {array} $embedding Post embedding data.
+						 * @param {array} $chunk Term chunk embedding data.
+						 * @param {int} $term_id ID of term we're comparing.
+						 * @param {string} $tax Taxonomy of term.
+						 * @param {bool} $consider_threshold Whether to consider the threshold or not.
+						 */
+						do_action( 'classifai_azure_openai_embeddings_single_embedding_similarity', $similarity, $embedding, $chunk, $term_id, $tax );
+
 						if ( false !== $similarity && ( ! $consider_threshold || $similarity <= $threshold ) ) {
 							$embedding_similarity[] = [
 								'taxonomy'   => $tax,

--- a/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
+++ b/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
@@ -554,6 +554,19 @@ class OllamaEmbeddings extends Ollama {
 			return new WP_Error( 'invalid', esc_html__( 'No matching terms found.', 'classifai' ) );
 		}
 
+		/**
+		 * Fires after the embeddings similarity has been run but before results are sorted.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_ollama_embeddings_pre_sort_embeddings_similarity
+		 *
+		 * @param {array} $embeddings_similarity The embeddings similarity results.
+		 * @param {int} $post_id ID of post to set terms on.
+		 * @param {array} $embeddings Embeddings data.
+		 * @param {bool} $link Whether to link the terms or not.
+		 */
+		do_action( 'classifai_ollama_embeddings_pre_sort_embeddings_similarity', $embeddings_similarity, $post_id, $embeddings, $link );
+
 		// Sort the results by similarity.
 		usort(
 			$embeddings_similarity,
@@ -572,6 +585,20 @@ class OllamaEmbeddings extends Ollama {
 		foreach ( $embeddings_similarity as $item ) {
 			$sorted_results[ $item['taxonomy'] ][] = $item;
 		}
+
+		/**
+		 * Fires after the embeddings similarity has been run and sorted.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_ollama_embeddings_post_sort_embeddings_similarity
+		 *
+		 * @param {array} $sorted_results The sorted embeddings similarity results.
+		 * @param {array} $embeddings_similarity The embeddings similarity results.
+		 * @param {int} $post_id ID of post to set terms on.
+		 * @param {array} $embeddings Embeddings data.
+		 * @param {bool} $link Whether to link the terms or not.
+		 */
+		do_action( 'classifai_ollama_embeddings_post_sort_embeddings_similarity', $sorted_results, $embeddings_similarity, $post_id, $embeddings, $link );
 
 		$return = [];
 

--- a/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
+++ b/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
@@ -781,7 +781,7 @@ class OllamaEmbeddings extends Ollama {
 						 * @param {string} $tax Taxonomy of term.
 						 * @param {bool} $consider_threshold Whether to consider the threshold or not.
 						 */
-						do_action( 'classifai_ollama_embeddings_single_embedding_similarity', $similarity, $embedding, $chunk, $term_id, $tax );
+						do_action( 'classifai_ollama_embeddings_single_embedding_similarity', $similarity, $embedding, $chunk, $term_id, $tax, $consider_threshold );
 
 						if ( false !== $similarity && ( ! $consider_threshold || $similarity <= $threshold ) ) {
 							$embedding_similarity[] = [

--- a/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
+++ b/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
@@ -768,6 +768,21 @@ class OllamaEmbeddings extends Ollama {
 					foreach ( $term_embedding as $chunk ) {
 						$similarity = $calculations->cosine_similarity( $embedding, $chunk );
 
+						/**
+						 * Fires after the embeddings similarity has been run for a single chunk.
+						 *
+						 * @since x.x.x
+						 * @hook classifai_ollama_embeddings_single_embedding_similarity
+						 *
+						 * @param {bool|float} $similarity The embeddings similarity result.
+						 * @param {array} $embedding Post embedding data.
+						 * @param {array} $chunk Term chunk embedding data.
+						 * @param {int} $term_id ID of term we're comparing.
+						 * @param {string} $tax Taxonomy of term.
+						 * @param {bool} $consider_threshold Whether to consider the threshold or not.
+						 */
+						do_action( 'classifai_ollama_embeddings_single_embedding_similarity', $similarity, $embedding, $chunk, $term_id, $tax );
+
 						if ( false !== $similarity && ( ! $consider_threshold || $similarity <= $threshold ) ) {
 							$embedding_similarity[] = [
 								'taxonomy'   => $tax,

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -824,7 +824,7 @@ class Embeddings extends Provider {
 						 * @param {string} $tax Taxonomy of term.
 						 * @param {bool} $consider_threshold Whether to consider the threshold or not.
 						 */
-						do_action( 'classifai_openai_embeddings_single_embedding_similarity', $similarity, $embedding, $chunk, $term_id, $tax );
+						do_action( 'classifai_openai_embeddings_single_embedding_similarity', $similarity, $embedding, $chunk, $term_id, $tax, $consider_threshold );
 
 						if ( false !== $similarity && ( ! $consider_threshold || $similarity <= $threshold ) ) {
 							$embedding_similarity[] = [

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -811,6 +811,21 @@ class Embeddings extends Provider {
 					foreach ( $term_embedding as $chunk ) {
 						$similarity = $calculations->cosine_similarity( $embedding, $chunk );
 
+						/**
+						 * Fires after the embeddings similarity has been run for a single chunk.
+						 *
+						 * @since x.x.x
+						 * @hook classifai_openai_embeddings_single_embedding_similarity
+						 *
+						 * @param {bool|float} $similarity The embeddings similarity result.
+						 * @param {array} $embedding Post embedding data.
+						 * @param {array} $chunk Term chunk embedding data.
+						 * @param {int} $term_id ID of term we're comparing.
+						 * @param {string} $tax Taxonomy of term.
+						 * @param {bool} $consider_threshold Whether to consider the threshold or not.
+						 */
+						do_action( 'classifai_openai_embeddings_single_embedding_similarity', $similarity, $embedding, $chunk, $term_id, $tax );
+
 						if ( false !== $similarity && ( ! $consider_threshold || $similarity <= $threshold ) ) {
 							$embedding_similarity[] = [
 								'taxonomy'   => $tax,

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -595,6 +595,19 @@ class Embeddings extends Provider {
 			return new WP_Error( 'invalid', esc_html__( 'No matching terms found.', 'classifai' ) );
 		}
 
+		/**
+		 * Fires after the embeddings similarity has been run but before results are sorted.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_openai_embeddings_pre_sort_embeddings_similarity
+		 *
+		 * @param {array} $embeddings_similarity The embeddings similarity results.
+		 * @param {int} $post_id ID of post to set terms on.
+		 * @param {array} $embeddings Embeddings data.
+		 * @param {bool} $link Whether to link the terms or not.
+		 */
+		do_action( 'classifai_openai_embeddings_pre_sort_embeddings_similarity', $embeddings_similarity, $post_id, $embeddings, $link );
+
 		// Sort the results by similarity.
 		usort(
 			$embeddings_similarity,
@@ -613,6 +626,20 @@ class Embeddings extends Provider {
 		foreach ( $embeddings_similarity as $item ) {
 			$sorted_results[ $item['taxonomy'] ][] = $item;
 		}
+
+		/**
+		 * Fires after the embeddings similarity has been run and sorted.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_openai_embeddings_post_sort_embeddings_similarity
+		 *
+		 * @param {array} $sorted_results The sorted embeddings similarity results.
+		 * @param {array} $embeddings_similarity The embeddings similarity results.
+		 * @param {int} $post_id ID of post to set terms on.
+		 * @param {array} $embeddings Embeddings data.
+		 * @param {bool} $link Whether to link the terms or not.
+		 */
+		do_action( 'classifai_openai_embeddings_post_sort_embeddings_similarity', $sorted_results, $embeddings_similarity, $post_id, $embeddings, $link );
 
 		$return = [];
 


### PR DESCRIPTION
### Description of the Change

When using an embedding model to run classification, we don't store the full similarity results and there's currently no easy way for someone to store that themselves if they want to use those results for something else.

This PR introduces a few new hooks allowing you to do just that:

- After embedding similarity has been run for an individual post embedding -> term chunk embedding, a new hook fires that allows you to do whatever you want with those results (like store them in post meta).
- After the full embedding similarity results are done, a new hooks fires that allows you to do whatever you want with those results
- And then another hook fires after we sort the results, allowing you to do whatever you want with those results

### How to test the Change

If desired, can add a custom plugin that uses one or more of these new hooks to ensure they work but mostly just need a code review here

### Changelog Entry

> Added - New hooks that allow extra processing of embedding similarity calculations

### Credits

Props @dkotter, @tylercherpak 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
