### PR TITLE
Add support for new OpenAI Text to Speech model

### DIFF
--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -31,6 +31,49 @@ class TextToSpeech extends Provider {
 	}
 
 	/**
+	 * Get the API url.
+	 *
+	 * @return string
+	 */
+	public function get_api_url(): string {
+		/**
+		 * Filter the API URL.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_openai_text_to_speech_api_url
+		 *
+		 * @param {string} $url The default API URL.
+		 *
+		 * @return {string} The API URL.
+		 */
+		return apply_filters( 'classifai_openai_text_to_speech_api_url', $this->api_url );
+	}
+
+	/**
+	 * Get the model name.
+	 *
+	 * @return string
+	 */
+	public function get_model(): string {
+		$settings = $this->feature_instance->get_settings();
+		$model    = $settings[ static::ID ]['tts_model'] ?? 'gpt-4o-mini-tts';
+
+		/**
+		 * Filter the model name.
+		 *
+		 * Useful if you want to change the model for certain use cases.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_openai_text_to_speech_model
+		 *
+		 * @param {string} $model The current model to use.
+		 *
+		 * @return {string} The model to use.
+		 */
+		return apply_filters( 'classifai_openai_text_to_speech_model', $model );
+	}
+
+	/**
 	 * Register settings for the provider.
 	 */
 	public function render_provider_fields(): void {
@@ -312,7 +355,7 @@ class TextToSpeech extends Provider {
 
 		// Create the request body to synthesize speech from text.
 		$request_body = array(
-			'model'           => $settings[ static::ID ]['tts_model'],
+			'model'           => $this->get_model(),
 			'voice'           => $settings[ static::ID ]['voice'],
 			'response_format' => $settings[ static::ID ]['format'],
 			'speed'           => (float) $settings[ static::ID ]['speed'],
@@ -320,7 +363,7 @@ class TextToSpeech extends Provider {
 		);
 
 		$response = $request->post(
-			$this->api_url,
+			$this->get_api_url(),
 			[
 				'body' => wp_json_encode( $request_body ),
 			]

--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -191,8 +191,8 @@ class TextToSpeech extends Provider {
 				return array_merge(
 					$common_settings,
 					[
-						'tts_model' => 'tts-1',
-						'voice'     => 'voice',
+						'tts_model' => 'gpt-4o-mini-tts',
+						'voice'     => 'alloy',
 						'format'    => 'mp3',
 						'speed'     => 1,
 					]
@@ -215,15 +215,15 @@ class TextToSpeech extends Provider {
 		$new_settings[ static::ID ]['authenticated'] = $api_key_settings[ static::ID ]['authenticated'];
 
 		if ( $this->feature_instance instanceof FeatureTextToSpeech ) {
-			if ( in_array( $new_settings[ static::ID ]['tts_model'], [ 'tts-1', 'tts-1-hd' ], true ) ) {
+			if ( in_array( $new_settings[ static::ID ]['tts_model'], [ 'gpt-4o-mini-tts', 'tts-1', 'tts-1-hd' ], true ) ) {
 				$new_settings[ static::ID ]['tts_model'] = sanitize_text_field( $new_settings[ static::ID ]['tts_model'] );
 			}
 
-			if ( in_array( $new_settings[ static::ID ]['voice'], [ 'alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer' ], true ) ) {
+			if ( in_array( $new_settings[ static::ID ]['voice'], [ 'alloy', 'ash', 'ballad', 'coral', 'echo', 'fable', 'onyx', 'nova', 'sage', 'shimmer' ], true ) ) {
 				$new_settings[ static::ID ]['voice'] = sanitize_text_field( $new_settings[ static::ID ]['voice'] );
 			}
 
-			if ( in_array( $new_settings[ static::ID ]['format'], [ 'mp3', 'opus', 'aac', 'flac', 'wav', 'pcm' ], true ) ) {
+			if ( in_array( $new_settings[ static::ID ]['format'], [ 'mp3', 'wav' ], true ) ) {
 				$new_settings[ static::ID ]['format'] = sanitize_text_field( $new_settings[ static::ID ]['format'] );
 			}
 

--- a/src/js/settings/components/provider-settings/openai-text-to-speech.js
+++ b/src/js/settings/components/provider-settings/openai-text-to-speech.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
 import { SettingsRow } from '../settings-row';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { STORE_NAME } from '../../data/store';
+import { OpenAISettings } from './openai';
 
 /**
  * Component for OpenAI Text to Speech Provider settings.
@@ -33,33 +34,13 @@ export const OpenAITextToSpeechSettings = ( { isConfigured = false } ) => {
 	const { setProviderSettings } = useDispatch( STORE_NAME );
 	const onChange = ( data ) => setProviderSettings( providerName, data );
 
-	const Description = () => (
-		<>
-			{ __( "Don't have an OpenAI account yet?", 'classifai' ) }{ ' ' }
-			<a
-				title={ __( 'Sign up for an OpenAI account', 'classifai' ) }
-				href="https://platform.openai.com/signup"
-			>
-				{ __( 'Sign up for one', 'classifai' ) }
-			</a>{ ' ' }
-			{ __( 'in order to get your API key.', 'classifai' ) }
-		</>
-	);
-
 	return (
 		<>
 			{ ! isConfigured && (
-				<SettingsRow
-					label={ __( 'API Key', 'classifai' ) }
-					description={ <Description /> }
-				>
-					<InputControl
-						id={ `${ providerName }_api_key` }
-						type="password"
-						value={ providerSettings.api_key || '' }
-						onChange={ ( value ) => onChange( { api_key: value } ) }
-					/>
-				</SettingsRow>
+				<OpenAISettings
+					providerSettings={ providerSettings }
+					onChange={ onChange }
+				/>
 			) }
 			<SettingsRow
 				label={ __( 'TTS model', 'classifai' ) }
@@ -67,7 +48,7 @@ export const OpenAITextToSpeechSettings = ( { isConfigured = false } ) => {
 					<>
 						{ __( 'Select a', 'classifai' ) }{ ' ' }
 						<a
-							href="https://platform.openai.com/docs/models/tts"
+							href="https://platform.openai.com/docs/models#tts"
 							title={ __(
 								'OpenAI Text to Speech models',
 								'classifai'
@@ -77,27 +58,28 @@ export const OpenAITextToSpeechSettings = ( { isConfigured = false } ) => {
 						>
 							{ __( 'model', 'classifai' ) }
 						</a>{ ' ' }
-						{ __( 'depending on your requirement.', 'classifai' ) }
+						{ __(
+							'depending on your requirements. GPT-4o mini TTS is the recommendation, as it is the newest model and typically provides the best results and performance at the best cost.',
+							'classifai'
+						) }
 					</>
 				}
 			>
 				<SelectControl
 					id={ `${ providerName }_tts_model` }
 					onChange={ ( value ) => onChange( { tts_model: value } ) }
-					value={ providerSettings.tts_model || 'tts-1' }
+					value={ providerSettings.tts_model || 'gpt-4o-mini-tts' }
 					options={ [
 						{
-							label: __(
-								'Text-to-speech 1 (Optimized for speed)',
-								'classifai'
-							),
+							label: __( 'GPT-4o mini TTS', 'classifai' ),
+							value: 'gpt-4o-mini-tts',
+						},
+						{
+							label: __( 'Text-to-speech 1', 'classifai' ),
 							value: 'tts-1',
 						},
 						{
-							label: __(
-								'Text-to-speech 1 HD (Optimized for quality)',
-								'classifai'
-							),
+							label: __( 'Text-to-speech 1 HD', 'classifai' ),
 							value: 'tts-1-hd',
 						},
 					] }
@@ -110,7 +92,7 @@ export const OpenAITextToSpeechSettings = ( { isConfigured = false } ) => {
 					<>
 						{ __( 'Select the speech', 'classifai' ) }{ ' ' }
 						<a
-							href="https://platform.openai.com/docs/models/tts"
+							href="https://platform.openai.com/docs/guides/text-to-speech#voice-options"
 							target="_blank"
 							rel="noreferrer"
 						>
@@ -126,27 +108,39 @@ export const OpenAITextToSpeechSettings = ( { isConfigured = false } ) => {
 					value={ providerSettings.voice || 'alloy' }
 					options={ [
 						{
-							label: __( 'Alloy (male)', 'classifai' ),
+							label: __( 'Alloy', 'classifai' ),
 							value: 'alloy',
 						},
 						{
-							label: __( 'Echo (male)', 'classifai' ),
+							label: __( 'Ash', 'classifai' ),
+							value: 'ash',
+						},
+						{
+							label: __( 'Coral', 'classifai' ),
+							value: 'coral',
+						},
+						{
+							label: __( 'Echo', 'classifai' ),
 							value: 'echo',
 						},
 						{
-							label: __( 'Fable (male)', 'classifai' ),
+							label: __( 'Fable', 'classifai' ),
 							value: 'fable',
 						},
 						{
-							label: __( 'Onyx (male)', 'classifai' ),
+							label: __( 'Onyx', 'classifai' ),
 							value: 'onyx',
 						},
 						{
-							label: __( 'Nova (female)', 'classifai' ),
+							label: __( 'Nova', 'classifai' ),
 							value: 'nova',
 						},
 						{
-							label: __( 'Shimmer (female)', 'classifai' ),
+							label: __( 'Sage', 'classifai' ),
+							value: 'sage',
+						},
+						{
+							label: __( 'Shimmer', 'classifai' ),
 							value: 'shimmer',
 						},
 					] }

--- a/tests/cypress/integration/language-processing/text-to-speech-openai-text-to-speech.test.js
+++ b/tests/cypress/integration/language-processing/text-to-speech-openai-text-to-speech.test.js
@@ -10,7 +10,7 @@ describe( '[Language Processing] Text to Speech (OpenAI) Tests', () => {
 		cy.get( '#openai_text_to_speech_tts_model' ).select(
 			'gpt-4o-mini-tts'
 		);
-		cy.get( '#openai_text_to_speech_api_key' ).clear().type( 'password' );
+		cy.get( '#openai_api_key' ).clear().type( 'password' );
 		cy.enableFeature();
 		cy.saveFeatureSettings();
 

--- a/tests/cypress/integration/language-processing/text-to-speech-openai-text-to-speech.test.js
+++ b/tests/cypress/integration/language-processing/text-to-speech-openai-text-to-speech.test.js
@@ -7,12 +7,14 @@ describe( '[Language Processing] Text to Speech (OpenAI) Tests', () => {
 		cy.get( '#classifai-logo' ).should( 'exist' );
 		cy.get( '.settings-allowed-post-types input#post' ).check();
 		cy.selectProvider( 'openai_text_to_speech' );
-		cy.get( '#openai_text_to_speech_tts_model' ).select( 'tts-1' );
+		cy.get( '#openai_text_to_speech_tts_model' ).select(
+			'gpt-4o-mini-tts'
+		);
 		cy.get( '#openai_text_to_speech_api_key' ).clear().type( 'password' );
 		cy.enableFeature();
 		cy.saveFeatureSettings();
 
-		cy.get( '#openai_text_to_speech_voice' ).select( 'alloy' );
+		cy.get( '#openai_text_to_speech_voice' ).select( 'ash' );
 		cy.saveFeatureSettings();
 		cy.optInAllFeatures();
 		cy.disableClassicEditor();


### PR DESCRIPTION
### Description of the Change

OpenAI recently introduced a new text to speech model, [GPT-4o mini TTS](https://platform.openai.com/docs/models/gpt-4o-mini-tts). We currently support the TTS-1 and TTS-1-HD models but seems this new model is better than those, both in terms of accuracy, speed and price.

This is the one Feature where we do already allow someone to choose the model in the settings so I've added GPT-4o mini TTS as an option there and have set that as the new default. I've also updated the available voice options as it seems those have changed (some new ones added, a few removed). And I've added new filters around the model and API URL, matching what we're doing in other Providers and making it easy for developers to modify those.

### How to test the Change

1. Configure the Text to Speech Feature, connecting to OpenAI
2. Try generating an audio file and ensure it works
3. Ensure this works with the new model and existing models

### Changelog Entry

> Added - Support for selecting the new GPT-4o mini TTS model in our Text to Speech Feature
> Added - New filters around the Text to Speech model and API URL, allowing those to easily be changed
> Changed - Set the GPT-4o mini TTS model as our new default in our Text to Speech Feature

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
