### PR TITLE
Fix: Key Takeaways block className

### DIFF
--- a/includes/Classifai/Blocks/key-takeaways/edit.js
+++ b/includes/Classifai/Blocks/key-takeaways/edit.js
@@ -217,7 +217,7 @@ const BlockEdit = ( props ) => {
 						placeholder="Key Takeaways"
 					/>
 					<div
-						className="wp-block-classifai-key-takeways__content"
+						className="wp-block-classifai-key-takeaways__content"
 						style={ { fontStyle: 'italic' } }
 					>
 						{ render === 'list' && (


### PR DESCRIPTION
### Description of the Change
This issue is described in https://github.com/10up/classifai/issues/950. The PR fixes a typo in `edit.js` of the Key Takeaways block, so that the CSS class for block content in the editor matches the CSS class for block content on the front end.

Closes https://github.com/10up/classifai/issues/950

### How to test the Change

1. Add a Key Takeaways block.
2. Add custom CSS, in your theme or plugin, targetting the block title (`.wp-block-classifai-key-takeaways__title.wp-block-classifai-key-takeaways__title`) and content (`.wp-block-classifai-key-takeaways__content`).
3. There should be no difference between styling on the front end and the back end.

### Changelog Entry
> Fixed - Key Takeaways block editor class name.

### Credits
Props @mattradford-sage

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
