### PR TITLE
Ensure that the Text-to-Speech feature options are available only for the allowed post types.

### DIFF
--- a/includes/Classifai/Features/TextToSpeech.php
+++ b/includes/Classifai/Features/TextToSpeech.php
@@ -111,9 +111,11 @@ class TextToSpeech extends Feature {
 			return;
 		}
 
-		$post = get_post();
+		$post                 = get_post();
+		$supported_post_types = $this->get_supported_post_types();
 
-		if ( empty( $post ) ) {
+		// Only enqueue the script if we're on a supported post type.
+		if ( empty( $post ) || ! in_array( $post->post_type, $supported_post_types, true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Description of the Change
While reviewing PR #876, I noticed that the "Enable audio generation" toggle appears in the ClassifAI panel regardless of whether the feature is allowed for a specific post type. This PR fixes the issue by ensuring that the toggle and other settings are available only for the allowed post types.

![image](https://github.com/user-attachments/assets/f695e1ac-9e78-4532-8da9-d56ed145ad6e)


### How to test the Change
1. Enable the "Text-to-Speech" feature by configuring the provider.  
2. Disable the feature for the "Page" post type.  
3. Create a new page or edit an existing one and ensure that no options related to the Text-to-Speech feature are available.  
4. Enable the feature for the "Page" post type.  
5. Create a new page or edit an existing one and ensure that the Text-to-Speech feature options are now available.

### Changelog Entry
> Fixed - Ensure that the Text-to-Speech feature options are available only for the allowed post types.

### Credits
Props @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
