### PR TITLE
Switch to using `gpt-4.1-mini` as our model for image processing

### DIFF
--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -50,6 +50,18 @@ class ChatGPT extends Provider {
 	protected $max_tokens = 128000;
 
 	/**
+	 * Image types to process.
+	 *
+	 * @var array
+	 */
+	private $image_types_to_process = [
+		'gif',
+		'jpeg',
+		'png',
+		'webp',
+	];
+
+	/**
 	 * OpenAI ChatGPT constructor.
 	 *
 	 * @param \Classifai\Features\Feature $feature_instance The feature instance.
@@ -1236,6 +1248,22 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'invalid', esc_html__( 'This attachment can\'t be processed.', 'classifai' ) );
 		}
 
+		// Check if the image is of a type we can process.
+		$mime_type          = get_post_mime_type( $attachment_id );
+		$matched_extensions = explode( '|', array_search( $mime_type, wp_get_mime_types(), true ) );
+		$process            = false;
+
+		foreach ( $matched_extensions as $ext ) {
+			if ( in_array( $ext, $this->image_types_to_process, true ) ) {
+				$process = true;
+				break;
+			}
+		}
+
+		if ( ! $process ) {
+			return new WP_Error( 'invalid', esc_html__( 'Image does not match a valid mime type.', 'classifai' ) );
+		}
+
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
 		if ( ! $metadata || ! is_array( $metadata ) ) {
@@ -1254,7 +1282,7 @@ class ChatGPT extends Provider {
 					'min' => 512,
 					'max' => 2000,
 				],
-				'filesize' => 100 * MB_IN_BYTES,
+				'filesize' => 50 * MB_IN_BYTES,
 			]
 		);
 

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -43,6 +43,13 @@ class ChatGPT extends Provider {
 	protected $chatgpt_model = 'gpt-4o-mini';
 
 	/**
+	 * OpenAI Vision model
+	 *
+	 * @var string
+	 */
+	protected $vision_model = 'gpt-4.1-mini';
+
+	/**
 	 * Maximum number of tokens our model supports
 	 *
 	 * @var int
@@ -300,7 +307,7 @@ class ChatGPT extends Provider {
 		$body = apply_filters(
 			'classifai_chatgpt_descriptive_text_request_body',
 			[
-				'model'       => $this->chatgpt_model,
+				'model'       => $this->vision_model,
 				'messages'    => [
 					[
 						'role'    => 'system',
@@ -401,7 +408,7 @@ class ChatGPT extends Provider {
 		$body = apply_filters(
 			'classifai_chatgpt_ocr_request_body',
 			[
-				'model'       => $this->chatgpt_model,
+				'model'       => $this->vision_model,
 				'messages'    => [
 					[
 						'role'    => 'system',
@@ -512,7 +519,7 @@ class ChatGPT extends Provider {
 		$body = apply_filters(
 			'classifai_chatgpt_image_tag_request_body',
 			[
-				'model'       => $this->chatgpt_model,
+				'model'       => $this->vision_model,
 				'messages'    => [
 					[
 						'role'    => 'system',


### PR DESCRIPTION
### Description of the Change

I recently was calculating some costs for someone that wanted to use OpenAI to generate image tags and image descriptive text. Looking through [OpenAI's pricing](https://platform.openai.com/docs/guides/images-vision#calculating-costs), I found out that even though the `gpt-4o-mini` model we use has the cheapest per-token cost, it uses significantly more tokens when processing images and thus can lead to higher costs overall.

I decided to run some tests using a certain image across various models to see what the costs looked like and what results I was getting. I tested with a pretty basic image of a stop sign, noting that results may vary with more complex images.

| `gpt-4o-mini` | `gpt-4.1-mini` | `gpt-4.1` |
| ---- | ---- | ---- |
| **Descriptive text response**: "A red octagonal stop sign is prominently displayed against a cloudy sky. The sign features bold white letters spelling "STOP." The background shows a mix of gray and white clouds, creating a dramatic atmosphere. The sign is mounted on a black pole with visible holes along its length." | **Descriptive text response**: "Red octagonal stop sign with white letters mounted on a black perforated metal pole against a cloudy sky background" | **Descriptive text response**: "Red octagonal stop sign with white lettering mounted on a pole, set against a cloudy sky" |
| Tokens used: 25,680 | Tokens used: 1,392 | Tokens used: 908 |
| **Tag response**: Stop sign, Traffic sign, Red color, Outdoor, Sky background | **Tag response**: Stop sign, Traffic sign, Red octagon, Road safety, Cloudy sky | **Tag response**: Stop sign, Red, Octagon, Road sign, Cloudy sky |
| Tokens used: 25,590 | Tokens used: 1,338 | Tokens used: 855 |
| **OCR response**: STOP | **OCR response**: STOP | **OCR response**: STOP |
| Tokens used: 25,560 | Tokens used: 1,305 | Tokens used: 824 |
| **Cost per run**: ~$0.003825 | **Cost per run**: ~$0.000498 | **Cost per run**: ~$0.00153 |

You can see there are differences here in what responses we get, though pretty much the same for `gpt-4.1-mini` and `gpt-4.1`. But the big thing here is `gtp-4o-mini` costs about 8x more than `gpt-4.1-mini` and about 2x more than `gpt-4.1`.

I personally don't think the results from `gpt-4o-mini` are better (the descriptive text is more descriptive though I'd argue you don't actually want/need that much detail in alt text) and because the results from `gpt-4.1-mini` and `gpt-4.1` are so close, I suggest we switch to `gpt-4.1-mini` for image processing as that will save the most money.

In addition, we had no check in place to ensure we only process image types that OpenAI supports (jpg, png, gif, webp), so that's added here and we also reduce the image size we support from 100MB to 50MB, matching what OpenAI claims to support.

### How to test the Change

1. Configure Descriptive Text Generator, Image Tags Generator and Image Text Extraction Features to all use OpenAI
2. Ensure these Features work and you get the results you'd expect (note images need to be publicly available)

### Changelog Entry

> Changed - Switch to using `gpt-4.1-mini` instead of `gpt-4o-mini` for any image processing Features with OpenAI
> Fixed - Only allow jpg, png, gif and webp images to be processed when using OpenAI, matching what they support

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
