### PR TITLE
Ensure the Settings button isn't disabled if the Feature is turned off

### DIFF
--- a/src/js/settings/components/service-settings/index.js
+++ b/src/js/settings/components/service-settings/index.js
@@ -211,16 +211,7 @@ export const ServiceSettings = () => {
 							</FlexBlock>
 							<FlexItem>
 								<NavLink to={ feature } key={ feature }>
-									<Button
-										variant="secondary"
-										disabled={
-											'1' !==
-											getFeatureSettings(
-												'status',
-												feature
-											)
-										}
-									>
+									<Button variant="secondary">
 										{ __( 'Settings', 'classifai' ) }
 									</Button>
 								</NavLink>

--- a/tests/cypress/integration/admin.test.js
+++ b/tests/cypress/integration/admin.test.js
@@ -1,4 +1,9 @@
 describe( 'Admin can login and make sure plugin is activated', () => {
+	before( () => {
+		cy.login();
+		cy.disableElasticPress();
+	} );
+
 	beforeEach( () => {
 		cy.login();
 	} );


### PR DESCRIPTION
### Description of the Change

With the settings refactor done in #824, we only allowed someone to click in and change settings if the Feature was first turned on. While I can understand this decision, there really isn't any reason why we need to prevent that. There's definitely valid reasons why someone would want to configure a Feature without having to turn the Feature on first.

### How to test the Change

1. Ensure the `Settings` button is enabled even if the Feature is off
2. Ensure clicking that button works as expected
3. Ensure turning on a Feature doesn't cause any problems with that button

### Changelog Entry

> Changed - Don't disable the Settings button if the Feature is turned off

### Credits

Props @dkotter, @fabiankaegy 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
