### PR TITLE
Fix/933 : Add registration message on Installed Plugins screen

### DIFF
--- a/includes/Classifai/Admin/Notifications.php
+++ b/includes/Classifai/Admin/Notifications.php
@@ -30,7 +30,6 @@ class Notifications {
 		add_action( 'admin_notices', [ $this, 'maybe_render_notices' ], 0 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'add_dismiss_script' ] );
 		add_action( 'wp_ajax_classifai_dismiss_notice', [ $this, 'ajax_maybe_dismiss_notice' ] );
-		add_action( 'after_plugin_row', [ $this, 'update_notice' ], 10, 3 );
 	}
 
 	/**
@@ -398,39 +397,5 @@ EOD;
 			'message' => $message,
 		];
 		set_transient( 'classifai_notices', $notices );
-	}
-
-	/**
-	 * Under plugin row update notice
-	 *
-	 * @param  string $plugin_file Plugin file path.
-	 * @return
-	 */
-	public function update_notice( $plugin_file ) {
-
-		if ( CLASSIFAI_PLUGIN_BASENAME !== $plugin_file ) {
-			return;
-		}
-
-		$registration_settings = get_option( 'classifai_settings' );
-
-		if ( ! isset( $registration_settings['valid_license'] ) || ! $registration_settings['valid_license'] ) {
-
-			$notice_url = 'https://classifaiplugin.com/#cta';
-			?>
-
-			<tr class="plugin-update-tr active" id="classifai-update" >
-				<td colspan="4" class="plugin-update colspanchange">
-					<div class="update-message notice inline notice-warning notice-alt">
-						<p>
-							<?php /* translators: %s: distributor notice url */ ?>
-							<?php echo wp_kses_post( sprintf( __( '<a href="%s" target="_blank" rel="noopener noreferrer">Register</a> for a free ClassifAI key to receive automatic plugin updates.', 'classifai' ), esc_url( $notice_url ) ) ); ?>
-						</p>
-					</div>
-				</td>
-			</tr>
-
-			<?php
-		}
 	}
 }

--- a/includes/Classifai/Admin/Notifications.php
+++ b/includes/Classifai/Admin/Notifications.php
@@ -30,6 +30,7 @@ class Notifications {
 		add_action( 'admin_notices', [ $this, 'maybe_render_notices' ], 0 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'add_dismiss_script' ] );
 		add_action( 'wp_ajax_classifai_dismiss_notice', [ $this, 'ajax_maybe_dismiss_notice' ] );
+		add_action( 'after_plugin_row', [ $this, 'update_notice' ], 10, 3 );
 	}
 
 	/**
@@ -397,5 +398,39 @@ EOD;
 			'message' => $message,
 		];
 		set_transient( 'classifai_notices', $notices );
+	}
+
+	/**
+	 * Under plugin row update notice
+	 *
+	 * @param  string $plugin_file Plugin file path.
+	 * @return
+	 */
+	public function update_notice( $plugin_file ) {
+
+		if ( CLASSIFAI_PLUGIN_BASENAME !== $plugin_file ) {
+			return;
+		}
+
+		$registration_settings = get_option( 'classifai_settings' );
+
+		if ( ! isset( $registration_settings['valid_license'] ) || ! $registration_settings['valid_license'] ) {
+
+			$notice_url = 'https://classifaiplugin.com/#cta';
+			?>
+
+			<tr class="plugin-update-tr active" id="classifai-update" >
+				<td colspan="4" class="plugin-update colspanchange">
+					<div class="update-message notice inline notice-warning notice-alt">
+						<p>
+							<?php /* translators: %s: distributor notice url */ ?>
+							<?php echo wp_kses_post( sprintf( __( '<a href="%s" target="_blank" rel="noopener noreferrer">Register</a> for a free ClassifAI key to receive automatic plugin updates.', 'classifai' ), esc_url( $notice_url ) ) ); ?>
+						</p>
+					</div>
+				</td>
+			</tr>
+
+			<?php
+		}
 	}
 }

--- a/includes/Classifai/Admin/Settings.php
+++ b/includes/Classifai/Admin/Settings.php
@@ -28,7 +28,7 @@ class Settings {
 		add_action( 'admin_menu', [ $this, 'register_settings_page' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
-		add_action( 'after_plugin_row', [ $this, 'update_notice' ] );
+		add_action( 'after_plugin_row_' . CLASSIFAI_PLUGIN_BASENAME, [ $this, 'update_notice' ] );
 	}
 
 	/**
@@ -497,15 +497,9 @@ class Settings {
 	}
 
 	/**
-	 * Add link to the ClassifAI registration in the plugin row.
-	 *
-	 * @param string $plugin_file Plugin file path.
+	 * Add a link to the ClassifAI registration page in the plugin row.
 	 */
-	public function update_notice( $plugin_file ) {
-
-		if ( CLASSIFAI_PLUGIN_BASENAME !== $plugin_file ) {
-			return;
-		}
+	public function update_notice() {
 
 		$registration_settings = get_option( 'classifai_settings' );
 

--- a/includes/Classifai/Admin/Settings.php
+++ b/includes/Classifai/Admin/Settings.php
@@ -497,7 +497,7 @@ class Settings {
 	}
 
 	/**
-	 * Add link to the ClassifAI registration in the plugin row, if needed.
+	 * Add link to the ClassifAI registration in the plugin row.
 	 *
 	 * @param string $plugin_file Plugin file path.
 	 */
@@ -519,7 +519,6 @@ class Settings {
 			<td colspan="4" class="plugin-update colspanchange">
 				<div class="update-message notice inline notice-warning notice-alt">
 					<p>
-						<?php /* translators: %s: ClassifAI registration url */ ?>
 						<?php echo wp_kses_post( __( '<a href="https://classifaiplugin.com/#cta" target="_blank" rel="noopener noreferrer">Register</a> for a free ClassifAI key to receive automatic plugin updates.', 'classifai' ) ); ?>
 					</p>
 				</div>

--- a/includes/Classifai/Admin/Settings.php
+++ b/includes/Classifai/Admin/Settings.php
@@ -28,6 +28,7 @@ class Settings {
 		add_action( 'admin_menu', [ $this, 'register_settings_page' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+		add_action( 'after_plugin_row', [ $this, 'update_notice' ] );
 	}
 
 	/**
@@ -493,5 +494,38 @@ class Settings {
 		];
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Add link to the ClassifAI registration in the plugin row, if needed.
+	 *
+	 * @param string $plugin_file Plugin file path.
+	 */
+	public function update_notice( $plugin_file ) {
+
+		if ( CLASSIFAI_PLUGIN_BASENAME !== $plugin_file ) {
+			return;
+		}
+
+		$registration_settings = get_option( 'classifai_settings' );
+
+		if ( ! empty( $registration_settings['valid_license'] ) ) {
+			return;
+		}
+
+		?>
+
+		<tr class="plugin-update-tr active" id="classifai-update" >
+			<td colspan="4" class="plugin-update colspanchange">
+				<div class="update-message notice inline notice-warning notice-alt">
+					<p>
+						<?php /* translators: %s: ClassifAI registration url */ ?>
+						<?php echo wp_kses_post( __( '<a href="https://classifaiplugin.com/#cta" target="_blank" rel="noopener noreferrer">Register</a> for a free ClassifAI key to receive automatic plugin updates.', 'classifai' ) ); ?>
+					</p>
+				</div>
+			</td>
+		</tr>
+
+		<?php
 	}
 }

--- a/src/scss/admin.scss
+++ b/src/scss/admin.scss
@@ -1078,3 +1078,14 @@ table.similar_terms.widefat th {
 table.similar_terms.widefat thead th {
 	font-weight: bold;
 }
+
+#wpbody {
+
+	tr[data-slug="classifai"] {
+
+		th, td {
+			box-shadow: none;
+			border-bottom: 0;
+		}
+	}
+}


### PR DESCRIPTION
### Description of the Change

- Added registration message on Installed Plugins screen.

<img width="1294" alt="image" src="https://github.com/user-attachments/assets/c18fd7a2-039b-4d68-a02f-ed7eab7a35fd" />


Closes #933 

### How to test the Change

- Install & Activate plugin
- Go to Plugins and check plugin row

### Changelog Entry

> Added - Registration message on Installed Plugins screen


### Credits

Props @dkotter 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All existing tests pass. ( Haven't added any new test )
