### PR TITLE
Switch to Gemini 2.5 Flash

### DIFF
--- a/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
+++ b/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
@@ -30,7 +30,7 @@ class GeminiAPI extends Provider {
 	protected $googleai_url = 'https://generativelanguage.googleapis.com/v1beta';
 
 	/**
-	 * GeminiAPI model
+	 * Gemini API model
 	 *
 	 * @var string
 	 */

--- a/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
+++ b/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
@@ -34,7 +34,7 @@ class GeminiAPI extends Provider {
 	 *
 	 * @var string
 	 */
-	protected $googleai_model = 'models/gemini-pro';
+	protected $model = 'models/gemini-2.5-flash-preview-05-20';
 
 	/**
 	 * GeminiAPI constructor.
@@ -43,6 +43,28 @@ class GeminiAPI extends Provider {
 	 */
 	public function __construct( $feature_instance = null ) {
 		$this->feature_instance = $feature_instance;
+	}
+
+	/**
+	 * Get the model name.
+	 *
+	 * @return string
+	 */
+	public function get_model(): string {
+		/**
+		 * Filter the model name.
+		 *
+		 * Useful if you want to use a different model, like
+		 * gemini-2.5-pro-preview-05-06.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_googleai_gemini_api_model
+		 *
+		 * @param {string} $model The default model to use.
+		 *
+		 * @return {string} The model to use.
+		 */
+		return apply_filters( 'classifai_googleai_gemini_api_model', $this->model );
 	}
 
 	/**
@@ -294,7 +316,7 @@ class GeminiAPI extends Provider {
 
 		// Make our API request.
 		$response = $request->post(
-			$this->googleai_url . '/' . $this->googleai_model . ':generateContent',
+			$this->googleai_url . '/' . $this->get_model() . ':generateContent',
 			[
 				'body' => wp_json_encode( $body ),
 			]
@@ -394,7 +416,7 @@ class GeminiAPI extends Provider {
 
 		// Make our API request.
 		$response = $request->post(
-			$this->googleai_url . '/' . $this->googleai_model . ':generateContent',
+			$this->googleai_url . '/' . $this->get_model() . ':generateContent',
 			[
 				'body' => wp_json_encode( $body ),
 			]
@@ -499,7 +521,7 @@ class GeminiAPI extends Provider {
 
 		// Make our API request.
 		$response = $request->post(
-			$this->googleai_url . '/' . $this->googleai_model . ':generateContent',
+			$this->googleai_url . '/' . $this->get_model() . ':generateContent',
 			[
 				'body' => wp_json_encode( $body ),
 			]
@@ -532,8 +554,9 @@ class GeminiAPI extends Provider {
 	 *
 	 * ### Important Note:
 	 * The content length is not limited in this implementation.
-	 * The Gemini Pro model can process up to 30,720 input tokens, which is approximately equivalent to 18,000 - 24,000 words. (https://ai.google.dev/models/gemini#model_variations)
-	 * Given that the average blog post length ranges from 1,500 - 2,500 words, this limit is more than sufficient for our use case.
+	 * The Gemini 2.5 Flash model can process up to 1,048,576 input tokens:
+	 * (https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-preview).
+	 * This limit should be more than sufficient for our use case.
 	 *
 	 * @param int    $post_id      Post ID to get content from.
 	 * @param bool   $use_title    Whether to use the title or not.


### PR DESCRIPTION
### Description of the Change

As reported in #926, the Gemini Pro model no longer exists and as such, using the Gemini Provider no longer works. This PR updates to the Gemini 2.5 Flash model (seemed like this was a better option than 2.5 Pro just due to cost). It also adds in a new helper method to get the model name (matching what we do in other Providers) making it easier for others to change that model if desired.

Closes #926

### How to test the Change

Test Title Generation, Excerpt Generation and Content Resizing Features with Google AI configured as the Provider and ensure they all work as expected

### Changelog Entry

> Changed - Switch to the Gemini 2.5 Flash model
> Developer - New filter, `classifai_googleai_gemini_api_model`, making it easier to change the model Google AI uses

### Credits

Props @dkotter, @MadtownLems

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
