### PR TITLE
Ensure we return API error when generating embeddings to avoid infinite loops

### DIFF
--- a/includes/Classifai/Providers/Azure/Embeddings.php
+++ b/includes/Classifai/Providers/Azure/Embeddings.php
@@ -366,11 +366,11 @@ class Embeddings extends OpenAI {
 	}
 
 	/**
-	 * Trigger embedding generation for content being saved.
+	 * Trigger embedding generation for a post.
 	 *
-	 * @param int  $post_id ID of post being saved.
+	 * @param int  $post_id ID of post.
 	 * @param bool $force Whether to force generation of embeddings even if they already exist. Default false.
-	 * @return array|WP_Error
+	 * @return array[]|WP_Error Array of embedding vectors on success, WP_Error on failure.
 	 */
 	public function generate_embeddings_for_post( int $post_id, bool $force = false ) {
 		// Don't run on autosaves.

--- a/includes/Classifai/Providers/Azure/Embeddings.php
+++ b/includes/Classifai/Providers/Azure/Embeddings.php
@@ -427,6 +427,8 @@ class Embeddings extends OpenAI {
 
 					if ( $embedding && ! is_wp_error( $embedding ) ) {
 						$embeddings[] = array_map( 'floatval', $embedding );
+					} elseif ( is_wp_error( $embedding ) ) {
+						return $embedding;
 					}
 				}
 			} else {
@@ -440,6 +442,8 @@ class Embeddings extends OpenAI {
 						},
 						$all_embeddings
 					);
+				} elseif ( is_wp_error( $all_embeddings ) ) {
+					return $all_embeddings;
 				}
 			}
 		}
@@ -934,6 +938,8 @@ class Embeddings extends OpenAI {
 
 				if ( $embedding && ! is_wp_error( $embedding ) ) {
 					$embeddings[] = array_map( 'floatval', $embedding );
+				} elseif ( is_wp_error( $embedding ) ) {
+					return $embedding;
 				}
 			}
 		}

--- a/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
+++ b/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
@@ -503,6 +503,8 @@ class OllamaEmbeddings extends Ollama {
 
 					if ( $embedding && ! is_wp_error( $embedding ) ) {
 						$embeddings[] = array_map( 'floatval', $embedding );
+					} elseif ( is_wp_error( $embedding ) ) {
+						return $embedding;
 					}
 				}
 			} else {
@@ -516,6 +518,8 @@ class OllamaEmbeddings extends Ollama {
 						},
 						$all_embeddings
 					);
+				} elseif ( is_wp_error( $all_embeddings ) ) {
+					return $all_embeddings;
 				}
 			}
 		}
@@ -1011,6 +1015,8 @@ class OllamaEmbeddings extends Ollama {
 
 				if ( $embedding && ! is_wp_error( $embedding ) ) {
 					$embeddings[] = array_map( 'floatval', $embedding );
+				} elseif ( is_wp_error( $embedding ) ) {
+					return $embedding;
 				}
 			}
 		}

--- a/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
+++ b/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
@@ -439,11 +439,11 @@ class OllamaEmbeddings extends Ollama {
 	}
 
 	/**
-	 * Trigger embedding generation for a post item.
+	 * Trigger embedding generation for a post.
 	 *
 	 * @param int  $post_id ID of post.
 	 * @param bool $force Whether to force generation of embeddings even if they already exist. Default false.
-	 * @return array|WP_Error
+	 * @return array[]|WP_Error Array of embedding vectors on success, WP_Error on failure.
 	 */
 	public function generate_embeddings_for_post( int $post_id, bool $force = false ) {
 		// Don't run on autosaves.

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -587,12 +587,12 @@ class Embeddings extends Provider {
 	}
 
 	/**
-	 * Trigger embedding generation for content being saved.
+	 * Trigger embedding generation for a post.
 	 *
-	 * @param int          $post_id ID of post being saved.
+	 * @param int          $post_id ID of post.
 	 * @param bool         $force Whether to force generation of embeddings even if they already exist. Default false.
 	 * @param Feature|null $feature The feature instance.
-	 * @return array|WP_Error
+	 * @return array[]|WP_Error Array of embedding vectors on success, WP_Error on failure.
 	 */
 	public function generate_embeddings_for_post( int $post_id, bool $force = false, $feature = null ) {
 		// Don't run on autosaves.

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -1430,6 +1430,8 @@ class Embeddings extends Provider {
 
 				if ( $embedding && ! is_wp_error( $embedding ) ) {
 					$embeddings[] = array_map( 'floatval', $embedding );
+				} elseif ( is_wp_error( $embedding ) ) {
+					return $embedding;
 				}
 			}
 		}


### PR DESCRIPTION
### Description of the Change

Was helping diagnose some issues on a client site and it appeared when generating embeddings for terms (when using OpenAI as the Provider for the Classification Feature) that we were getting stuck in an infinite loop with Action Scheduler.

In doing some testing locally, I think I figured out the issue. If we encounter an API error when generating an embedding for a term, we don't ever return that error and thus we continue to process that same term (or terms) over and over again with the same result. We previously fixed this for post embeddings but missed it for term embeddings, so this PR brings that same handling over.

In addition, we were missing both post and term error handling in our other embedding Providers so this PR fixes that as well.

### How to test the Change

Tricky to test this as it requires a situation where you have a valid API key (so you can configure the Provider properly) but the API key doesn't have access to make requests. Can also modify the code to always return an error for easier testing.

1. Enable the Classification Feature with OpenAI as the Provider
2. (Tricky part) Add an API key that is valid but doesn't have access to generate embeddings (I tested this with my personal account that has no credits associated with it)
3. May need to save twice to get embedding generation to start (this is another bug we need to fix). You should see a message saying embedding generation in progress
4. Validate within the Action Scheduler page that the process stops after processing all terms. Previously the same Action Scheduler event would be scheduled over and over

### Changelog Entry

> Fixed - Ensure if an API error occurs when generating embeddings, we don't try to keep processing that item and end up in an infinite loop

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
