### PR TITLE
Add a main Diagrams doc page and nest all diagrams under that

### DIFF
--- a/hookdoc-conf.json
+++ b/hookdoc-conf.json
@@ -7,7 +7,7 @@
       "tutorials": "./hookdocs"
   },
   "source": {
-      "includePattern": ".+\\.(php|inc)?$"
+    "includePattern": ".+\\.(php|inc)?$"
   },
   "plugins": [
     "node_modules/wp-hookdoc/plugin",

--- a/hookdocs/meta.json
+++ b/hookdocs/meta.json
@@ -15,9 +15,41 @@
         "title": "Chrome built-in AI"
     },
     "data-flow": {
-        "title": "ClassifAI Data Flow"
+        "title": "Data Flow"
     },
     "feature-provider-support": {
         "title": "Providers supported per Feature"
+    },
+    "diagrams": {
+      "title": "Diagrams",
+      "children": {
+        "classification-openai-flow": {
+          "title": "Classification Feature Flow (with OpenAI Embeddings)"
+        },
+        "descriptive-text-generator-openai-flow": {
+          "title": "Descriptive Text Generator Feature Flow (with OpenAI)"
+        },
+        "excerpt-generation-openai-flow": {
+          "title": "Excerpt Generation Feature Flow (with OpenAI ChatGPT)"
+        },
+        "image-tags-generator-openai-flow": {
+          "title": "Image Tags Generator Feature Flow (with OpenAI)"
+        },
+        "image-text-extraction-openai-flow": {
+          "title": "Image Text Extraction Feature Flow (with OpenAI)"
+        },
+        "smart-404-openai-flow": {
+          "title": "Smart 404 Feature Flow (with OpenAI Embeddings & Elasticsearch)"
+        },
+        "term-cleanup-openai-flow": {
+          "title": "Term Cleanup Feature Flow (with OpenAI)"
+        },
+        "text-to-speech-openai-flow": {
+          "title": "Text-to-Speech Feature Flow (with OpenAI)"
+        },
+        "title-generation-openai-flow": {
+          "title": "Title Generation Feature Flow (with OpenAI)"
+        }
+      }
     }
 }


### PR DESCRIPTION
### Description of the Change

Noticed today that all of the new diagrams we added in #902 are showing as navigation items in our sidebar menu (see https://10up.github.io/classifai/). While this works it's not ideal, as these don't have proper titles added and they take more space in our sidebar.

This PR fixes that by adding a new Diagrams page and nesting all of these diagrams underneath that. The result will be a single link in the sidebar (Diagrams) that will take you to a page that lists out all of the individual diagrams:

<img width="1180" alt="Diagrams page and sidebar navigation" src="https://github.com/user-attachments/assets/ca44dbfa-55e2-4b26-adf6-248ee3099d86" />

There are potential followups we could look at here if we want, though not sure how feasible these are:

1. The tutorials template automatically outputs a list of children pages and then the actual page title and content beneath that. Would be great to be able to modify that template to show the title and content above instead of below but I didn't find a quick way to accomplish this
2. The diagrams we have on these pages are mermaid charts and they don't render properly. In doing some quick searching, seems there's a somewhat hacky approach to fix this (basically loading in some custom JS on those pages) that if we can get it working, would make those diagram pages nicer

### How to test the Change

If desired, can build docs locally by running `npm run build:docs` and verify things look good.

Otherwise not much to review here

### Changelog Entry

> Developer - Add a main Diagrams doc page and nest all diagrams under that

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
