### PR TITLE
Fix condition to prevent warnings when `$args['args']` is not defined

### DIFF
--- a/includes/Classifai/EmbeddingsScheduler.php
+++ b/includes/Classifai/EmbeddingsScheduler.php
@@ -117,7 +117,7 @@ class EmbeddingsScheduler {
 
 		$args = $action->get_args();
 
-		if ( ! isset( $args['args'] ) && ! isset( $args['args']['exclude'] ) ) {
+		if ( ! isset( $args['args'] ) || ! isset( $args['args']['exclude'] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
The current condition:

```php
if ( ! isset( $args['args'] ) && ! isset( $args['args']['exclude'] ) ) {
    return;
}
```

is incorrect because it evaluates `isset($args['args']['exclude'])` even when `$args['args']` is not set, which can cause warnings.

### ✅ Proposed Change:
Change the `&&` to `||` to ensure proper short-circuiting:

```php
if ( ! isset( $args['args'] ) || ! isset( $args['args']['exclude'] ) ) {
    return;
}
```

This fix prevents the warning and improves the condition.
