### PR TITLE
Fix Gutenberg deprecation warnings

### DIFF
--- a/src/js/features/classification/pre-publish-classify-post.js
+++ b/src/js/features/classification/pre-publish-classify-post.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginPrePublishPanel } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
 
 /**
@@ -45,6 +45,6 @@ class PrePubClassifyPost extends Component {
 
 export default withSelect( ( select ) => {
 	return {
-		isPublishPanelOpen: select( 'core/edit-post' ).isPublishSidebarOpened(),
+		isPublishPanelOpen: select( 'core/editor' ).isPublishSidebarOpened(),
 	};
 } )( PrePubClassifyPost );

--- a/src/js/features/excerpt-generation/index.js
+++ b/src/js/features/excerpt-generation/index.js
@@ -3,8 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { dispatch } from '@wordpress/data';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { PostExcerptCheck } from '@wordpress/editor';
+import {
+	PluginDocumentSettingPanel,
+	PostExcerptCheck,
+} from '@wordpress/editor';
 import { registerPlugin } from '@wordpress/plugins';
 
 /**
@@ -15,7 +17,7 @@ import MaybeExcerptPanel from './maybe-excerpt-panel';
 
 // Remove core Post Excerpt panel.
 ( () => {
-	dispatch( 'core/edit-post' ).removeEditorPanel( 'post-excerpt' );
+	dispatch( 'core/editor' ).removeEditorPanel( 'post-excerpt' );
 } )();
 
 // Add our own custom Post Excerpt panel.

--- a/src/js/features/excerpt-generation/maybe-excerpt-panel.js
+++ b/src/js/features/excerpt-generation/maybe-excerpt-panel.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginPrePublishPanel } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
 
 /**
@@ -65,6 +65,6 @@ class MaybeExcerptPanel extends Component {
 export default withSelect( ( select ) => {
 	return {
 		excerpt: select( 'core/editor' ).getEditedPostAttribute( 'excerpt' ),
-		isPublishPanelOpen: select( 'core/edit-post' ).isPublishSidebarOpened(),
+		isPublishPanelOpen: select( 'core/editor' ).isPublishSidebarOpened(),
 	};
 } )( MaybeExcerptPanel );

--- a/src/js/features/excerpt-generation/panel.js
+++ b/src/js/features/excerpt-generation/panel.js
@@ -31,9 +31,6 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 
 	const { select } = wp.data;
 	const postId = select( 'core/editor' ).getCurrentPostId();
-	const postContent =
-		select( 'core/editor' ).getEditedPostAttribute( 'content' );
-	const postTitle = select( 'core/editor' ).getEditedPostAttribute( 'title' );
 	const buttonText =
 		'' === excerpt
 			? __( 'Generate excerpt', 'classifai' )
@@ -41,6 +38,11 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	const isPublishPanelOpen = select( 'core/editor' ).isPublishSidebarOpened();
 
 	const buttonClick = async ( path ) => {
+		const postContent =
+			select( 'core/editor' ).getEditedPostAttribute( 'content' );
+		const postTitle =
+			select( 'core/editor' ).getEditedPostAttribute( 'title' );
+
 		setIsLoading( true );
 		apiFetch( {
 			path,

--- a/src/js/features/excerpt-generation/panel.js
+++ b/src/js/features/excerpt-generation/panel.js
@@ -38,8 +38,7 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 		'' === excerpt
 			? __( 'Generate excerpt', 'classifai' )
 			: __( 'Re-generate excerpt', 'classifai' );
-	const isPublishPanelOpen =
-		select( 'core/edit-post' ).isPublishSidebarOpened();
+	const isPublishPanelOpen = select( 'core/editor' ).isPublishSidebarOpened();
 
 	const buttonClick = async ( path ) => {
 		setIsLoading( true );

--- a/src/js/features/image-generation/inserter-media-category.js
+++ b/src/js/features/image-generation/inserter-media-category.js
@@ -10,8 +10,7 @@ import { addQueryArgs } from '@wordpress/url';
 const { classifaiDalleData } = window;
 
 const isInserterOpened = () =>
-	select( 'core/edit-post' )?.isInserterOpened() ||
-	select( 'core/edit-site' )?.isInserterOpened() ||
+	select( 'core/editor' )?.isInserterOpened() ||
 	select( 'core/edit-widgets' )?.isInserterOpened?.();
 
 const waitFor = async ( selector ) =>

--- a/src/js/features/slot-fill/index.js
+++ b/src/js/features/slot-fill/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { Icon, SlotFillProvider, Slot, Fill } from '@wordpress/components';
 import { PluginArea, registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';

--- a/src/js/features/title-generation/index.js
+++ b/src/js/features/title-generation/index.js
@@ -2,8 +2,7 @@
  * External Dependencies.
  */
 import { dispatch, select } from '@wordpress/data';
-import { PluginPostStatusInfo } from '@wordpress/edit-post';
-import { PostTypeSupportCheck } from '@wordpress/editor';
+import { PluginPostStatusInfo, PostTypeSupportCheck } from '@wordpress/editor';
 import {
 	Button,
 	Modal,

--- a/src/js/features/title-generation/index.js
+++ b/src/js/features/title-generation/index.js
@@ -8,7 +8,8 @@ import {
 	Modal,
 	Spinner,
 	TextareaControl,
-	BaseControl,
+	Flex,
+	FlexItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
@@ -94,50 +95,52 @@ const TitleGenerationPlugin = () => {
 		}
 
 		return (
-			<>
+			<Flex gap="5" wrap>
 				{ dataToRender.map( ( item, i ) => {
 					return (
-						<div className="classifai-title" key={ i }>
-							<BaseControl>
-								<TextareaControl
-									rows="5"
-									width="100%"
-									value={ item }
-									onChange={ ( e ) => {
-										dataToRender[ i ] = e.target.value;
-										setData( dataToRender );
-									} }
-								/>
-								<Button
-									variant="secondary"
-									onClick={ async () => {
-										const isDirty =
-											select(
-												'core/editor'
-											).isEditedPostDirty();
-										dispatch( 'core/editor' ).editPost( {
-											title: data[ i ],
-										} );
-										closeModal();
-										if ( ! isDirty ) {
-											await dispatch(
-												'core'
-											).saveEditedEntityRecord(
-												'postType',
-												postType,
-												postId
-											);
-										}
-									} }
-								>
-									{ __( 'Select', 'classifai' ) }
-								</Button>
-							</BaseControl>
-							<br />
-						</div>
+						<FlexItem
+							className="classifai-title"
+							key={ i }
+							style={ { flexGrow: 1 } }
+						>
+							<TextareaControl
+								rows="5"
+								label={ __( 'Generated title', 'classifai' ) }
+								hideLabelFromVision
+								value={ item }
+								onChange={ ( e ) => {
+									dataToRender[ i ] = e.target.value;
+									setData( dataToRender );
+								} }
+							/>
+							<Button
+								variant="secondary"
+								onClick={ async () => {
+									const isDirty =
+										select(
+											'core/editor'
+										).isEditedPostDirty();
+									dispatch( 'core/editor' ).editPost( {
+										title: data[ i ],
+									} );
+									closeModal();
+									if ( ! isDirty ) {
+										await dispatch(
+											'core'
+										).saveEditedEntityRecord(
+											'postType',
+											postType,
+											postId
+										);
+									}
+								} }
+							>
+								{ __( 'Select', 'classifai' ) }
+							</Button>
+						</FlexItem>
 					);
 				} ) }
-			</>
+			</Flex>
 		);
 	};
 
@@ -148,6 +151,7 @@ const TitleGenerationPlugin = () => {
 					title={ __( 'Select a title', 'classifai' ) }
 					onRequestClose={ closeModal }
 					isFullScreen={ false }
+					size="medium"
 					className="title-modal"
 				>
 					{ isLoading && <Spinner /> }

--- a/src/js/features/title-generation/index.js
+++ b/src/js/features/title-generation/index.js
@@ -52,13 +52,15 @@ const TitleGenerationPlugin = () => {
 
 	const postId = select( 'core/editor' ).getCurrentPostId();
 	const postType = select( 'core/editor' ).getCurrentPostType();
-	const postContent =
-		select( 'core/editor' ).getEditedPostAttribute( 'content' );
+
 	const openModal = () => setOpen( true );
 	const closeModal = () =>
 		setOpen( false ) && setData( [] ) && setError( false );
 
 	const buttonClick = async ( path ) => {
+		const postContent =
+			select( 'core/editor' ).getEditedPostAttribute( 'content' );
+
 		setIsLoading( true );
 		openModal();
 		apiFetch( {


### PR DESCRIPTION
### Description of the Change

As of the last release our minimum supported version of WordPress is 6.6. There were quite a few [deprecation warnings added](https://make.wordpress.org/core/2024/06/18/editor-unified-extensibility-apis-in-6-6/) in that version that we've previously been ignoring but we can now safely update those to the proper components to fix those.

In addition, while fixing those up and testing to ensure everything worked, found a few other things I thought worth fixing:

- In both our title generation and excerpt generation Features, we grab the content and/or title of the item to send along. But we grab this on page load so if someone were to update the content and then click the button, the most recent version of the content isn't used. This has been fixed
- Took some learnings from #859 to make the modal we show when generating titles a bit nicer. It's now wider and if generating multiple titles, those end up in columns instead of stacked

**Before**

![Generate title modal before changes](https://github.com/user-attachments/assets/601511e7-c702-4eac-87ad-d8824beaeff9)

**After**

![Generate title modal after changes](https://github.com/user-attachments/assets/b8d703c9-8e13-4f70-9b44-77ca7d97ecd2)

### How to test the Change

Minimal changes made across multiple Features so ideal is to test to ensure those Features still work and no WordPress 6.5 or 6.6 deprecation warnings are shown. Note there are some deprecation notices introduced in 6.7 around bottom margin styles being deprecated since version 6.7 and will be removed in version 7.0 but decided not to address those yet

### Changelog Entry

> Changed - Update the layout of the generate titles modal
> Fixed - Fix various Gutenberg deprecation notices added in WordPress 6.5 and 6.6
> Fixed - Ensure we pass the most recent version of the content in our title and excerpt generation Features

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
