### PR TITLE
Increase precision of thresholds to allow 2 decimals

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -37,4 +37,5 @@ jobs:
           build-dir: ${{ github.event.repository.name }}
           exclude-checks: 'plugin_readme,plugin_updater' # Plugin isn't on .org so excluding these for now.
           exclude-directories: 'assets,dist,vendor'
+          ignore-codes: 'PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound' # Plugin isn't on .org so we load the textdomain manually.
           ignore-warnings: true

--- a/includes/Classifai/Features/Classification.php
+++ b/includes/Classifai/Features/Classification.php
@@ -893,7 +893,7 @@ class Classification extends Feature {
 		if ( ! empty( $provider_instance->nlu_features ) ) {
 			foreach ( array_keys( $provider_instance->nlu_features ) as $feature_name ) {
 				$new_settings[ $feature_name ]               = absint( $new_settings[ $feature_name ] ?? $settings[ $feature_name ] );
-				$new_settings[ "{$feature_name}_threshold" ] = absint( $new_settings[ "{$feature_name}_threshold" ] ?? $settings[ "{$feature_name}_threshold" ] );
+				$new_settings[ "{$feature_name}_threshold" ] = floatval( $new_settings[ "{$feature_name}_threshold" ] ?? $settings[ "{$feature_name}_threshold" ] );
 				$new_settings[ "{$feature_name}_taxonomy" ]  = sanitize_text_field( $new_settings[ "{$feature_name}_taxonomy" ] ?? $settings[ "{$feature_name}_taxonomy" ] );
 			}
 		}
@@ -963,6 +963,9 @@ class Classification extends Feature {
 			'label_for'     => "{$feature}_threshold",
 			'input_type'    => 'number',
 			'default_value' => $labels['threshold_default'],
+			'min'           => 0,
+			'max'           => 100,
+			'step'          => 0.01,
 		];
 		?>
 

--- a/includes/Classifai/Features/TermCleanup.php
+++ b/includes/Classifai/Features/TermCleanup.php
@@ -515,11 +515,11 @@ class TermCleanup extends Feature {
 	 * Get similar terms.
 	 *
 	 * @param string $taxonomy Taxonomy to process.
-	 * @param int    $threshold Threshold to consider terms as duplicates.
+	 * @param float  $threshold Threshold to consider terms as duplicates.
 	 * @param array  $args     Additional arguments.
 	 * @return array|bool|WP_Error
 	 */
-	public function get_similar_terms( string $taxonomy, int $threshold, array $args = [] ) {
+	public function get_similar_terms( string $taxonomy, float $threshold, array $args = [] ) {
 		if ( class_exists( '\\ElasticPress\\Feature' ) && '1' === $this->get_settings( 'use_ep' ) ) {
 			return $this->get_similar_terms_using_elasticpress( $taxonomy, $threshold, $args );
 		}
@@ -535,11 +535,11 @@ class TermCleanup extends Feature {
 	 * when ElasticPress is not installed or not in use.
 	 *
 	 * @param string $taxonomy Taxonomy to process.
-	 * @param int    $threshold Threshold to consider terms as duplicates.
+	 * @param float  $threshold Threshold to consider terms as duplicates.
 	 * @param array  $args     Additional arguments.
 	 * @return array|bool
 	 */
-	public function get_similar_terms_using_wpdb( string $taxonomy, int $threshold, array $args = [] ) {
+	public function get_similar_terms_using_wpdb( string $taxonomy, float $threshold, array $args = [] ) {
 		$processed = $args['processed'] ?? 0;
 		$term_id   = $args['term_id'] ?? 0;
 		$offset    = $args['offset'] ?? 0;
@@ -655,11 +655,11 @@ class TermCleanup extends Feature {
 	 * Get similar terms using Elasticsearch via ElasticPress.
 	 *
 	 * @param string $taxonomy Taxonomy to process.
-	 * @param int    $threshold Threshold to consider terms as duplicates.
+	 * @param float  $threshold Threshold to consider terms as duplicates.
 	 * @param array  $args     Additional arguments.
 	 * @return array|bool|WP_Error
 	 */
-	public function get_similar_terms_using_elasticpress( string $taxonomy, int $threshold, array $args = [] ) {
+	public function get_similar_terms_using_elasticpress( string $taxonomy, float $threshold, array $args = [] ) {
 		$processed = $args['processed'] ?? 0;
 		$meta_key  = sanitize_text_field( $this->get_embeddings_meta_key() );
 

--- a/includes/Classifai/Features/TermCleanup.php
+++ b/includes/Classifai/Features/TermCleanup.php
@@ -361,7 +361,7 @@ class TermCleanup extends Feature {
 
 		$settings  = $this->get_settings( 'taxonomies' );
 		$taxonomy  = isset( $_POST['classifai_term_cleanup_taxonomy'] ) ? sanitize_text_field( wp_unslash( $_POST['classifai_term_cleanup_taxonomy'] ) ) : '';
-		$threshold = isset( $settings[ $taxonomy . '_threshold' ] ) ? absint( $settings[ $taxonomy . '_threshold' ] ) : 75;
+		$threshold = isset( $settings[ $taxonomy . '_threshold' ] ) ? floatval( $settings[ $taxonomy . '_threshold' ] ) : 75;
 
 		if ( empty( $taxonomy ) ) {
 			wp_die( esc_html__( 'Invalid taxonomy.', 'classifai' ) );

--- a/includes/Classifai/Features/TermCleanupEPIntegration.php
+++ b/includes/Classifai/Features/TermCleanupEPIntegration.php
@@ -175,7 +175,7 @@ class TermCleanupEPIntegration {
 	 * @param int    $term_id Term ID to search for.
 	 * @param string $index Indexable to run the query against. Default term.
 	 * @param int    $num Number of items to return.
-	 * @param int    $threshold Threshold for the minimum score.
+	 * @param float  $threshold Threshold for the minimum score.
 	 * @return array|WP_Error
 	 */
 	public function exact_knn_search( int $term_id, string $index = 'term', int $num = 1000, $threshold = 75 ) {

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -242,11 +242,11 @@ class ComputerVision extends Provider {
 		}
 
 		if ( $this->feature_instance instanceof DescriptiveTextGenerator ) {
-			$new_settings[ static::ID ]['descriptive_confidence_threshold'] = absint( $new_settings[ static::ID ]['descriptive_confidence_threshold'] ?? $settings[ static::ID ]['descriptive_confidence_threshold'] );
+			$new_settings[ static::ID ]['descriptive_confidence_threshold'] = floatval( $new_settings[ static::ID ]['descriptive_confidence_threshold'] ?? $settings[ static::ID ]['descriptive_confidence_threshold'] );
 		}
 
 		if ( $this->feature_instance instanceof ImageTagsGenerator ) {
-			$new_settings[ static::ID ]['tag_confidence_threshold'] = absint( $new_settings[ static::ID ]['tag_confidence_threshold'] ?? $settings[ static::ID ]['tag_confidence_threshold'] );
+			$new_settings[ static::ID ]['tag_confidence_threshold'] = floatval( $new_settings[ static::ID ]['tag_confidence_threshold'] ?? $settings[ static::ID ]['tag_confidence_threshold'] );
 		}
 
 		return $new_settings;

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -526,7 +526,7 @@ class ComputerVision extends Provider {
 				 * @hook classifai_computer_vision_caption_failed
 				 *
 				 * @param {array} $caption   The caption data.
-				 * @param {int}   $threshold The caption_threshold setting.
+				 * @param {float} $threshold The caption_threshold setting.
 				 */
 				do_action( 'classifai_computer_vision_caption_failed', $caption, $threshold );
 			}
@@ -629,7 +629,7 @@ class ComputerVision extends Provider {
 				 * @hook classifai_computer_vision_image_tag_failed
 				 *
 				 * @param {array} $tags      The image tag data.
-				 * @param {int}   $threshold The tag_threshold setting.
+				 * @param {float} $threshold The tag_threshold setting.
 				 */
 				do_action( 'classifai_computer_vision_image_tag_failed', $tags, $threshold );
 			}

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -128,8 +128,9 @@ class ComputerVision extends Provider {
 				'option_index'  => static::ID,
 				'label_for'     => 'descriptive_confidence_threshold',
 				'input_type'    => 'number',
-				'min'           => 1,
-				'step'          => 1,
+				'min'           => 0,
+				'max'           => 100,
+				'step'          => 0.01,
 				'default_value' => $settings['descriptive_confidence_threshold'],
 				'description'   => esc_html__( 'Minimum confidence score for automatically added generated text, numeric value from 0-100. Recommended to be set to at least 70.', 'classifai' ),
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
@@ -153,8 +154,9 @@ class ComputerVision extends Provider {
 				'option_index'  => static::ID,
 				'label_for'     => 'tag_confidence_threshold',
 				'input_type'    => 'number',
-				'min'           => 1,
-				'step'          => 1,
+				'min'           => 0,
+				'max'           => 100,
+				'step'          => 0.01,
 				'default_value' => $settings['tag_confidence_threshold'],
 				'description'   => esc_html__( 'Minimum confidence score for automatically added image tags, numeric value from 0-100. Recommended to be set to at least 70.', 'classifai' ),
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
@@ -514,8 +516,8 @@ class ComputerVision extends Provider {
 			if ( isset( $caption['confidence'] ) && $caption['confidence'] * 100 > $threshold ) {
 				$rtn = ucfirst( $caption['text'] ?? '' );
 			} else {
-				/* translators: 1: Confidence score, 2: Threshold setting */
-				$rtn = new WP_Error( 'threshold', sprintf( esc_html__( 'Caption confidence score is %1$d%% which is lower than your threshold setting of %2$d%%', 'classifai' ), $caption['confidence'] * 100, $threshold ) );
+				/* translators: 1: Confidence score (percentage), 2: Threshold setting (percentage). */
+				$rtn = new WP_Error( 'threshold', sprintf( esc_html__( 'Caption confidence score is %1$s which is lower than your threshold setting of %2$s', 'classifai' ), number_format_i18n( $caption['confidence'] * 100, 2 ) . '%', number_format_i18n( (float) $threshold, 2 ) . '%' ) );
 
 				/**
 				 * Fires if there were no captions returned.

--- a/includes/Classifai/Providers/Azure/Embeddings.php
+++ b/includes/Classifai/Providers/Azure/Embeddings.php
@@ -1223,7 +1223,7 @@ class Embeddings extends OpenAI {
 		if ( $this->feature_instance instanceof Classification ) {
 			foreach ( array_keys( $this->feature_instance->get_supported_taxonomies() ) as $tax ) {
 				$debug_info[ "Taxonomy ($tax)" ]           = Feature::get_debug_value_text( $settings[ $tax ], 1 );
-				$debug_info[ "Taxonomy ($tax threshold)" ] = absint( $settings[ $tax . '_threshold' ] );
+				$debug_info[ "Taxonomy ($tax threshold)" ] = floatval( $settings[ $tax . '_threshold' ] );
 			}
 
 			$debug_info[ __( 'Latest response', 'classifai' ) ] = $this->get_formatted_latest_response( get_transient( 'classifai_azure_openai_embeddings_latest_response' ) );

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -396,7 +396,7 @@ class Embeddings extends Provider {
 		$new_settings[ static::ID ]['authenticated'] = $api_key_settings[ static::ID ]['authenticated'];
 
 		if ( isset( $new_settings[ static::ID ]['embedding_threshold'] ) ) {
-			$new_settings[ static::ID ]['embedding_threshold'] = absint( $new_settings[ static::ID ]['embedding_threshold'] );
+			$new_settings[ static::ID ]['embedding_threshold'] = floatval( $new_settings[ static::ID ]['embedding_threshold'] );
 		}
 
 		if (

--- a/includes/Classifai/Providers/Watson/Helpers.php
+++ b/includes/Classifai/Providers/Watson/Helpers.php
@@ -103,7 +103,7 @@ function get_feature_threshold( string $feature ): float {
 	if ( ! empty( $settings ) && ! empty( $settings[ $feature . '_threshold' ] ) ) {
 		$threshold = filter_var(
 			$settings[ $feature . '_threshold' ],
-			FILTER_VALIDATE_INT
+			FILTER_VALIDATE_FLOAT
 		);
 	}
 
@@ -111,7 +111,7 @@ function get_feature_threshold( string $feature ): float {
 		$constant = 'WATSON_' . strtoupper( $feature ) . '_THRESHOLD';
 
 		if ( defined( $constant ) ) {
-			$threshold = intval( constant( $constant ) );
+			$threshold = floatval( constant( $constant ) );
 		}
 	}
 

--- a/src/js/settings/components/feature-additional-settings/nlu-feature.js
+++ b/src/js/settings/components/feature-additional-settings/nlu-feature.js
@@ -126,6 +126,9 @@ export const NLUFeatureSettings = () => {
 									[ `${ feature }_threshold` ]: value,
 								} );
 							} }
+							min="0"
+							max="100"
+							step="0.01"
 						/>
 						{ 'ibm_watson_nlu' === featureSettings.provider && (
 							<SelectControl

--- a/src/js/settings/components/feature-additional-settings/term-cleanup.js
+++ b/src/js/settings/components/feature-additional-settings/term-cleanup.js
@@ -138,6 +138,9 @@ export const TermCleanupSettings = () => {
 										},
 									} );
 								} }
+								min="0"
+								max="100"
+								step="0.01"
 							/>
 						</SettingsRow>
 					);

--- a/src/js/settings/components/provider-settings/azure-ai-vision.js
+++ b/src/js/settings/components/provider-settings/azure-ai-vision.js
@@ -94,6 +94,9 @@ export const AzureAIVisionSettings = ( { isConfigured = false } ) => {
 								descriptive_confidence_threshold: value,
 							} )
 						}
+						min="0"
+						max="100"
+						step="0.01"
 					/>
 				</SettingsRow>
 			) }
@@ -116,6 +119,9 @@ export const AzureAIVisionSettings = ( { isConfigured = false } ) => {
 								tag_confidence_threshold: value,
 							} )
 						}
+						min="0"
+						max="100"
+						step="0.01"
 					/>
 				</SettingsRow>
 			) }

--- a/src/js/settings/components/provider-settings/azure-ai-vision.js
+++ b/src/js/settings/components/provider-settings/azure-ai-vision.js
@@ -94,9 +94,6 @@ export const AzureAIVisionSettings = ( { isConfigured = false } ) => {
 								descriptive_confidence_threshold: value,
 							} )
 						}
-						min="0"
-						max="100"
-						step="0.01"
 					/>
 				</SettingsRow>
 			) }
@@ -119,9 +116,6 @@ export const AzureAIVisionSettings = ( { isConfigured = false } ) => {
 								tag_confidence_threshold: value,
 							} )
 						}
-						min="0"
-						max="100"
-						step="0.01"
 					/>
 				</SettingsRow>
 			) }

--- a/src/js/settings/components/provider-settings/azure-ai-vision.js
+++ b/src/js/settings/components/provider-settings/azure-ai-vision.js
@@ -85,6 +85,9 @@ export const AzureAIVisionSettings = ( { isConfigured = false } ) => {
 					<InputControl
 						id={ `${ providerName }_descriptive_confidence_threshold` }
 						type="number"
+						min={ 0 }
+						max={ 100 }
+						step={ 0.01 }
 						value={
 							providerSettings.descriptive_confidence_threshold ||
 							70
@@ -108,6 +111,9 @@ export const AzureAIVisionSettings = ( { isConfigured = false } ) => {
 					<InputControl
 						id={ `${ providerName }_tag_confidence_threshold` }
 						type="number"
+						min={ 0 }
+						max={ 100 }
+						step={ 0.01 }
 						value={
 							providerSettings.tag_confidence_threshold || 70
 						}

--- a/src/js/settings/components/provider-settings/openai-embeddings.js
+++ b/src/js/settings/components/provider-settings/openai-embeddings.js
@@ -55,6 +55,7 @@ export const OpenAIEmbeddingsSettings = ( { isConfigured = false } ) => {
 						}
 						min="1"
 						max="100"
+						step="0.01"
 					/>
 				</SettingsRow>
 			) }


### PR DESCRIPTION
### Description of the Change

This PR intends to allow decimal precision support for all threshold percentage fields across the ClassifAI plugin, allowing users to set precise threshold values like 70.57% instead of being limited to whole numbers like 70%.

#### Changes done for

##### Language Processing
- Classification – taxonomy similarity thresholds (providers: IBM Watson NLU, OpenAI Embeddings, Azure OpenAI Embeddings, Ollama).
- Term Cleanup – taxonomy similarity threshold (providers: OpenAI Embeddings, Azure OpenAI Embeddings).

##### Image Processing
- Microsoft Azure AI Vision – Descriptive Text Generator: confidence threshold.
- Microsoft Azure AI Vision – Image Tags Generator: confidence threshold.

##### Recommendation Service
- Recommended Content – OpenAI Embeddings: embedding threshold.

Closes #637 

### How to test the Change

Before proceeding with tests please regenerate static assets using `npm run build` as JavaScript files were changed by this PR.

1. **Access settings:** Go to WordPress Admin > ClassifAI > Settings
2. **Test Classification:** Navigate to Language Processing > Classification
3. **Set decimal threshold:** Enter a value with 2 decimals in any threshold field
4. **Save settings:** Click "Save Changes"
5. **Verify Persistence:** Refresh page and confirm value remains with decimals
6. **Test Functionality:** Use classification previewer to verify decimal precision in calculation

#### Additional tests - verify the difference in output for different thresholds
7. **Test Term Cleanup:** Navigate to Language Processing > Term Cleanup, set decimal threshold values, verify persistence and service
8. **Test Image Processing - Descriptive Text:** Navigate to Image Processing > Descriptive Text Generator > Azure Computer Vision, set confidence threshold with decimals and verify
9. **Test Image Processing - Tags:** Navigate to Image Processing > Image Tags Generator > Azure Computer Vision, set confidence threshold with decimals and verify
10. **Test Embeddings:** Navigate to Language Processing > Classification > OpenAI Embeddings provider settings, set embedding threshold with decimals and verify

### Changelog Entry

> Changed - Increase precision of thresholds to allow 2 decimals

### Credits

Props @MiguelAxcar 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
