### PR TITLE
Ensure we log errors appropriately in our image WP-CLI command

### DIFF
--- a/includes/Classifai/Command/ClassifaiCommand.php
+++ b/includes/Classifai/Command/ClassifaiCommand.php
@@ -903,12 +903,16 @@ class ClassifaiCommand extends \WP_CLI_Command {
 			$text_result = $text_feature->run( $attachment_id, 'descriptive_text' );
 			if ( $text_result && ! is_wp_error( $text_result ) ) {
 				$text_feature->save( $text_result, $attachment_id );
+			} elseif ( is_wp_error( $text_result ) ) {
+				$errors[ $attachment_id ] = $text_result;
 			}
 
 			$crop_result = $crop_feature->run( $attachment_id, 'crop' );
 			if ( ! empty( $crop_result ) && ! is_wp_error( $crop_result ) ) {
 				$meta = $crop_feature->save( $crop_result, $attachment_id );
 				wp_update_attachment_metadata( $attachment_id, $meta );
+			} elseif ( is_wp_error( $crop_result ) ) {
+				$errors[ $attachment_id ] = $crop_result;
 			}
 		}
 
@@ -920,7 +924,7 @@ class ClassifaiCommand extends \WP_CLI_Command {
 		\WP_CLI::success( "Classified $total_success images, $total_errors errors." );
 
 		foreach ( $errors as $attachment_id => $error ) {
-			\WP_CLI::log( $attachment_id . ': ' . $error->get_error_code() . ' - ' . $error->get_error_message() );
+			\WP_CLI::log( 'Attachment ID: ' . $attachment_id . ' - ' . $error->get_error_code() . ' - ' . $error->get_error_message() );
 		}
 	}
 


### PR DESCRIPTION
### Description of the Change

We have a number of WP-CLI commands that can be used to run functionality in ClassifAI. In recently testing our `image` command, noticed that we had code that would output any errors that were logged but we weren't actually logging errors if they occurred. This PR fixes that by ensure we save any errors so they can be output, making it easier to debug if something goes wrong.

### How to test the Change

1. Configure the Descriptive Text Generator Feature
2. Run the image WP-CLI command, ex `wp classifai image 4579`
3. Ensure this works properly
4. Disable the Feature and run the command again
5. Ensure an error message shows

### Changelog Entry

> Developer - Ensure error messages are properly logged when running the image WP-CLI command

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
