### PR TITLE
Ensure any post statuses we render don't show any HTML or entities

### DIFF
--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -415,7 +415,7 @@ function get_all_post_statuses(): array {
 	);
 
 	// Remove any HTML from the statuses.
-	$all_statuses = array_map( 'strip_tags', $all_statuses );
+	$all_statuses = array_map( 'wp_strip_all_tags', $all_statuses );
 
 	/*
 	 * There is a minor difference in the label for 'pending' status between

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -414,6 +414,9 @@ function get_all_post_statuses(): array {
 		$all_statuses['request-completed']
 	);
 
+	// Remove any HTML from the statuses.
+	$all_statuses = array_map( 'strip_tags', $all_statuses );
+
 	/*
 	 * There is a minor difference in the label for 'pending' status between
 	 * `get_post_statuses()` and `get_post_stati()`.

--- a/src/js/settings/components/feature-additional-settings/classification.js
+++ b/src/js/settings/components/feature-additional-settings/classification.js
@@ -18,6 +18,7 @@ import { useState, useEffect, useContext, useRef } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -260,7 +261,7 @@ export const ClassificationSettings = () => {
 							checked={
 								featureSettings.post_statuses?.[ key ] === key
 							}
-							label={ postStatuses?.[ key ] }
+							label={ decodeEntities( postStatuses?.[ key ] ) }
 							onChange={ ( value ) => {
 								setFeatureSettings( {
 									post_statuses: {


### PR DESCRIPTION
### Description of the Change

As mentioned in #777, some plugins register custom post statuses that have HTML in their labels. This HTML then shows up when we render these in our settings page.

This PR fixes that by stripping any HTML from these post statuses before we use them. In addition, adding a decode entities function that we use before render to ensure things like ampersands render properly.

Note: this issue was found when using WooCommerce and WooCommerce Bookings. These two add lots of custom post statuses and may be worth a discussion to see if we should automatically remove some of these. For instance, don't think we'll ever need/want to run functionality on `was-in-cart` or `In Cart` post statuses.
 
Closes #777 

### How to test the Change

1. Make sure WooCommerce and WooCommerce Bookings plugins are active (or register your own custom statuses that have HTML)
2. Go to Tools > ClassifAI > Language Processing > Classification
3. Ensure the Post statuses render without HTML

### Changelog Entry

> Fixed - Remove HTML from post statuses before rendering those in our settings

### Credits

Props @faisal-alvi, @dkotter 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
