### PR TITLE
When saving settings, ensure the selected Provider is supported by the Feature

### DIFF
--- a/includes/Classifai/Admin/Settings.php
+++ b/includes/Classifai/Admin/Settings.php
@@ -338,8 +338,14 @@ class Settings {
 		foreach ( $settings as $feature_key => $feature_settings ) {
 			$feature = $features[ $feature_key ];
 
+			// Ensure this is a valid Feature.
 			if ( ! $feature ) {
-				return new \WP_Error( 'invalid_feature', __( 'Invalid feature.', 'classifai' ), [ 'status' => 400 ] );
+				return new \WP_Error( 'invalid_feature', __( 'Invalid Feature.', 'classifai' ), [ 'status' => 400 ] );
+			}
+
+			// Ensure the selected Provider is supported by the Feature.
+			if ( ! in_array( $feature_settings['provider'], array_keys( $feature->get_providers() ), true ) ) {
+				return new \WP_Error( 'invalid_provider', __( 'Invalid Provider.', 'classifai' ), [ 'status' => 400 ] );
 			}
 
 			// Skip sanitizing settings for setup step 1.


### PR DESCRIPTION
### Description of the Change

Minor fix to ensure that when Feature settings are saved, that the Provider selected for that Feature is actually supported. This isn't something that should ever happen but seems like a nice check to add in.

### How to test the Change

Not really a great way to fully test this (this was something flagged in a security report but without details on reproduction).

Would suggest just ensuring that saving settings works as expected

### Changelog Entry

> Fixed - Ensure a Feature supports a Provider before we save that Provider with the Feature settings.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
