### PR TITLE
Allow HTML in error responses from API requests

### DIFF
--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -814,7 +814,7 @@ class OpenAI extends Provider {
 				// If the request was refused, return an error.
 				if ( isset( $choice['message'], $choice['message']['refusal'] ) ) {
 					// translators: %s: error message.
-					return new WP_Error( 'refusal', sprintf( esc_html__( 'Request failed: %s', 'classifai' ), esc_html( $choice['message']['refusal'] ) ) );
+					return new WP_Error( 'refusal', sprintf( esc_html__( 'Request failed: %s', 'classifai' ), wp_kses_post( $choice['message']['refusal'] ) ) );
 				}
 			}
 		}

--- a/includes/Classifai/Providers/Azure/Speech.php
+++ b/includes/Classifai/Providers/Azure/Speech.php
@@ -391,7 +391,7 @@ class Speech extends Provider {
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error(
 				'azure_text_to_speech_http_error',
-				esc_html( $response->get_error_message() )
+				wp_kses_post( $response->get_error_message() )
 			);
 		}
 

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -1036,7 +1036,7 @@ class ChatGPT extends Provider {
 				// If the request was refused, return an error.
 				if ( isset( $choice['message'], $choice['message']['refusal'] ) ) {
 					// translators: %s: error message.
-					return new WP_Error( 'refusal', sprintf( esc_html__( 'OpenAI request failed: %s', 'classifai' ), esc_html( $choice['message']['refusal'] ) ) );
+					return new WP_Error( 'refusal', sprintf( esc_html__( 'OpenAI request failed: %s', 'classifai' ), wp_kses_post( $choice['message']['refusal'] ) ) );
 				}
 			}
 		}

--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -372,7 +372,7 @@ class TextToSpeech extends Provider {
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error(
 				'openai_text_to_speech_http_error',
-				esc_html( $response->get_error_message() )
+				wp_kses_post( $response->get_error_message() )
 			);
 		}
 


### PR DESCRIPTION
### Description of the Change

Was helping debug some issues on a site that wanted to try out ClassifAI and when trying to run the Text to Speech Feature, they were getting an error. This error was hard to parse as it had characters in it that were being escaped. Looking into it, we were running `esc_html` on this response, which is great but when a response does contain HTML, this results in hard to parse error messages.

This PR updates any places we were using `esc_html` on API responses to use `wp_kses_post` instead, which will allow most HTML to come through.

### Screenshots

**Before**

![Text to Speech HTML escaped error message](https://github.com/user-attachments/assets/8ea5f35a-2b1e-4605-b6d5-d1bde3a66b07)

**After**

![Text to Speech properly escaped error message](https://github.com/user-attachments/assets/83485d98-202d-4fa2-ba46-3a1c07e0bf80)

### How to test the Change

Mostly just need a code review here but if you want to test more thoroughly, the easiest way I found to reproduce an error is in the OpenAI Text To Speech Provider class. Modify the request body we send to have an invalid value in the `voice` parameter (change it to something like `test`). This will result in an error coming back from the API and you should see no escaped HTML in that message.

### Changelog Entry

> Fixed - Ensure API error messages aren't fully HTML escaped so they are easier to read and understand

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
