### PR TITLE
Updates to admin notices

### DIFF
--- a/.github/blueprints/blueprint.json
+++ b/.github/blueprints/blueprint.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://playground.wordpress.net/blueprint-schema.json",
-  "landingPage": "/wp-admin/tools.php?page=classifai#/language_processing?welcome_guide=1",
+  "landingPage": "/wp-admin/tools.php?welcome_guide=1&page=classifai#/language_processing",
   "preferredVersions": {
     "php": "7.4",
     "wp": "latest"

--- a/includes/Classifai/Admin/Notifications.php
+++ b/includes/Classifai/Admin/Notifications.php
@@ -55,9 +55,10 @@ class Notifications {
 	public function render_registration_notice() {
 		$registration_settings = get_option( 'classifai_settings' );
 		$page                  = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$welcome_guide         = isset( $_GET['welcome_guide'] ) ? sanitize_text_field( wp_unslash( $_GET['welcome_guide'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if (
-			'classifai' === $page &&
+			'classifai' === $page && '1' !== $welcome_guide &&
 			( ! isset( $registration_settings['valid_license'] ) || ! $registration_settings['valid_license'] )
 		) {
 			$notice_url = 'https://classifaiplugin.com/#cta';

--- a/includes/Classifai/Admin/Notifications.php
+++ b/includes/Classifai/Admin/Notifications.php
@@ -61,12 +61,13 @@ class Notifications {
 			( ! isset( $registration_settings['valid_license'] ) || ! $registration_settings['valid_license'] )
 		) {
 			$notice_url = 'https://classifaiplugin.com/#cta';
-
 			?>
+
 			<div data-notice="auto-upgrade-disabled" class="notice notice-warning">
-				<?php /* translators: %s: ClassifAI settings url */ ?>
-				<p><?php echo wp_kses_post( sprintf( __( '<a href="%s">Register ClassifAI</a> to receive important plugin updates and other ClassifAI news.', 'classifai' ), esc_url( $notice_url ) ) ); ?></p>
+				<?php /* translators: %s: ClassifAI registration URL */ ?>
+				<p><?php echo wp_kses_post( sprintf( __( '<a href="%s" target="_blank" rel="noopener noreferrer">Register ClassifAI</a> to enable automatic plugin updates and receive important ClassifAI news.', 'classifai' ), esc_url( $notice_url ) ) ); ?></p>
 			</div>
+
 			<?php
 		}
 	}

--- a/includes/Classifai/Admin/Notifications.php
+++ b/includes/Classifai/Admin/Notifications.php
@@ -88,7 +88,7 @@ class Notifications {
 			return;
 		}
 
-		$setup_url = admin_url( 'tools.php?page=classifai#/language_processing?welcome_guide=1' );
+		$setup_url = admin_url( 'tools.php?welcome_guide=1&page=classifai#/language_processing' );
 		if ( should_use_legacy_settings_panel() ) {
 			$setup_url = admin_url( 'admin.php?page=classifai_setup' );
 		}

--- a/includes/Classifai/Plugin.php
+++ b/includes/Classifai/Plugin.php
@@ -226,7 +226,7 @@ class Plugin {
 			return $links;
 		}
 
-		$setup_url = admin_url( 'tools.php?page=classifai#/language_processing?welcome_guide=1' );
+		$setup_url = admin_url( 'tools.php?welcome_guide=1&page=classifai#/language_processing' );
 		if ( should_use_legacy_settings_panel() ) {
 			$setup_url = admin_url( 'admin.php?page=classifai_setup' );
 		}

--- a/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
+++ b/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
@@ -315,6 +315,9 @@ class OllamaEmbeddings extends Ollama {
 			}
 		}
 
+		// Hide the update notice. This ensures we don't show this for new users.
+		update_option( 'classifai_hide_embeddings_notice', true, false );
+
 		return $new_settings;
 	}
 

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -341,6 +341,9 @@ class Embeddings extends Provider {
 			}
 		}
 
+		// Hide the update notice. This ensures we don't show this for new users.
+		update_option( 'classifai_hide_embeddings_notice', true, false );
+
 		return $new_settings;
 	}
 

--- a/src/js/settings/components/classifai-registration/index.js
+++ b/src/js/settings/components/classifai-registration/index.js
@@ -92,7 +92,7 @@ export const ClassifAIRegistrationForm = ( { onSaveSuccess = () => {} } ) => {
 		<>
 			<Notices feature="registration" />
 			<Panel
-				header={ __( 'Classifai Registration Settings', 'classifai' ) }
+				header={ __( 'Registration Details', 'classifai' ) }
 				className="settings-panel"
 			>
 				<PanelBody>
@@ -114,7 +114,7 @@ export const ClassifAIRegistrationForm = ( { onSaveSuccess = () => {} } ) => {
 								{
 									// eslint-disable-next-line @wordpress/i18n-translator-comments
 									__(
-										'Registration is 100% free and provides update notifications and upgrades inside the dashboard.',
+										'Registration is 100% free and provides automatic update notifications and upgrades inside the dashboard.',
 										'classifai'
 									)
 								}{ ' ' }

--- a/src/js/settings/components/classifai-settings/index.js
+++ b/src/js/settings/components/classifai-settings/index.js
@@ -79,7 +79,7 @@ const ServiceSettingsWrapper = () => {
  * @return {React.ReactElement} The ServiceNavigation component.
  */
 export const ServiceNavigation = () => {
-	const location = useLocation();
+	const location = window.location;
 	const queryParams = new URLSearchParams( location.search );
 	const [ showWelcomeGuide, setShowWelcomeGuide ] = useState(
 		() => '1' === queryParams.get( 'welcome_guide' )

--- a/tests/cypress/integration/admin.test.js
+++ b/tests/cypress/integration/admin.test.js
@@ -1,4 +1,9 @@
 describe( 'Admin can login and make sure plugin is activated', () => {
+	before( () => {
+		cy.login();
+		cy.disableElasticPress();
+	} );
+
 	beforeEach( () => {
 		cy.login();
 	} );


### PR DESCRIPTION
### Description of the Change

This PR makes a few updates to some admin notices that we show:

1. For our registration notice, make some minor text tweaks and ensure the link to our registration form opens in a new tab
2. Don't show the registration notice if we are showing the welcome guide. This ensures things are less cluttered and overwhelming for new users
3. To support the above, change how the add the welcome guide param to the URL
4. Minor text updates to the registration setting screen (I know, not admin notice related)
5. Don't show the embeddings update notice when setting up the Embeddings Provider from scratch, as embeddings will be generated during that process

### How to test the Change

1. In a new environment, ensure the registration admin notice doesn't show when the welcome guide is there
2. Ensure it does show if the welcome guide isn't there
3. Setup the Classification Feature with OpenAI Embeddings and ensure the embeddings admin notice doesn't show

### Changelog Entry

> Changed - Minor text tweaks to our registration language
> Changed - Don't show the registration admin notice when the welcome guide is showing
> Fixed - Ensure the embeddings update notice doesn't show if it isn't needed

### Credits

Props @dkotter, @fabiankaegy 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
