### PR TITLE
Ensure we save post type settings properly

### DIFF
--- a/includes/Classifai/Admin/BulkActions.php
+++ b/includes/Classifai/Admin/BulkActions.php
@@ -83,6 +83,10 @@ class BulkActions {
 			}
 
 			foreach ( $settings['post_types'] as $post_type ) {
+				if ( ! is_string( $post_type ) ) {
+					continue;
+				}
+
 				add_filter( "bulk_actions-edit-$post_type", [ $this, 'register_language_processing_actions' ] );
 				add_filter( "handle_bulk_actions-edit-$post_type", [ $this, 'language_processing_actions_handler' ], 10, 3 );
 

--- a/includes/Classifai/Features/ContentGeneration.php
+++ b/includes/Classifai/Features/ContentGeneration.php
@@ -302,14 +302,13 @@ EOD;
 	 * @return array
 	 */
 	public function sanitize_default_feature_settings( array $new_settings ): array {
-		$settings   = $this->get_settings();
 		$post_types = \Classifai\get_post_types_for_language_settings();
 
 		$new_settings['prompt'] = sanitize_prompts( 'prompt', $new_settings );
 
 		foreach ( $post_types as $post_type ) {
 			if ( ! isset( $new_settings['post_types'][ $post_type->name ] ) ) {
-				$new_settings['post_types'][ $post_type->name ] = $settings['post_types'];
+				$new_settings['post_types'][ $post_type->name ] = '';
 			} else {
 				$new_settings['post_types'][ $post_type->name ] = sanitize_text_field( $new_settings['post_types'][ $post_type->name ] );
 			}

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -392,7 +392,7 @@ class ExcerptGeneration extends Feature {
 			}
 
 			if ( ! isset( $new_settings['post_types'][ $post_type->name ] ) ) {
-				$new_settings['post_types'][ $post_type->name ] = $settings['post_types'];
+				$new_settings['post_types'][ $post_type->name ] = '';
 			} else {
 				$new_settings['post_types'][ $post_type->name ] = sanitize_text_field( $new_settings['post_types'][ $post_type->name ] );
 			}

--- a/includes/Classifai/Features/TextToSpeech.php
+++ b/includes/Classifai/Features/TextToSpeech.php
@@ -786,12 +786,11 @@ class TextToSpeech extends Feature {
 	 * @return array
 	 */
 	public function sanitize_default_feature_settings( array $new_settings ): array {
-		$settings   = $this->get_settings();
 		$post_types = \Classifai\get_post_types_for_language_settings();
 
 		foreach ( $post_types as $post_type ) {
 			if ( ! isset( $new_settings['post_types'][ $post_type->name ] ) ) {
-				$new_settings['post_types'][ $post_type->name ] = $settings['post_types'];
+				$new_settings['post_types'][ $post_type->name ] = '';
 			} else {
 				$new_settings['post_types'][ $post_type->name ] = sanitize_text_field( $new_settings['post_types'][ $post_type->name ] );
 			}


### PR DESCRIPTION
### Description of the Change

As reported in #892, there are situations where PHP notices can be rendered because we try and use an `array` as a `string`, which PHP doesn't like :)

In looking into this, we have a few Features that you can choose which post types are available. When that data is saved, we check to see if each available post type has been saved or not but our logic was incorrect and instead of discarding data if it wasn't saved, it was saving the default value for that item instead. This resulted in some situations where you could save an `array` when we expect a `string`.

This PR brings in two fixes:

1. In our logic that uses the post type values for bulk actions, we check if the value is a `string` before using it, to fix issues that bad data was saved
2. We've updated our save logic in the few Features that had the issue to ensure if a value isn't set, we don't use the default and instead use a blank string

Closes #892

### How to test the Change

These are the steps I found to work most predictably, though even then it sometimes would be fine :shrug:

1. On the latest release within a clean environment, enable the Text to Speech Feature and set it up to use OpenAI
2. Leave all other settings (most important post types) as-is
3. Ensure you have debug on and if you go to the admin dashboard, you should get a PHP notice
4. Checkout this PR and in the same environment, the PHP notice should no longer show though the data saved is still an array
5. Wipe the environment and follow these steps again. The PHP notice shouldn't happen and the data stored should be valid

### Changelog Entry

> Fixed - Ensure we properly store the post type setting to avoid PHP notices

### Credits

Props @JiveDig, @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
