### PR TITLE
Ensure release asset is attached properly to the release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,7 @@ tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .nvmrc export-ignore
+.typos.toml export-ignore
 .wordpress-version-checker.json export-ignore
 .wp-env.json export-ignore
 .wp-env.override.json export-ignore

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -19,13 +19,17 @@ jobs:
       with:
         node-version-file: .nvmrc
 
-    - name: npm install and build
+    - name: Install dependencies and build assets
       run: |
         npm install
         npm run build
         npm run makepot
         composer install --no-dev -o
+
+    - name: Build release asset
+      run: |
         npm run archive
+        mkdir -p release/.github/workflows && cp -rf .github/workflows/ release/.github/workflows && cp .gitattributes release
 
     - name: Release to Stable
       uses: s0/git-publish-subdir-action@develop

--- a/includes/Classifai/Admin/Update.php
+++ b/includes/Classifai/Admin/Update.php
@@ -58,6 +58,8 @@ class Update {
 			'classifai'
 		);
 
+		$this->updater->getVcsApi()->enableReleaseAssets();
+
 		$this->updater->addResultFilter(
 			function ( $plugin_info ) {
 				$plugin_info->icons = array(


### PR DESCRIPTION
### Description of the Change

We've had a long-standing issue where our [GitHub Workflow](https://github.com/10up/classifai/blob/develop/.github/workflows/release.yml) that is supposed to build a final release asset and attach that to a published release has not been working (in fact, it doesn't run at all). We've attempted to fix this a few times but nothing has worked. Did another dive today and I think I've figured out the problem:

- When we do a release, we open a release PR against `develop`
- This is merged in and then we merge `develop` into `trunk`
- We have a [GitHub Workflow](https://github.com/10up/classifai/blob/develop/.github/workflows/stable.yml) that fires on merges to `trunk` that will build the code and push that to our `stable` branch
- We then publish a release on GitHub and we target the `stable` branch for that release
- At this point, we'd expect our release Workflow to fire (as it is supposed to fire on release publish) but it doesn't

I believe the issue here is that when we build the code to push to the `stable` branch, we remove any files that we don't want in the final release, based on our [`.gitattributes`](https://github.com/10up/classifai/blob/develop/.gitattributes) file. This will include removing the `.github/workflows` directory. So when the release is published, the `stable` branch won't contain any of those workflow files and thus the workflow won't ever run.

I compared this to how we do things on [Distributor](https://github.com/10up/distributor/) and I do see the `.github/workflows` directory and `.gitattributes` file in the [`stable` branch](https://github.com/10up/distributor/tree/stable), whereas we don't see that in this [repo](https://github.com/10up/classifai/tree/stable).

So this PR attempts to fix things by adding the `.github/workflows` directory and `.gitattributes` file into the code we push to the `stable` branch. When the release workflow runs, it should remove those when it runs `npm run archive`, so the release that gets attached shouldn't have those files.

In addition, to ensure those files don't end up in the release we send people when they sign up (or any updates we push out to them), we've changed our updater to pull the release asset, which matches what we do on Distributor.

### How to test the Change

Not a great way to test this until we push out a new release. You can run all the release commands locally and ensure those work as expected:

```bash
npm install
npm run build
npm run makepot
composer install --no-dev -o
npm run archive
mkdir -p release/.github/workflows && cp -rf .github/workflows/ release/.github/workflows && cp .gitattributes release
```

### Changelog Entry

> Changed - Use the attached release asset in our plugin updater
> Fixed - Ensure the final release asset gets attached properly to the release

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
