### PR TITLE
Add ability to only allow manual processing of our various image Features

### DIFF
--- a/includes/Classifai/Features/DescriptiveTextGenerator.php
+++ b/includes/Classifai/Features/DescriptiveTextGenerator.php
@@ -390,6 +390,7 @@ class DescriptiveTextGenerator extends Feature {
 				'caption'     => 0,
 				'description' => 0,
 			],
+			'processing_mode'         => 'automatic',
 			'provider'                => ComputerVision::ID,
 		];
 	}
@@ -444,6 +445,8 @@ class DescriptiveTextGenerator extends Feature {
 		$settings = $this->get_settings();
 
 		$new_settings['descriptive_text_fields'] = array_map( 'sanitize_text_field', $new_settings['descriptive_text_fields'] ?? $settings['descriptive_text_fields'] );
+
+		$new_settings['processing_mode'] = sanitize_text_field( $new_settings['processing_mode'] ?? $settings['processing_mode'] );
 
 		return $new_settings;
 	}

--- a/includes/Classifai/Features/DescriptiveTextGenerator.php
+++ b/includes/Classifai/Features/DescriptiveTextGenerator.php
@@ -150,7 +150,10 @@ class DescriptiveTextGenerator extends Feature {
 	 * @return array
 	 */
 	public function generate_image_alt_tags( array $metadata, int $attachment_id ): array {
-		if ( ! $this->is_feature_enabled() ) {
+		if (
+			! $this->is_feature_enabled() ||
+			'automatic' !== $this->get_processing_mode()
+		) {
 			return $metadata;
 		}
 
@@ -341,6 +344,18 @@ class DescriptiveTextGenerator extends Feature {
 		}
 
 		return $enabled_fields;
+	}
+
+	/**
+	 * Return the processing mode for the feature.
+	 *
+	 * @return string
+	 */
+	public function get_processing_mode(): string {
+		$settings = $this->get_settings();
+		$value    = $settings['processing_mode'] ?? 'automatic';
+
+		return $value;
 	}
 
 	/**

--- a/includes/Classifai/Features/ImageCropping.php
+++ b/includes/Classifai/Features/ImageCropping.php
@@ -147,7 +147,10 @@ class ImageCropping extends Feature {
 	 * @return array
 	 */
 	public function generate_smart_crops( array $metadata, int $attachment_id ): array {
-		if ( ! $this->is_feature_enabled() ) {
+		if (
+			! $this->is_feature_enabled() ||
+			'automatic' !== $this->get_processing_mode()
+		) {
 			return $metadata;
 		}
 
@@ -347,8 +350,23 @@ class ImageCropping extends Feature {
 	 */
 	public function get_feature_default_settings(): array {
 		return [
-			'provider' => ComputerVision::ID,
+			'processing_mode' => 'automatic',
+			'provider'        => ComputerVision::ID,
 		];
+	}
+
+	/**
+	 * Sanitizes the default feature settings.
+	 *
+	 * @param array $new_settings Settings being saved.
+	 * @return array
+	 */
+	public function sanitize_default_feature_settings( array $new_settings ): array {
+		$settings = $this->get_settings();
+
+		$new_settings['processing_mode'] = sanitize_text_field( $new_settings['processing_mode'] ?? $settings['processing_mode'] );
+
+		return $new_settings;
 	}
 
 	/**
@@ -378,6 +396,18 @@ class ImageCropping extends Feature {
 		 * @return {WP_Filesystem_Base} Filtered Filesystem class.
 		 */
 		return apply_filters( 'classifai_smart_crop_wp_filesystem', $this->wp_filesystem );
+	}
+
+	/**
+	 * Return the processing mode for the feature.
+	 *
+	 * @return string
+	 */
+	public function get_processing_mode(): string {
+		$settings = $this->get_settings();
+		$value    = $settings['processing_mode'] ?? 'automatic';
+
+		return $value;
 	}
 
 	/**

--- a/includes/Classifai/Features/ImageTagsGenerator.php
+++ b/includes/Classifai/Features/ImageTagsGenerator.php
@@ -198,7 +198,10 @@ EOD;
 	 * @return array
 	 */
 	public function generate_image_tags( array $metadata, int $attachment_id ): array {
-		if ( ! $this->is_feature_enabled() ) {
+		if (
+			! $this->is_feature_enabled() ||
+			'automatic' !== $this->get_processing_mode()
+		) {
 			return $metadata;
 		}
 
@@ -385,8 +388,9 @@ EOD;
 		}
 
 		return [
-			'tag_taxonomy' => array_key_first( $options ),
-			'provider'     => ComputerVision::ID,
+			'tag_taxonomy'    => array_key_first( $options ),
+			'processing_mode' => 'automatic',
+			'provider'        => ComputerVision::ID,
 		];
 	}
 
@@ -400,6 +404,8 @@ EOD;
 		$settings = $this->get_settings();
 
 		$new_settings['tag_taxonomy'] = $new_settings['tag_taxonomy'] ?? $settings['tag_taxonomy'];
+
+		$new_settings['processing_mode'] = sanitize_text_field( $new_settings['processing_mode'] ?? $settings['processing_mode'] );
 
 		return $new_settings;
 	}
@@ -430,6 +436,18 @@ EOD;
 		 * @return {array} Array of taxonomies.
 		 */
 		return apply_filters( 'classifai_' . static::ID . '_setting_taxonomies', $taxonomies, $this );
+	}
+
+	/**
+	 * Return the processing mode for the feature.
+	 *
+	 * @return string
+	 */
+	public function get_processing_mode(): string {
+		$settings = $this->get_settings();
+		$value    = $settings['processing_mode'] ?? 'automatic';
+
+		return $value;
 	}
 
 	/**

--- a/includes/Classifai/Features/ImageTextExtraction.php
+++ b/includes/Classifai/Features/ImageTextExtraction.php
@@ -184,7 +184,10 @@ class ImageTextExtraction extends Feature {
 	 * @return array
 	 */
 	public function generate_ocr_text( array $metadata, int $attachment_id ): array {
-		if ( ! $this->is_feature_enabled() ) {
+		if (
+			! $this->is_feature_enabled() ||
+			'automatic' !== $this->get_processing_mode()
+		) {
 			return $metadata;
 		}
 
@@ -446,8 +449,35 @@ class ImageTextExtraction extends Feature {
 	 */
 	public function get_feature_default_settings(): array {
 		return [
-			'provider' => ComputerVision::ID,
+			'processing_mode' => 'automatic',
+			'provider'        => ComputerVision::ID,
 		];
+	}
+
+	/**
+	 * Sanitizes the default feature settings.
+	 *
+	 * @param array $new_settings Settings being saved.
+	 * @return array
+	 */
+	public function sanitize_default_feature_settings( array $new_settings ): array {
+		$settings = $this->get_settings();
+
+		$new_settings['processing_mode'] = sanitize_text_field( $new_settings['processing_mode'] ?? $settings['processing_mode'] );
+
+		return $new_settings;
+	}
+
+	/**
+	 * Return the processing mode for the feature.
+	 *
+	 * @return string
+	 */
+	public function get_processing_mode(): string {
+		$settings = $this->get_settings();
+		$value    = $settings['processing_mode'] ?? 'automatic';
+
+		return $value;
 	}
 
 	/**

--- a/includes/Classifai/Features/PDFTextExtraction.php
+++ b/includes/Classifai/Features/PDFTextExtraction.php
@@ -190,6 +190,13 @@ class PDFTextExtraction extends Feature {
 	 * @param int $attachment_id Attachment ID.
 	 */
 	public function read_pdf( int $attachment_id ) {
+		if (
+			! $this->is_feature_enabled() ||
+			'automatic' !== $this->get_processing_mode()
+		) {
+			return;
+		}
+
 		$this->run( $attachment_id, 'read_pdf' );
 	}
 
@@ -269,8 +276,35 @@ class PDFTextExtraction extends Feature {
 	 */
 	public function get_feature_default_settings(): array {
 		return [
-			'provider' => ComputerVision::ID,
+			'processing_mode' => 'automatic',
+			'provider'        => ComputerVision::ID,
 		];
+	}
+
+	/**
+	 * Sanitizes the default feature settings.
+	 *
+	 * @param array $new_settings Settings being saved.
+	 * @return array
+	 */
+	public function sanitize_default_feature_settings( array $new_settings ): array {
+		$settings = $this->get_settings();
+
+		$new_settings['processing_mode'] = sanitize_text_field( $new_settings['processing_mode'] ?? $settings['processing_mode'] );
+
+		return $new_settings;
+	}
+
+	/**
+	 * Return the processing mode for the feature.
+	 *
+	 * @return string
+	 */
+	public function get_processing_mode(): string {
+		$settings = $this->get_settings();
+		$value    = $settings['processing_mode'] ?? 'automatic';
+
+		return $value;
 	}
 
 	/**

--- a/src/js/settings/components/feature-additional-settings/descriptive-text-generator.js
+++ b/src/js/settings/components/feature-additional-settings/descriptive-text-generator.js
@@ -3,7 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl, RadioControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -13,9 +13,7 @@ import { SettingsRow } from '../settings-row';
 import { STORE_NAME } from '../../data/store';
 
 /**
- * Component for Descriptive Text Generator feature settings.
- *
- * This component is used within the FeatureSettings component to allow users to configure the Descriptive Text Generator feature.
+ * Component for the Descriptive Text Generator Feature settings.
  *
  * @return {React.ReactElement} DescriptiveTextGeneratorSettings component.
  */
@@ -30,38 +28,68 @@ export const DescriptiveTextGeneratorSettings = () => {
 		caption: __( 'Image caption', 'classifai' ),
 		description: __( 'Image description', 'classifai' ),
 	};
+
 	return (
-		<SettingsRow
-			label={ __( 'Descriptive text fields', 'classifai' ) }
-			description={ __(
-				'Choose image fields where the generated text should be applied.',
-				'classifai'
-			) }
-			className="classifai-descriptive-text-fields"
-		>
-			{ Object.keys( options ).map( ( option ) => {
-				return (
-					<CheckboxControl
-						id={ option }
-						key={ option }
-						checked={
-							featureSettings.descriptive_text_fields?.[
-								option
-							] === option
-						}
-						label={ options[ option ] }
-						onChange={ ( value ) => {
-							setFeatureSettings( {
-								descriptive_text_fields: {
-									...featureSettings.descriptive_text_fields,
-									[ option ]: value ? option : '0',
-								},
-							} );
-						} }
-						__nextHasNoMarginBottom
-					/>
-				);
-			} ) }
-		</SettingsRow>
+		<>
+			<SettingsRow
+				label={ __( 'Descriptive text fields', 'classifai' ) }
+				description={ __(
+					'Choose image fields where the generated text should be applied.',
+					'classifai'
+				) }
+				className="classifai-descriptive-text-fields"
+			>
+				{ Object.keys( options ).map( ( option ) => {
+					return (
+						<CheckboxControl
+							id={ option }
+							key={ option }
+							checked={
+								featureSettings.descriptive_text_fields?.[
+									option
+								] === option
+							}
+							label={ options[ option ] }
+							onChange={ ( value ) => {
+								setFeatureSettings( {
+									descriptive_text_fields: {
+										...featureSettings.descriptive_text_fields,
+										[ option ]: value ? option : '0',
+									},
+								} );
+							} }
+							__nextHasNoMarginBottom
+						/>
+					);
+				} ) }
+			</SettingsRow>
+			<SettingsRow
+				label={ __( 'Processing mode', 'classifai' ) }
+				description={ __(
+					'Choose how you want images to be processed. These can be processed automatically when each image is uploaded or can instead be triggered manually on each desired image. Note if set to automatic, you can still trigger the processing manually on individual images.',
+					'classifai'
+				) }
+			>
+				<RadioControl
+					className="processing-mode-radio-control"
+					onChange={ ( value ) => {
+						setFeatureSettings( {
+							processing_mode: value,
+						} );
+					} }
+					options={ [
+						{
+							label: __( 'Automatically on upload', 'classifai' ),
+							value: 'automatic',
+						},
+						{
+							label: __( 'Manually trigger', 'classifai' ),
+							value: 'manual',
+						},
+					] }
+					selected={ featureSettings.processing_mode }
+				/>
+			</SettingsRow>
+		</>
 	);
 };

--- a/src/js/settings/components/feature-additional-settings/image-cropping.js
+++ b/src/js/settings/components/feature-additional-settings/image-cropping.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+import { CheckboxControl, RadioControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { SettingsRow } from '../settings-row';
+import { STORE_NAME } from '../../data/store';
+
+/**
+ * Component for the Image Cropping Feature settings.
+ *
+ * @return {React.ReactElement} ImageCroppingSettings component.
+ */
+export const ImageCroppingSettings = () => {
+	const featureSettings = useSelect( ( select ) =>
+		select( STORE_NAME ).getFeatureSettings()
+	);
+	const { setFeatureSettings } = useDispatch( STORE_NAME );
+
+	return (
+		<SettingsRow
+			label={ __( 'Processing mode', 'classifai' ) }
+			description={ __(
+				'Choose how you want images to be processed. These can be processed automatically when each image is uploaded or can instead be triggered manually on each desired image. Note if set to automatic, you can still trigger the processing manually on individual images.',
+				'classifai'
+			) }
+		>
+			<RadioControl
+				className="processing-mode-radio-control"
+				onChange={ ( value ) => {
+					setFeatureSettings( {
+						processing_mode: value,
+					} );
+				} }
+				options={ [
+					{
+						label: __( 'Automatically on upload', 'classifai' ),
+						value: 'automatic',
+					},
+					{
+						label: __( 'Manually trigger', 'classifai' ),
+						value: 'manual',
+					},
+				] }
+				selected={ featureSettings.processing_mode }
+			/>
+		</SettingsRow>
+	);
+};

--- a/src/js/settings/components/feature-additional-settings/image-tag-generator.js
+++ b/src/js/settings/components/feature-additional-settings/image-tag-generator.js
@@ -3,7 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-import { SelectControl } from '@wordpress/components';
+import { SelectControl, RadioControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -36,18 +36,49 @@ export const ImageTagGeneratorSettings = () => {
 		};
 	} );
 	return (
-		<SettingsRow label={ __( 'Tag taxonomy', 'classifai' ) }>
-			<SelectControl
-				id="feature_image_tags_generator_tag_taxonomy"
-				onChange={ ( value ) => {
-					setFeatureSettings( {
-						tag_taxonomy: value,
-					} );
-				} }
-				value={ featureSettings.tag_taxonomy || 'classifai-image-tags' }
-				options={ options }
-				__nextHasNoMarginBottom
-			/>
-		</SettingsRow>
+		<>
+			<SettingsRow label={ __( 'Tag taxonomy', 'classifai' ) }>
+				<SelectControl
+					id="feature_image_tags_generator_tag_taxonomy"
+					onChange={ ( value ) => {
+						setFeatureSettings( {
+							tag_taxonomy: value,
+						} );
+					} }
+					value={
+						featureSettings.tag_taxonomy || 'classifai-image-tags'
+					}
+					options={ options }
+					__nextHasNoMarginBottom
+				/>
+			</SettingsRow>
+			<SettingsRow
+				label={ __( 'Processing mode', 'classifai' ) }
+				description={ __(
+					'Choose how you want images to be processed. These can be processed automatically when each image is uploaded or can instead be triggered manually on each desired image. Note if set to automatic, you can still trigger the processing manually on individual images.',
+					'classifai'
+				) }
+			>
+				<RadioControl
+					className="processing-mode-radio-control"
+					onChange={ ( value ) => {
+						setFeatureSettings( {
+							processing_mode: value,
+						} );
+					} }
+					options={ [
+						{
+							label: __( 'Automatically on upload', 'classifai' ),
+							value: 'automatic',
+						},
+						{
+							label: __( 'Manually trigger', 'classifai' ),
+							value: 'manual',
+						},
+					] }
+					selected={ featureSettings.processing_mode }
+				/>
+			</SettingsRow>
+		</>
 	);
 };

--- a/src/js/settings/components/feature-additional-settings/image-to-text-generator.js
+++ b/src/js/settings/components/feature-additional-settings/image-to-text-generator.js
@@ -13,11 +13,11 @@ import { SettingsRow } from '../settings-row';
 import { STORE_NAME } from '../../data/store';
 
 /**
- * Component for the Image Cropping Feature settings.
+ * Component for the Image To Text Generator (OCR) settings.
  *
  * @return {React.ReactElement} ImageCroppingSettings component.
  */
-export const ImageCroppingSettings = () => {
+export const ImageToTextGeneratorSettings = () => {
 	const featureSettings = useSelect( ( select ) =>
 		select( STORE_NAME ).getFeatureSettings()
 	);

--- a/src/js/settings/components/feature-additional-settings/index.js
+++ b/src/js/settings/components/feature-additional-settings/index.js
@@ -12,6 +12,7 @@ import { useFeatureContext } from '../feature-settings/context';
 import { DescriptiveTextGeneratorSettings } from './descriptive-text-generator';
 import { ImageTagGeneratorSettings } from './image-tag-generator';
 import { ImageCroppingSettings } from './image-cropping';
+import { ImageToTextGeneratorSettings } from './image-to-text-generator';
 import { TextToSpeechSettings } from './text-to-speech';
 import { TitleGenerationSettings } from './title-generation';
 import { ContentResizingSettings } from './content-resizing';
@@ -55,6 +56,9 @@ const AdditionalSettingsFields = () => {
 
 		case 'feature_image_tags_generator':
 			return <ImageTagGeneratorSettings />;
+
+		case 'feature_image_to_text_generator':
+			return <ImageToTextGeneratorSettings />;
 
 		case 'feature_image_cropping':
 			return <ImageCroppingSettings />;

--- a/src/js/settings/components/feature-additional-settings/index.js
+++ b/src/js/settings/components/feature-additional-settings/index.js
@@ -13,6 +13,7 @@ import { DescriptiveTextGeneratorSettings } from './descriptive-text-generator';
 import { ImageTagGeneratorSettings } from './image-tag-generator';
 import { ImageCroppingSettings } from './image-cropping';
 import { ImageToTextGeneratorSettings } from './image-to-text-generator';
+import { PDFToTextGenerationSettings } from './pdf-to-text-generation';
 import { TextToSpeechSettings } from './text-to-speech';
 import { TitleGenerationSettings } from './title-generation';
 import { ContentResizingSettings } from './content-resizing';
@@ -62,6 +63,9 @@ const AdditionalSettingsFields = () => {
 
 		case 'feature_image_cropping':
 			return <ImageCroppingSettings />;
+
+		case 'feature_pdf_to_text_generation':
+			return <PDFToTextGenerationSettings />;
 
 		case 'feature_text_to_speech_generation':
 			return <TextToSpeechSettings />;

--- a/src/js/settings/components/feature-additional-settings/index.js
+++ b/src/js/settings/components/feature-additional-settings/index.js
@@ -11,6 +11,7 @@ import { getScope } from '../../utils/utils';
 import { useFeatureContext } from '../feature-settings/context';
 import { DescriptiveTextGeneratorSettings } from './descriptive-text-generator';
 import { ImageTagGeneratorSettings } from './image-tag-generator';
+import { ImageCroppingSettings } from './image-cropping';
 import { TextToSpeechSettings } from './text-to-speech';
 import { TitleGenerationSettings } from './title-generation';
 import { ContentResizingSettings } from './content-resizing';
@@ -54,6 +55,9 @@ const AdditionalSettingsFields = () => {
 
 		case 'feature_image_tags_generator':
 			return <ImageTagGeneratorSettings />;
+
+		case 'feature_image_cropping':
+			return <ImageCroppingSettings />;
 
 		case 'feature_text_to_speech_generation':
 			return <TextToSpeechSettings />;

--- a/src/js/settings/components/feature-additional-settings/pdf-to-text-generation.js
+++ b/src/js/settings/components/feature-additional-settings/pdf-to-text-generation.js
@@ -13,11 +13,11 @@ import { SettingsRow } from '../settings-row';
 import { STORE_NAME } from '../../data/store';
 
 /**
- * Component for the Image To Text Generator (OCR) settings.
+ * Component for the PDF To Text Generation settings.
  *
- * @return {React.ReactElement} ImageToTextGeneratorSettings component.
+ * @return {React.ReactElement} PDFToTextGenerationSettings component.
  */
-export const ImageToTextGeneratorSettings = () => {
+export const PDFToTextGenerationSettings = () => {
 	const featureSettings = useSelect( ( select ) =>
 		select( STORE_NAME ).getFeatureSettings()
 	);
@@ -27,7 +27,7 @@ export const ImageToTextGeneratorSettings = () => {
 		<SettingsRow
 			label={ __( 'Processing mode', 'classifai' ) }
 			description={ __(
-				'Choose how you want images to be processed. These can be processed automatically when each image is uploaded or can instead be triggered manually on each desired image. Note if set to automatic, you can still trigger the processing manually on individual images.',
+				'Choose how you want PDFs to be processed. These can be processed automatically when each PDF is uploaded or can instead be triggered manually on each desired PDF. Note if set to automatic, you can still trigger the processing manually on individual PDFs.',
 				'classifai'
 			) }
 		>

--- a/tests/cypress/integration/image-processing/image-processing-microsoft-azure.test.js
+++ b/tests/cypress/integration/image-processing/image-processing-microsoft-azure.test.js
@@ -145,11 +145,12 @@ describe( 'Image processing Tests', () => {
 		).check();
 		cy.saveFeatureSettings();
 
+		cy.wait( 1000 );
 		cy.visit( '/wp-admin/upload.php?mode=grid' ); // Ensure grid mode is enabled.
 		cy.visit( '/wp-admin/media-new.php' );
 		cy.get( '#plupload-upload-ui' ).should( 'exist' );
 		cy.get( '#plupload-upload-ui input[type=file]' ).attachFile(
-			'../../../assets/img/banner-772x250.png'
+			'../../../assets/img/onboarding-1.png'
 		);
 
 		cy.get( '#media-items .media-item a.edit-attachment', {

--- a/tests/cypress/integration/image-processing/image-processing-microsoft-azure.test.js
+++ b/tests/cypress/integration/image-processing/image-processing-microsoft-azure.test.js
@@ -109,6 +109,83 @@ describe( 'Image processing Tests', () => {
 		cy.get( '#classifai-rescan-smart-crop' ).should( 'exist' );
 	} );
 
+	it( 'Can turn on manual mode and image uploads will not be processed', () => {
+		// Turn on manual processing mode.
+		cy.visitFeatureSettings(
+			'image_processing/feature_descriptive_text_generator'
+		);
+		cy.wait( 1000 );
+		cy.get(
+			'.processing-mode-radio-control input[value="manual"]'
+		).check();
+		cy.saveFeatureSettings();
+
+		cy.visitFeatureSettings(
+			'image_processing/feature_image_tags_generator'
+		);
+		cy.wait( 1000 );
+		cy.get(
+			'.processing-mode-radio-control input[value="manual"]'
+		).check();
+		cy.saveFeatureSettings();
+
+		cy.visitFeatureSettings( 'image_processing/feature_image_cropping' );
+		cy.wait( 1000 );
+		cy.get(
+			'.processing-mode-radio-control input[value="manual"]'
+		).check();
+		cy.saveFeatureSettings();
+
+		cy.visitFeatureSettings(
+			'image_processing/feature_image_to_text_generator'
+		);
+		cy.wait( 1000 );
+		cy.get(
+			'.processing-mode-radio-control input[value="manual"]'
+		).check();
+		cy.saveFeatureSettings();
+
+		cy.visit( '/wp-admin/upload.php?mode=grid' ); // Ensure grid mode is enabled.
+		cy.visit( '/wp-admin/media-new.php' );
+		cy.get( '#plupload-upload-ui' ).should( 'exist' );
+		cy.get( '#plupload-upload-ui input[type=file]' ).attachFile(
+			'../../../assets/img/banner-772x250.png'
+		);
+
+		cy.get( '#media-items .media-item a.edit-attachment', {
+			timeout: 20000,
+		} ).should( 'exist' );
+		cy.get( '#media-items .media-item a.edit-attachment' )
+			.invoke( 'attr', 'href' )
+			.then( ( editLink ) => {
+				cy.visit( editLink );
+			} );
+
+		// Verify Metabox with Image processing actions.
+		cy.get( '.postbox-header h2, #classifai_image_processing h2' )
+			.first()
+			.contains( 'ClassifAI Image Processing' );
+		cy.get(
+			'#classifai_image_processing label[for=rescan-captions]'
+		).contains( 'Generate descriptive text' );
+		cy.get( '#classifai_image_processing label[for=rescan-tags]' ).contains(
+			'Generate image tags'
+		);
+		cy.get( '#classifai_image_processing label[for=rescan-ocr]' ).contains(
+			'Scan image for text'
+		);
+		cy.get(
+			'#classifai_image_processing label[for=rescan-smart-crop]'
+		).contains( 'Regenerate smart thumbnail' );
+
+		// Verify generated Data.
+		cy.get( '#attachment_alt' ).should( 'have.value', '' );
+		cy.get( '#attachment_content' ).should( 'have.value', '' );
+		cy.get( '#classifai-image-tags ul.tagchecklist li' ).should(
+			'not.exist'
+		);
+	} );
+
 	it( 'Can disable Azure AI Vision Image processing features', () => {
 		const options = {
 			imageEditLink,

--- a/tests/cypress/integration/image-processing/image-processing-openai-chatgpt.test.js
+++ b/tests/cypress/integration/image-processing/image-processing-openai-chatgpt.test.js
@@ -19,6 +19,9 @@ import { getChatGPTData } from '../../plugins/functions';
 				cy.enableFeature();
 				cy.selectProvider( provider );
 				cy.get( `#${ provider }_api_key` ).clear().type( 'password' );
+				cy.get(
+					'.processing-mode-radio-control input[value="automatic"]'
+				).check();
 				cy.allowFeatureToAdmin();
 				cy.get(
 					'.classifai-settings__user-based-opt-out input'
@@ -264,6 +267,9 @@ describe( `OpenAI ChatGPT Image Tag and Text Generator Tests`, () => {
 			cy.enableFeature();
 			cy.selectProvider( 'openai_chatgpt' );
 			cy.get( '#openai_chatgpt_api_key' ).clear().type( 'password' );
+			cy.get(
+				'.processing-mode-radio-control input[value="automatic"]'
+			).check();
 			cy.allowFeatureToAdmin();
 			cy.get( '.classifai-settings__user-based-opt-out input' ).uncheck();
 


### PR DESCRIPTION
### Description of the Change

Right now most of our Image Processing Features automatically trigger when an image (or PDF) is uploaded. While this can be nice as it means things just magically happen without any extra effort, it does mean every single upload goes through this flow.

There's very likely a scenario where someone doesn't want an image to be processed. Also, because of the extra processing that happens (sending this image off to AI and waiting for the response), it makes the upload process slower. I could see a situation where someone wants uploads to be as fast as possible but still allow images to be manually processed after the fact (**side note**, there is a potential feature change we could look at where we change our image processing to fire after the image has been fully uploaded instead of blocking that process).

Similar to how we introduced a mode toggle in our Classification Feature, this PR adds in a new `Processing mode` setting to each of our `Image Processing` Features that have extra processing (all but `Image Generation`). This will default to `Automatically on upload` (which is the current behavior) but can be changed to `Manually trigger`, which won't process at all unless someone requests it at the individual media level.

Worth noting that you can still trigger things manually even if the mode is set to automatic.

### Screenshots

<img width="1286" alt="New Processing mode setting" src="https://github.com/user-attachments/assets/bc51ff2c-4294-4b39-96a8-a088992c789a" />

### How to test the Change

1. Check out this PR
2. Go to the `Descriptive Text Generator`, `Image Tags Generator`, `Image Cropping`, `Image Text Extraction` or `PDF Text Extraction` Features
3. Ensure the `Processing mode` settings shows for each and is defaulted to `Automatically on upload`
4. Test each Feature to ensure it still works as expected
5. Change the setting to be `Manually trigger` and test again, ensuring no processing happens until it's triggered on an individual media item

### Changelog Entry

> Added - New Processing Mode setting to our Image Processing Features, allowing you to only have those Features trigger when someone manually requests it, rather than automatically on upload

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
