### PR TITLE
Adjustments to the Key Takeaways Feature

### DIFF
--- a/includes/Classifai/Blocks/key-takeaways/edit.js
+++ b/includes/Classifai/Blocks/key-takeaways/edit.js
@@ -49,7 +49,7 @@ const BlockEdit = ( props ) => {
 			) {
 				setErrors( [
 					__(
-						'No content found. Please add content then click the "Refresh results" button.',
+						'No content found. Please add content then click the "Generate results" button.',
 						'classifai'
 					),
 				] );
@@ -118,6 +118,11 @@ const BlockEdit = ( props ) => {
 		} );
 	};
 
+	const buttonText =
+		takeaways.length > 0
+			? __( 'Refresh results', 'classifai' )
+			: __( 'Generate results', 'classifai' );
+
 	return (
 		<>
 			<BlockControls>
@@ -126,8 +131,8 @@ const BlockEdit = ( props ) => {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'classifai' ) }>
 					<Button
-						label={ __( 'Re-generate key takeaways', 'classifai' ) }
-						text={ __( 'Refresh results', 'classifai' ) }
+						label={ __( 'Generate key takeaways', 'classifai' ) }
+						text={ buttonText }
 						variant={ 'secondary' }
 						onClick={ () => setRun( true ) }
 						isBusy={ isLoading }
@@ -187,14 +192,14 @@ const BlockEdit = ( props ) => {
 						) }
 						<Button
 							label={ __(
-								'Re-generate key takeaways',
+								'Generate key takeaways',
 								'classifai'
 							) }
-							text={ __( 'Refresh results', 'classifai' ) }
+							text={ buttonText }
 							variant={ 'secondary' }
 							onClick={ () => setRun( true ) }
 							isBusy={ isLoading }
-							style={ { width: '115px' } }
+							style={ { width: '125px' } }
 						/>
 					</Placeholder>
 				</div>

--- a/includes/Classifai/Blocks/key-takeaways/edit.js
+++ b/includes/Classifai/Blocks/key-takeaways/edit.js
@@ -68,6 +68,7 @@ const BlockEdit = ( props ) => {
 					content: postContent,
 					title: postTitle,
 					render,
+					run: run ? 'manual' : 'auto',
 				},
 			} ).then(
 				async ( res ) => {

--- a/includes/Classifai/Blocks/key-takeaways/edit.js
+++ b/includes/Classifai/Blocks/key-takeaways/edit.js
@@ -19,6 +19,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { postList, paragraph } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -166,7 +167,9 @@ const BlockEdit = ( props ) => {
 						</p>
 						<ul style={ { lineHeight: '1.5', marginTop: 0 } }>
 							{ errors.map( ( error, index ) => (
-								<li key={ index }>{ error }</li>
+								<li key={ index }>
+									{ decodeEntities( error ) }
+								</li>
 							) ) }
 						</ul>
 						<Button

--- a/includes/Classifai/Blocks/key-takeaways/edit.js
+++ b/includes/Classifai/Blocks/key-takeaways/edit.js
@@ -28,6 +28,7 @@ import { ReactComponent as icon } from '../../../../assets/img/block-icon.svg';
 const BlockEdit = ( props ) => {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ run, setRun ] = useState( false );
+	const [ errors, setErrors ] = useState( [] );
 	const { attributes, setAttributes } = props;
 	const { render, takeaways, title } = attributes;
 	const blockProps = useBlockProps();
@@ -40,8 +41,24 @@ const BlockEdit = ( props ) => {
 			const postTitle =
 				select( 'core/editor' ).getEditedPostAttribute( 'title' );
 
+			// If no content or the only content in the post is this block, don't make an API call.
+			if (
+				! postContent ||
+				'<!-- wp:classifai/key-takeaways /-->' === postContent
+			) {
+				setErrors( [
+					__(
+						'No content found. Please add content then refresh results from the block settings.',
+						'classifai'
+					),
+				] );
+				setRun( false );
+				return;
+			}
+
 			setRun( false );
 			setIsLoading( true );
+			setErrors( [] );
 
 			apiFetch( {
 				path: '/classifai/v1/key-takeaways/',
@@ -63,9 +80,7 @@ const BlockEdit = ( props ) => {
 					setIsLoading( false );
 				},
 				( err ) => {
-					setAttributes( {
-						takeaways: [ `Error:  ${ err?.message }` ],
-					} );
+					setErrors( [ err?.message ] );
 					setIsLoading( false );
 				}
 			);
@@ -132,7 +147,32 @@ const BlockEdit = ( props ) => {
 				</Placeholder>
 			) }
 
-			{ ! isLoading && (
+			{ ! isLoading && errors.length > 0 && (
+				<div { ...blockProps }>
+					<Placeholder
+						icon={ icon }
+						label={ __( 'Key Takeaways', 'classifai' ) }
+						isColumnLayout
+					>
+						<p
+							style={ {
+								color: '#cc1818',
+								fontWeight: 'bold',
+								marginBottom: 0,
+							} }
+						>
+							{ __( 'Error', 'classifai' ) }
+						</p>
+						<ul style={ { lineHeight: '1.5', marginTop: 0 } }>
+							{ errors.map( ( error, index ) => (
+								<li key={ index }>{ error }</li>
+							) ) }
+						</ul>
+					</Placeholder>
+				</div>
+			) }
+
+			{ ! isLoading && takeaways.length > 0 && errors.length === 0 && (
 				<div { ...blockProps }>
 					<RichText
 						tagName="h2"

--- a/includes/Classifai/Blocks/key-takeaways/edit.js
+++ b/includes/Classifai/Blocks/key-takeaways/edit.js
@@ -156,22 +156,35 @@ const BlockEdit = ( props ) => {
 						label={ __( 'Key Takeaways', 'classifai' ) }
 						isColumnLayout
 					>
-						<p
-							style={ {
-								color: '#cc1818',
-								fontWeight: 'bold',
-								marginBottom: 0,
-							} }
-						>
-							{ __( 'Error', 'classifai' ) }
-						</p>
-						<ul style={ { lineHeight: '1.5', marginTop: 0 } }>
-							{ errors.map( ( error, index ) => (
-								<li key={ index }>
-									{ decodeEntities( error ) }
-								</li>
-							) ) }
-						</ul>
+						{ ! errors[ 0 ].toLowerCase().includes( 'disabled' ) ? (
+							<>
+								<p
+									style={ {
+										color: '#cc1818',
+										fontWeight: 'bold',
+										marginBottom: 0,
+									} }
+								>
+									{ __( 'Errors', 'classifai' ) }
+								</p>
+								<ul
+									style={ {
+										lineHeight: '1.5',
+										marginTop: 0,
+									} }
+								>
+									{ errors.map( ( error, index ) => (
+										<li key={ index }>
+											{ decodeEntities( error ) }
+										</li>
+									) ) }
+								</ul>
+							</>
+						) : (
+							errors.map( ( error, index ) => (
+								<p key={ index }>{ decodeEntities( error ) }</p>
+							) )
+						) }
 						<Button
 							label={ __(
 								'Re-generate key takeaways',

--- a/includes/Classifai/Blocks/key-takeaways/edit.js
+++ b/includes/Classifai/Blocks/key-takeaways/edit.js
@@ -48,7 +48,7 @@ const BlockEdit = ( props ) => {
 			) {
 				setErrors( [
 					__(
-						'No content found. Please add content then refresh results from the block settings.',
+						'No content found. Please add content then click the "Refresh results" button.',
 						'classifai'
 					),
 				] );
@@ -169,6 +169,17 @@ const BlockEdit = ( props ) => {
 								<li key={ index }>{ error }</li>
 							) ) }
 						</ul>
+						<Button
+							label={ __(
+								'Re-generate key takeaways',
+								'classifai'
+							) }
+							text={ __( 'Refresh results', 'classifai' ) }
+							variant={ 'secondary' }
+							onClick={ () => setRun( true ) }
+							isBusy={ isLoading }
+							style={ { width: '115px' } }
+						/>
 					</Placeholder>
 				</div>
 			) }

--- a/includes/Classifai/Blocks/key-takeaways/render.php
+++ b/includes/Classifai/Blocks/key-takeaways/render.php
@@ -10,6 +10,11 @@
 $block_title = $attributes['title'] ?? '';
 $layout      = $attributes['render'] ?? 'list';
 $takeaways   = $attributes['takeaways'] ?? [];
+
+// If there are no takeaways, don't render the block.
+if ( empty( $takeaways ) ) {
+	return;
+}
 ?>
 
 <div <?php echo get_block_wrapper_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>

--- a/includes/Classifai/Features/KeyTakeaways.php
+++ b/includes/Classifai/Features/KeyTakeaways.php
@@ -104,6 +104,17 @@ class KeyTakeaways extends Feature {
 							'validate_callback' => 'rest_validate_request_arg',
 							'description'       => esc_html__( 'How the key takeaways should be rendered.', 'classifai' ),
 						],
+						'run'    => [
+							'type'              => 'string',
+							'enum'              => [
+								'auto',
+								'manual',
+							],
+							'default'           => 'auto',
+							'sanitize_callback' => 'sanitize_text_field',
+							'validate_callback' => 'rest_validate_request_arg',
+							'description'       => esc_html__( 'Whether the key takeaways were generated automatically or manually.', 'classifai' ),
+						],
 					],
 					'permission_callback' => [ $this, 'generate_key_takeaways_permissions_check' ],
 				],
@@ -133,6 +144,17 @@ class KeyTakeaways extends Feature {
 							'sanitize_callback' => 'sanitize_text_field',
 							'validate_callback' => 'rest_validate_request_arg',
 							'description'       => esc_html__( 'How the key takeaways should be rendered.', 'classifai' ),
+						],
+						'run'     => [
+							'type'              => 'string',
+							'enum'              => [
+								'auto',
+								'manual',
+							],
+							'default'           => 'auto',
+							'sanitize_callback' => 'sanitize_text_field',
+							'validate_callback' => 'rest_validate_request_arg',
+							'description'       => esc_html__( 'Whether the key takeaways were generated automatically or manually.', 'classifai' ),
 						],
 					],
 					'permission_callback' => [ $this, 'generate_key_takeaways_permissions_check' ],
@@ -193,6 +215,7 @@ class KeyTakeaways extends Feature {
 						'content' => $request->get_param( 'content' ),
 						'title'   => $request->get_param( 'title' ),
 						'render'  => $request->get_param( 'render' ),
+						'run'     => $request->get_param( 'run' ),
 					]
 				)
 			);

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -699,6 +699,7 @@ class OpenAI extends Provider {
 				'content' => '',
 				'title'   => get_the_title( $post_id ),
 				'render'  => 'list',
+				'run'     => 'auto',
 			]
 		);
 
@@ -706,6 +707,33 @@ class OpenAI extends Provider {
 		// but we run them again here in case this method is called directly.
 		if ( empty( $settings ) || ( isset( $settings[ static::ID ]['authenticated'] ) && false === $settings[ static::ID ]['authenticated'] ) || ( ! $feature->is_feature_enabled() && ( ! defined( 'WP_CLI' ) || ! WP_CLI ) ) ) {
 			return new WP_Error( 'not_enabled', esc_html__( 'Key Takeaways generation is disabled or authentication failed. Please check your settings.', 'classifai' ) );
+		}
+
+		/**
+		 * Decide if we should automatically run the key takeaways generation.
+		 *
+		 * By default, we will always run the generation. If you
+		 * only want to run when triggered manually, you can
+		 * filter the return value to false.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_azure_openai_key_takeaways_auto_run
+		 *
+		 * @param {bool} $run Whether to run the key takeaways generation.
+		 * @param {int} $post_id ID of post we are summarizing.
+		 *
+		 * @return {bool} Whether to run the key takeaways generation.
+		 */
+		$run = apply_filters( 'classifai_azure_openai_key_takeaways_auto_run', true, $post_id );
+
+		if ( 'auto' === $args['run'] && ! (bool) $run ) {
+			return new WP_Error( 'not_run', esc_html__( 'Automatic generation is disabled. Please click the "Refresh results" button when ready.', 'classifai' ) );
+		}
+
+		// Ensure we have content before making a request.
+		$content = $this->get_content( $post_id, 0, false, $args['content'] );
+		if ( empty( $content ) ) {
+			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Refresh results" button.', 'classifai' ) );
 		}
 
 		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->prompt );
@@ -749,7 +777,7 @@ class OpenAI extends Provider {
 					],
 					[
 						'role'    => 'user',
-						'content' => '"""' . $this->get_content( $post_id, 0, false, $args['content'] ) . '"""',
+						'content' => '"""' . $content . '"""',
 					],
 				],
 				'response_format' => [

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -728,13 +728,13 @@ class OpenAI extends Provider {
 		$run = apply_filters( 'classifai_azure_openai_key_takeaways_auto_run', true, $post_id );
 
 		if ( 'auto' === $args['run'] && ! (bool) $run ) {
-			return new WP_Error( 'not_run', esc_html__( 'Automatic generation is disabled. Please click the "Refresh results" button when ready.', 'classifai' ) );
+			return new WP_Error( 'not_run', esc_html__( 'Automatic generation is disabled. Please click the "Generate results" button when ready.', 'classifai' ) );
 		}
 
 		// Ensure we have content before making a request.
 		$content = $this->get_content( $post_id, 0, false, $args['content'] );
 		if ( empty( $content ) ) {
-			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Refresh results" button.', 'classifai' ) );
+			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Generate results" button.', 'classifai' ) );
 		}
 
 		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->prompt );

--- a/includes/Classifai/Providers/Localhost/Ollama.php
+++ b/includes/Classifai/Providers/Localhost/Ollama.php
@@ -511,13 +511,13 @@ class Ollama extends Provider {
 		$run = apply_filters( 'classifai_ollama_key_takeaways_auto_run', true, $post_id );
 
 		if ( 'auto' === $args['run'] && ! (bool) $run ) {
-			return new WP_Error( 'not_run', esc_html__( 'Automatic generation is disabled. Please click the "Refresh results" button when ready.', 'classifai' ) );
+			return new WP_Error( 'not_run', esc_html__( 'Automatic generation is disabled. Please click the "Generate results" button when ready.', 'classifai' ) );
 		}
 
 		// Ensure we have content before making a request.
 		$content = $this->get_content( $post_id, false, $args['content'] );
 		if ( empty( $content ) ) {
-			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Refresh results" button.', 'classifai' ) );
+			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Generate results" button.', 'classifai' ) );
 		}
 
 		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->prompt );

--- a/includes/Classifai/Providers/Localhost/Ollama.php
+++ b/includes/Classifai/Providers/Localhost/Ollama.php
@@ -482,6 +482,7 @@ class Ollama extends Provider {
 				'content' => '',
 				'title'   => get_the_title( $post_id ),
 				'render'  => 'list',
+				'run'     => 'auto',
 			]
 		);
 
@@ -489,6 +490,33 @@ class Ollama extends Provider {
 		// but we run them again here in case this method is called directly.
 		if ( empty( $settings ) || ( isset( $settings[ static::ID ]['authenticated'] ) && false === $settings[ static::ID ]['authenticated'] ) || ( ! $feature->is_feature_enabled() && ( ! defined( 'WP_CLI' ) || ! WP_CLI ) ) ) {
 			return new WP_Error( 'not_enabled', esc_html__( 'Key Takeaways generation is disabled or authentication failed. Please check your settings.', 'classifai' ) );
+		}
+
+		/**
+		 * Decide if we should automatically run the key takeaways generation.
+		 *
+		 * By default, we will always run the generation. If you
+		 * only want to run when triggered manually, you can
+		 * filter the return value to false.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_ollama_key_takeaways_auto_run
+		 *
+		 * @param {bool} $run Whether to run the key takeaways generation.
+		 * @param {int} $post_id ID of post we are summarizing.
+		 *
+		 * @return {bool} Whether to run the key takeaways generation.
+		 */
+		$run = apply_filters( 'classifai_ollama_key_takeaways_auto_run', true, $post_id );
+
+		if ( 'auto' === $args['run'] && ! (bool) $run ) {
+			return new WP_Error( 'not_run', esc_html__( 'Automatic generation is disabled. Please click the "Refresh results" button when ready.', 'classifai' ) );
+		}
+
+		// Ensure we have content before making a request.
+		$content = $this->get_content( $post_id, false, $args['content'] );
+		if ( empty( $content ) ) {
+			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Refresh results" button.', 'classifai' ) );
 		}
 
 		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->prompt );
@@ -533,7 +561,7 @@ class Ollama extends Provider {
 					],
 					[
 						'role'    => 'user',
-						'content' => '"""' . $this->get_content( $post_id, false, $args['content'] ) . '"""',
+						'content' => '"""' . $content . '"""',
 					],
 				],
 				'format'   => 'json',

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -913,6 +913,12 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Key Takeaways generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
+		// Ensure we have content before making a request.
+		$content = $this->get_content( $post_id, 0, false, $args['content'] );
+		if ( empty( $content ) ) {
+			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then refresh results from the block settings.', 'classifai' ) );
+		}
+
 		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
 
 		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->prompt );
@@ -957,7 +963,7 @@ class ChatGPT extends Provider {
 					],
 					[
 						'role'    => 'user',
-						'content' => '"""' . $this->get_content( $post_id, 0, false, $args['content'] ) . '"""',
+						'content' => '"""' . $content . '"""',
 					],
 				],
 				'response_format' => [

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -932,7 +932,7 @@ class ChatGPT extends Provider {
 		$run = apply_filters( 'classifai_chatgpt_key_takeaways_auto_run', true, $post_id );
 
 		if ( 'auto' === $args['run'] && ! (bool) $run ) {
-			return new WP_Error( 'not_run', esc_html__( 'Automatic generation is disabled. Please run the generation from the block settings.', 'classifai' ) );
+			return new WP_Error( 'not_run', esc_html__( 'Automatic generation is disabled. Please click the "Refresh results" button when ready.', 'classifai' ) );
 		}
 
 		// Ensure we have content before making a request.

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -904,6 +904,7 @@ class ChatGPT extends Provider {
 				'content' => '',
 				'title'   => get_the_title( $post_id ),
 				'render'  => 'list',
+				'run'     => 'auto',
 			]
 		);
 
@@ -911,6 +912,27 @@ class ChatGPT extends Provider {
 		// but we run them again here in case this method is called directly.
 		if ( empty( $settings ) || ( isset( $settings[ static::ID ]['authenticated'] ) && false === $settings[ static::ID ]['authenticated'] ) || ( ! $feature->is_feature_enabled() && ( ! defined( 'WP_CLI' ) || ! WP_CLI ) ) ) {
 			return new WP_Error( 'not_enabled', esc_html__( 'Key Takeaways generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
+		}
+
+		/**
+		 * Decide if we should automatically run the key takeaways generation.
+		 *
+		 * By default, we will always run the generation. If you
+		 * only want to run when triggered manually, you can
+		 * filter the return value to false.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_chatgpt_key_takeaways_auto_run
+		 *
+		 * @param {bool} $run Whether to run the key takeaways generation.
+		 * @param {int} $post_id ID of post we are summarizing.
+		 *
+		 * @return {bool} Whether to run the key takeaways generation.
+		 */
+		$run = apply_filters( 'classifai_chatgpt_key_takeaways_auto_run', true, $post_id );
+
+		if ( 'auto' === $args['run'] && ! (bool) $run ) {
+			return new WP_Error( 'not_run', esc_html__( 'Automatic generation is disabled. Please run the generation from the block settings.', 'classifai' ) );
 		}
 
 		// Ensure we have content before making a request.

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -938,7 +938,7 @@ class ChatGPT extends Provider {
 		// Ensure we have content before making a request.
 		$content = $this->get_content( $post_id, 0, false, $args['content'] );
 		if ( empty( $content ) ) {
-			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then refresh results from the block settings.', 'classifai' ) );
+			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Refresh results" button.', 'classifai' ) );
 		}
 
 		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -952,13 +952,13 @@ class ChatGPT extends Provider {
 		$run = apply_filters( 'classifai_chatgpt_key_takeaways_auto_run', true, $post_id );
 
 		if ( 'auto' === $args['run'] && ! (bool) $run ) {
-			return new WP_Error( 'not_run', esc_html__( 'Automatic generation is disabled. Please click the "Refresh results" button when ready.', 'classifai' ) );
+			return new WP_Error( 'not_run', esc_html__( 'Automatic generation is disabled. Please click the "Generate results" button when ready.', 'classifai' ) );
 		}
 
 		// Ensure we have content before making a request.
 		$content = $this->get_content( $post_id, 0, false, $args['content'] );
 		if ( empty( $content ) ) {
-			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Refresh results" button.', 'classifai' ) );
+			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Generate results" button.', 'classifai' ) );
 		}
 
 		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );

--- a/tests/cypress/integration/language-processing/key-takeaways-azure-openai.test.js
+++ b/tests/cypress/integration/language-processing/key-takeaways-azure-openai.test.js
@@ -39,7 +39,7 @@ describe( '[Language processing] Key Takeaways Tests', () => {
 		} ).then( () => {
 			cy.getBlockEditor()
 				.find(
-					'.wp-block-classifai-key-takeaways .wp-block-classifai-key-takeways__content'
+					'.wp-block-classifai-key-takeaways .components-placeholder__fieldset'
 				)
 				.should( 'contain.text', 'Request failed' );
 		} );

--- a/tests/cypress/integration/language-processing/key-takeaways-ollama.test.js
+++ b/tests/cypress/integration/language-processing/key-takeaways-ollama.test.js
@@ -37,7 +37,7 @@ describe( '[Language processing] Key Takeaways Tests', () => {
 		} ).then( () => {
 			cy.getBlockEditor()
 				.find(
-					'.wp-block-classifai-key-takeaways .wp-block-classifai-key-takeways__content'
+					'.wp-block-classifai-key-takeaways .components-placeholder__fieldset'
 				)
 				.should( 'contain.text', 'Ollama request failed' );
 		} );

--- a/tests/cypress/integration/language-processing/key-takeaways-openai-chatgpt.test.js
+++ b/tests/cypress/integration/language-processing/key-takeaways-openai-chatgpt.test.js
@@ -35,7 +35,7 @@ describe( '[Language processing] Key Takeaways Tests', () => {
 		} ).then( () => {
 			cy.getBlockEditor()
 				.find(
-					'.wp-block-classifai-key-takeaways .wp-block-classifai-key-takeways__content'
+					'.wp-block-classifai-key-takeaways .components-placeholder__fieldset'
 				)
 				.should( 'contain.text', 'OpenAI request failed' );
 		} );


### PR DESCRIPTION
### Description of the Change

This PR brings a number of fixes/adjustments to the Key Takeaways Feature:

- Add a new error state to the block, instead of rendering errors as Key Takeaways. This makes it more clear when an error occurs and also prevents these errors from being rendered on the front-end
- If we have no Key Takeaways, don't render the block at all on the front-end
- If we have no content to process, don't make an API request and instead show an error message
- Add new filter that allows users to turn on automatic processing. By default, Key Takeaways are generated as soon as the block is added. Some sites may automatically inject this block on all posts and they don't want to generate Key Takeaways until the post is done. Using this new filter allows this workflow

### Screenshots

<img width="717" alt="New error state when no content is found" src="https://github.com/user-attachments/assets/e60715f3-e694-4f1d-ad03-c996e2ec0776" />

<img width="714" alt="New error state when automatic generation is disabled" src="https://github.com/user-attachments/assets/53fb4af2-bd1c-4f33-991a-c6e6b81c016a" />

<img width="754" alt="New error state when an API error occurs" src="https://github.com/user-attachments/assets/0da8ec9d-197d-4633-9faa-498a1b7c8789" />

### How to test the Change

1. Configure the Key Takeaways Feature
2. Create a new post and add the Key Takeaways block and nothing else. Ensure a proper error message shows
3. View the front-end and ensure the block doesn't render
4. Add some content to this post and manually trigger Key Takeaways generation, ensuring this works
5. In a separate plugin, utilize one of the new filters to turn off automatic processing: `add_filter( 'classifai_chatgpt_key_takeaways_auto_run', '__return_false' );`
6. Create a new post, add content to this post and then add the Key Takeaways block. Ensure a proper error message shows
7. Manually trigger generation of Key Takeaways and ensure this works
8. Remove custom filter, create another new post, add content to this post and then add the Key Takeaways block. Ensure generation happens automatically

### Changelog Entry

> Added - New filters, `classifai_chatgpt_key_takeaways_auto_run`, `classifai_ollama_key_takeaways_auto_run`, `classifai_azure_openai_key_takeaways_auto_run`, that allow turning off automatic processing of Key Takeaways
> Changed - New error state in the Key Takeaways block, making it more clear when an error occurs
> Fixed - Don't render the Key Takeaways block if we have no Key Takeaways to show

### Credits

Props @gsarig, @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
