### PR TITLE
Enhancement/921 Add Custom and ACF Field targeting for Excerpt Generation

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -38,3 +38,4 @@ jobs:
           exclude-checks: 'plugin_readme,plugin_updater' # Plugin isn't on .org so excluding these for now.
           exclude-directories: 'assets,dist,vendor'
           ignore-warnings: true
+          ignore-codes: 'PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound'

--- a/includes/Classifai/Admin/Settings.php
+++ b/includes/Classifai/Admin/Settings.php
@@ -243,7 +243,7 @@ class Settings {
 
 		// Loop through field groups and get their fields.
 		foreach ( $field_groups as $field_group ) {
-			$fields = acf_get_fields( $field_group );
+			$fields = function_exists( 'acf_get_fields' ) ? acf_get_fields( $field_group ) : array();
 
 			if ( ! empty( $fields ) ) {
 				foreach ( $fields as $field ) {

--- a/includes/Classifai/Admin/Settings.php
+++ b/includes/Classifai/Admin/Settings.php
@@ -110,6 +110,7 @@ class Settings {
 			'postStatuses'     => get_post_statuses_for_language_settings(),
 			'isEPinstalled'    => is_elasticpress_installed(),
 			'nluTaxonomies'    => $this->get_nlu_taxonomies(),
+			'acfFields'        => $this->get_acf_fields(),
 		);
 
 		wp_add_inline_script(
@@ -218,6 +219,49 @@ class Settings {
 		return apply_filters( 'classifai_settings_ibm_watson_nlu_taxonomies', $taxonomies );
 	}
 
+	/**
+	 * Get ACF fields if ACF is active.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @return array
+	 */
+	public function get_acf_fields(): array {
+		$acf_fields = array();
+
+		// Check if ACF is active.
+		if ( ! function_exists( 'acf_get_field_groups' ) ) {
+			return $acf_fields;
+		}
+
+		// Get all ACF field groups.
+		$field_groups = acf_get_field_groups();
+		
+		if ( empty( $field_groups ) ) {
+			return $acf_fields;
+		}
+
+		// Loop through field groups and get their fields.
+		foreach ( $field_groups as $field_group ) {
+			$fields = acf_get_fields( $field_group );
+			
+			if ( ! empty( $fields ) ) {
+				foreach ( $fields as $field ) {
+					// Only include text, textarea, and wysiwyg fields for excerpt generation.
+					if ( in_array( $field['type'], array( 'text', 'textarea', 'wysiwyg' ), true ) ) {
+						$acf_fields[] = array(
+							'key'   => $field['key'],
+							'name'  => $field['name'],
+							'label' => $field['label'],
+							'type'  => $field['type'],
+						);
+					}
+				}
+			}
+		}
+
+		return $acf_fields;
+	}
 
 	/**
 	 * Get the settings.

--- a/includes/Classifai/Admin/Settings.php
+++ b/includes/Classifai/Admin/Settings.php
@@ -236,7 +236,7 @@ class Settings {
 
 		// Get all ACF field groups.
 		$field_groups = acf_get_field_groups();
-		
+
 		if ( empty( $field_groups ) ) {
 			return $acf_fields;
 		}
@@ -244,7 +244,7 @@ class Settings {
 		// Loop through field groups and get their fields.
 		foreach ( $field_groups as $field_group ) {
 			$fields = acf_get_fields( $field_group );
-			
+
 			if ( ! empty( $fields ) ) {
 				foreach ( $fields as $field ) {
 					// Only include text, textarea, and wysiwyg fields for excerpt generation.

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -336,7 +336,7 @@ class ExcerptGeneration extends Feature {
 	 * @return string
 	 */
 	public function get_enable_description(): string {
-		return esc_html__( 'A button will be added to the excerpt panel that can be used to generate an excerpt.', 'classifai' );
+		return esc_html__( 'A button will be added to the excerpt panel that can be used to generate an excerpt. You can configure where the generated excerpt is saved (default excerpt field, custom meta fields, or ACF fields).', 'classifai' );
 	}
 
 	/**

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -246,7 +246,9 @@ class ExcerptGeneration extends Feature {
 
 			// If generation was successful and we have a post ID, save to target field.
 			if ( ! is_wp_error( $result ) && $post_id ) {
-				$save_result = $this->save_excerpt_to_target_field( $result, $post_id );
+				$excerpt     = is_array( $result ) ? $result['content'] : $result;
+				$excerpt     = is_string( $excerpt ) ? $excerpt : '';
+				$save_result = $this->save_excerpt_to_target_field( $excerpt, $post_id );
 				if ( is_wp_error( $save_result ) ) {
 					return rest_ensure_response( $save_result );
 				}

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -562,6 +562,15 @@ class ExcerptGeneration extends Feature {
 
 		$new_settings['length'] = absint( $new_settings['length'] ?? $settings['length'] );
 
+		// Sanitize target field settings.
+		$new_settings['target_field_type'] = sanitize_text_field( $new_settings['target_field_type'] ?? 'post_excerpt' );
+		
+		if ( 'custom_meta' === $new_settings['target_field_type'] ) {
+			$new_settings['target_custom_field'] = sanitize_text_field( $new_settings['target_custom_field'] ?? '' );
+		} elseif ( 'acf_field' === $new_settings['target_field_type'] ) {
+			$new_settings['target_acf_field'] = sanitize_text_field( $new_settings['target_acf_field'] ?? '' );
+		}
+
 		foreach ( $post_types as $post_type ) {
 			if ( ! post_type_supports( $post_type->name, 'excerpt' ) ) {
 				continue;

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -718,4 +718,46 @@ class ExcerptGeneration extends Feature {
 				return apply_filters( 'classifai_excerpt_save_to_custom_target', new WP_Error( 'invalid_field_type', __( 'Invalid target field type.', 'classifai' ) ), $excerpt, $post_id, $field_type );
 		}
 	}
+
+	/**
+	 * Get the current value from the target field.
+	 *
+	 * @param int $post_id The post ID.
+	 * @return string The current value.
+	 */
+	public function get_current_target_field_value( $post_id ) {
+		$settings = $this->get_settings();
+		$field_type = $settings['target_field_type'] ?? 'post_excerpt';
+
+		switch ( $field_type ) {
+			case 'post_excerpt':
+				return get_the_excerpt( $post_id );
+
+			case 'custom_meta':
+				$meta_key = $settings['target_custom_field'] ?? '';
+				return get_post_meta( $post_id, $meta_key, true );
+
+			case 'acf_field':
+				$acf_field_key = $settings['target_acf_field'] ?? '';
+				if ( function_exists( 'get_field' ) ) {
+					return get_field( $acf_field_key, $post_id );
+				}
+				return '';
+
+			default:
+				/**
+				 * Filter for custom target field types when getting current value.
+				 *
+				 * @since 3.x.x
+				 * @hook classifai_excerpt_get_custom_target_value
+				 *
+				 * @param {string} $value      The current value.
+				 * @param {int}    $post_id    The post ID.
+				 * @param {string} $field_type The target field type.
+				 *
+				 * @return {string} The current value.
+				 */
+				return apply_filters( 'classifai_excerpt_get_custom_target_value', '', $post_id, $field_type );
+		}
+	}
 }

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -630,6 +630,9 @@ class ExcerptGeneration extends Feature {
 			$new_settings['user_based_opt_out'] = $old_settings['excerpt_generation_user_based_opt_out'];
 		}
 
+		// Set default target field type for existing installations.
+		$new_settings['target_field_type'] = 'post_excerpt';
+
 		return $new_settings;
 	}
 }

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -162,6 +162,17 @@ class ExcerptGeneration extends Feature {
 				'permission_callback' => [ $this, 'generate_excerpt_permissions_check' ],
 			]
 		);
+
+		// Add endpoint to get target field settings.
+		register_rest_route(
+			'classifai/v1',
+			'get-target-field-settings',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_target_field_settings_callback' ],
+				'permission_callback' => [ $this, 'generate_excerpt_permissions_check' ],
+			]
+		);
 	}
 
 	/**
@@ -178,8 +189,23 @@ class ExcerptGeneration extends Feature {
 	public function generate_excerpt_permissions_check( WP_REST_Request $request ) {
 		$post_id = $request->get_param( 'id' );
 
+		// For endpoints that don't require a post ID (like get-target-field-settings),
+		// just check if the feature is enabled and user has appropriate permissions.
+		if ( empty( $post_id ) ) {
+			if ( ! current_user_can( 'edit_posts' ) ) {
+				return false;
+			}
+
+			// Ensure the feature is enabled. Also runs a user check.
+			if ( ! $this->is_feature_enabled() ) {
+				return new WP_Error( 'not_enabled', esc_html__( 'Excerpt generation not currently enabled.', 'classifai' ) );
+			}
+
+			return true;
+		}
+
 		// Ensure we have a logged in user that can edit the item.
-		if ( empty( $post_id ) || ! current_user_can( 'edit_post', $post_id ) ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return false;
 		}
 
@@ -246,9 +272,7 @@ class ExcerptGeneration extends Feature {
 
 			// If generation was successful and we have a post ID, save to target field.
 			if ( ! is_wp_error( $result ) && $post_id ) {
-				$excerpt     = is_array( $result ) ? $result['content'] : $result;
-				$excerpt     = is_string( $excerpt ) ? $excerpt : '';
-				$save_result = $this->save_excerpt_to_target_field( $excerpt, $post_id );
+				$save_result = $this->save_excerpt_to_target_field( $result, $post_id );
 				if ( is_wp_error( $save_result ) ) {
 					return rest_ensure_response( $save_result );
 				}
@@ -273,6 +297,17 @@ class ExcerptGeneration extends Feature {
 		return rest_ensure_response( [
 			'value' => $value,
 		] );
+	}
+
+	/**
+	 * REST API callback to get target field settings.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_target_field_settings_callback() {
+		$settings = $this->get_target_field_info();
+
+		return rest_ensure_response( $settings );
 	}
 
 	/**
@@ -828,6 +863,7 @@ class ExcerptGeneration extends Feature {
 			case 'custom_meta':
 				$meta_key = $settings['target_custom_field'] ?? '';
 				$info['field_name'] = $meta_key ? sprintf( __( 'Custom meta: %s', 'classifai' ), $meta_key ) : __( 'Custom meta field', 'classifai' );
+				$info['meta_key'] = $meta_key;
 				break;
 				
 			case 'acf_field':
@@ -835,6 +871,7 @@ class ExcerptGeneration extends Feature {
 				if ( $acf_field_key && function_exists( 'acf_get_field' ) ) {
 					$acf_field = acf_get_field( $acf_field_key );
 					$info['field_name'] = $acf_field ? $acf_field['label'] : __( 'ACF field', 'classifai' );
+					$info['meta_key'] = $acf_field_key;
 				} else {
 					$info['field_name'] = __( 'ACF field', 'classifai' );
 				}

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -826,4 +826,13 @@ class ExcerptGeneration extends Feature {
 
 		return $info;
 	}
+
+	/**
+	 * Check if ACF is available and active.
+	 *
+	 * @return bool True if ACF is available.
+	 */
+	public function is_acf_available() {
+		return function_exists( 'acf_get_field_groups' ) && function_exists( 'acf_get_fields' );
+	}
 }

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -792,4 +792,38 @@ class ExcerptGeneration extends Feature {
 
 		return $fields;
 	}
+
+	/**
+	 * Get target field information for JavaScript.
+	 *
+	 * @return array Target field information.
+	 */
+	public function get_target_field_info() {
+		$settings = $this->get_settings();
+		$field_type = $settings['target_field_type'] ?? 'post_excerpt';
+		
+		$info = [
+			'field_type' => $field_type,
+			'field_name' => __( 'Default excerpt field', 'classifai' ),
+		];
+
+		switch ( $field_type ) {
+			case 'custom_meta':
+				$meta_key = $settings['target_custom_field'] ?? '';
+				$info['field_name'] = $meta_key ? sprintf( __( 'Custom meta: %s', 'classifai' ), $meta_key ) : __( 'Custom meta field', 'classifai' );
+				break;
+				
+			case 'acf_field':
+				$acf_field_key = $settings['target_acf_field'] ?? '';
+				if ( $acf_field_key && function_exists( 'acf_get_field' ) ) {
+					$acf_field = acf_get_field( $acf_field_key );
+					$info['field_name'] = $acf_field ? $acf_field['label'] : __( 'ACF field', 'classifai' );
+				} else {
+					$info['field_name'] = __( 'ACF field', 'classifai' );
+				}
+				break;
+		}
+
+		return $info;
+	}
 }

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -234,17 +234,25 @@ class ExcerptGeneration extends Feature {
 			 */
 			$author_name = apply_filters( 'classifai_excerpt_generation_author_name', $author_name, $post_id );
 
-			return rest_ensure_response(
-				$this->run(
-					$post_id,
-					'excerpt',
-					[
-						'content' => $request->get_param( 'content' ),
-						'title'   => $request->get_param( 'title' ),
-						'author'  => $author_name,
-					]
-				)
+			$result = $this->run(
+				$post_id,
+				'excerpt',
+				[
+					'content' => $request->get_param( 'content' ),
+					'title'   => $request->get_param( 'title' ),
+					'author'  => $author_name,
+				]
 			);
+
+			// If generation was successful and we have a post ID, save to target field.
+			if ( ! is_wp_error( $result ) && $post_id ) {
+				$save_result = $this->save_excerpt_to_target_field( $result, $post_id );
+				if ( is_wp_error( $save_result ) ) {
+					return rest_ensure_response( $save_result );
+				}
+			}
+
+			return rest_ensure_response( $result );
 		}
 
 		return parent::rest_endpoint_callback( $request );

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -259,6 +259,21 @@ class ExcerptGeneration extends Feature {
 	}
 
 	/**
+	 * REST API callback to get target field value.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response
+	 */
+	public function get_target_field_value_callback( WP_REST_Request $request ) {
+		$post_id = $request->get_param( 'id' );
+		$value   = $this->get_current_target_field_value( $post_id );
+
+		return rest_ensure_response( [
+			'value' => $value,
+		] );
+	}
+
+	/**
 	 * Enqueue the editor scripts.
 	 */
 	public function enqueue_editor_assets() {

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -635,4 +635,87 @@ class ExcerptGeneration extends Feature {
 
 		return $new_settings;
 	}
+
+	/**
+	 * Save the generated excerpt to the target field.
+	 *
+	 * @param string $excerpt The generated excerpt.
+	 * @param int    $post_id The post ID.
+	 * @return bool|WP_Error True on success, WP_Error on failure.
+	 */
+	public function save_excerpt_to_target_field( $excerpt, $post_id ) {
+		$settings = $this->get_settings();
+		$field_type = $settings['target_field_type'] ?? 'post_excerpt';
+
+		/**
+		 * Filter the excerpt before saving to target field.
+		 *
+		 * @since 3.x.x
+		 * @hook classifai_excerpt_before_save_to_target
+		 *
+		 * @param {string} $excerpt   The generated excerpt.
+		 * @param {int}    $post_id   The post ID.
+		 * @param {string} $field_type The target field type.
+		 *
+		 * @return {string} The excerpt to save.
+		 */
+		$excerpt = apply_filters( 'classifai_excerpt_before_save_to_target', $excerpt, $post_id, $field_type );
+
+		switch ( $field_type ) {
+			case 'post_excerpt':
+				$result = wp_update_post( [
+					'ID'           => $post_id,
+					'post_excerpt' => wp_kses_post( $excerpt ),
+				] );
+				return is_wp_error( $result ) ? $result : true;
+
+			case 'custom_meta':
+				$meta_key = $settings['target_custom_field'] ?? '';
+				if ( empty( $meta_key ) ) {
+					return new WP_Error( 'no_meta_key', __( 'No custom meta key specified.', 'classifai' ) );
+				}
+				
+				/**
+				 * Filter the meta key for custom meta field saving.
+				 *
+				 * @since 3.x.x
+				 * @hook classifai_excerpt_custom_meta_key
+				 *
+				 * @param {string} $meta_key The meta key.
+				 * @param {int}    $post_id  The post ID.
+				 *
+				 * @return {string} The meta key to use.
+				 */
+				$meta_key = apply_filters( 'classifai_excerpt_custom_meta_key', $meta_key, $post_id );
+				
+				update_post_meta( $post_id, $meta_key, wp_kses_post( $excerpt ) );
+				return true;
+
+			case 'acf_field':
+				$acf_field_key = $settings['target_acf_field'] ?? '';
+				if ( empty( $acf_field_key ) ) {
+					return new WP_Error( 'no_acf_field', __( 'No ACF field specified.', 'classifai' ) );
+				}
+				if ( function_exists( 'update_field' ) ) {
+					update_field( $acf_field_key, wp_kses_post( $excerpt ), $post_id );
+					return true;
+				}
+				return new WP_Error( 'acf_not_available', __( 'ACF plugin is not available.', 'classifai' ) );
+
+			default:
+				/**
+				 * Filter for custom target field types.
+				 *
+				 * @since 3.x.x
+				 * @hook classifai_excerpt_save_to_custom_target
+				 *
+				 * @param {string} $excerpt    The generated excerpt.
+				 * @param {int}    $post_id    The post ID.
+				 * @param {string} $field_type The target field type.
+				 *
+				 * @return {bool|WP_Error} True on success, WP_Error on failure.
+				 */
+				return apply_filters( 'classifai_excerpt_save_to_custom_target', new WP_Error( 'invalid_field_type', __( 'Invalid target field type.', 'classifai' ) ), $excerpt, $post_id, $field_type );
+		}
+	}
 }

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -294,9 +294,11 @@ class ExcerptGeneration extends Feature {
 		$post_id = $request->get_param( 'id' );
 		$value   = $this->get_current_target_field_value( $post_id );
 
-		return rest_ensure_response( [
-			'value' => $value,
-		] );
+		return rest_ensure_response(
+			[
+				'value' => $value,
+			]
+		);
 	}
 
 	/**
@@ -368,10 +370,10 @@ class ExcerptGeneration extends Feature {
 							'var classifaiGenerateExcerpt = %s;',
 							wp_json_encode(
 								[
-									'path'               => '/classifai/v1/generate-excerpt/',
-									'buttonText'         => __( 'Generate excerpt', 'classifai' ),
-									'regenerateText'     => __( 'Re-generate excerpt', 'classifai' ),
-									'target_field_info'  => $target_field_info,
+									'path'              => '/classifai/v1/generate-excerpt/',
+									'buttonText'        => __( 'Generate excerpt', 'classifai' ),
+									'regenerateText'    => __( 'Re-generate excerpt', 'classifai' ),
+									'target_field_info' => $target_field_info,
 								]
 							)
 						),
@@ -522,7 +524,7 @@ class ExcerptGeneration extends Feature {
 								foreach ( $fields as $field ) {
 									if ( in_array( $field['type'], [ 'text', 'textarea', 'wysiwyg' ], true ) ) {
 										$selected = ( $settings['target_acf_field'] ?? '' ) === $field['key'] ? 'selected' : '';
-										echo '<option value="' . esc_attr( $field['key'] ) . '" ' . $selected . '>';
+										echo '<option value="' . esc_attr( $field['key'] ) . '" ' . esc_attr( $selected ) . '>';
 										echo esc_html( $field['label'] );
 										echo '</option>';
 									}
@@ -616,7 +618,7 @@ class ExcerptGeneration extends Feature {
 
 		// Sanitize target field settings.
 		$new_settings['target_field_type'] = sanitize_text_field( $new_settings['target_field_type'] ?? 'post_excerpt' );
-		
+
 		if ( 'custom_meta' === $new_settings['target_field_type'] ) {
 			$new_settings['target_custom_field'] = sanitize_text_field( $new_settings['target_custom_field'] ?? '' );
 		} elseif ( 'acf_field' === $new_settings['target_field_type'] ) {
@@ -696,7 +698,7 @@ class ExcerptGeneration extends Feature {
 	 * @return bool|WP_Error True on success, WP_Error on failure.
 	 */
 	public function save_excerpt_to_target_field( $excerpt, $post_id ) {
-		$settings = $this->get_settings();
+		$settings   = $this->get_settings();
 		$field_type = $settings['target_field_type'] ?? 'post_excerpt';
 
 		/**
@@ -715,10 +717,12 @@ class ExcerptGeneration extends Feature {
 
 		switch ( $field_type ) {
 			case 'post_excerpt':
-				$result = wp_update_post( [
-					'ID'           => $post_id,
-					'post_excerpt' => wp_kses_post( $excerpt ),
-				] );
+				$result = wp_update_post(
+					[
+						'ID'           => $post_id,
+						'post_excerpt' => wp_kses_post( $excerpt ),
+					]
+				);
 				return is_wp_error( $result ) ? $result : true;
 
 			case 'custom_meta':
@@ -726,7 +730,7 @@ class ExcerptGeneration extends Feature {
 				if ( empty( $meta_key ) ) {
 					return new WP_Error( 'no_meta_key', __( 'No custom meta key specified.', 'classifai' ) );
 				}
-				
+
 				/**
 				 * Filter the meta key for custom meta field saving.
 				 *
@@ -739,7 +743,7 @@ class ExcerptGeneration extends Feature {
 				 * @return {string} The meta key to use.
 				 */
 				$meta_key = apply_filters( 'classifai_excerpt_custom_meta_key', $meta_key, $post_id );
-				
+
 				update_post_meta( $post_id, $meta_key, wp_kses_post( $excerpt ) );
 				return true;
 
@@ -778,7 +782,7 @@ class ExcerptGeneration extends Feature {
 	 * @return string The current value.
 	 */
 	public function get_current_target_field_value( $post_id ) {
-		$settings = $this->get_settings();
+		$settings   = $this->get_settings();
 		$field_type = $settings['target_field_type'] ?? 'post_excerpt';
 
 		switch ( $field_type ) {
@@ -820,7 +824,7 @@ class ExcerptGeneration extends Feature {
 	 */
 	public function get_available_acf_fields() {
 		$fields = [];
-		
+
 		if ( ! function_exists( 'acf_get_field_groups' ) ) {
 			return $fields;
 		}
@@ -851,9 +855,9 @@ class ExcerptGeneration extends Feature {
 	 * @return array Target field information.
 	 */
 	public function get_target_field_info() {
-		$settings = $this->get_settings();
+		$settings   = $this->get_settings();
 		$field_type = $settings['target_field_type'] ?? 'post_excerpt';
-		
+
 		$info = [
 			'field_type' => $field_type,
 			'field_name' => __( 'Default excerpt field', 'classifai' ),
@@ -862,16 +866,17 @@ class ExcerptGeneration extends Feature {
 		switch ( $field_type ) {
 			case 'custom_meta':
 				$meta_key = $settings['target_custom_field'] ?? '';
+				// translators: %s is the custom meta key.
 				$info['field_name'] = $meta_key ? sprintf( __( 'Custom meta: %s', 'classifai' ), $meta_key ) : __( 'Custom meta field', 'classifai' );
-				$info['meta_key'] = $meta_key;
+				$info['meta_key']   = $meta_key; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				break;
-				
+
 			case 'acf_field':
 				$acf_field_key = $settings['target_acf_field'] ?? '';
 				if ( $acf_field_key && function_exists( 'acf_get_field' ) ) {
-					$acf_field = acf_get_field( $acf_field_key );
+					$acf_field          = acf_get_field( $acf_field_key );
 					$info['field_name'] = $acf_field ? $acf_field['label'] : __( 'ACF field', 'classifai' );
-					$info['meta_key'] = $acf_field_key;
+					$info['meta_key']   = $acf_field_key; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				} else {
 					$info['field_name'] = __( 'ACF field', 'classifai' );
 				}

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -520,6 +520,9 @@ class ExcerptGeneration extends Feature {
 			],
 			'length'                  => absint( apply_filters( 'excerpt_length', 55 ) ),
 			'provider'                => ChatGPT::ID,
+			'target_field_type'       => 'post_excerpt',
+			'target_custom_field'     => '',
+			'target_acf_field'        => '',
 		];
 	}
 

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -307,15 +307,19 @@ class ExcerptGeneration extends Feature {
 						true
 					);
 
+					// Get target field information for JavaScript.
+					$target_field_info = $this->get_target_field_info();
+
 					wp_add_inline_script(
 						'classifai-plugin-classic-excerpt-generation-js',
 						sprintf(
 							'var classifaiGenerateExcerpt = %s;',
 							wp_json_encode(
 								[
-									'path'           => '/classifai/v1/generate-excerpt/',
-									'buttonText'     => __( 'Generate excerpt', 'classifai' ),
-									'regenerateText' => __( 'Re-generate excerpt', 'classifai' ),
+									'path'               => '/classifai/v1/generate-excerpt/',
+									'buttonText'         => __( 'Generate excerpt', 'classifai' ),
+									'regenerateText'     => __( 'Re-generate excerpt', 'classifai' ),
+									'target_field_info'  => $target_field_info,
 								]
 							)
 						),

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -760,4 +760,36 @@ class ExcerptGeneration extends Feature {
 				return apply_filters( 'classifai_excerpt_get_custom_target_value', '', $post_id, $field_type );
 		}
 	}
+
+	/**
+	 * Get available ACF fields for the target field selector.
+	 *
+	 * @return array Array of ACF fields.
+	 */
+	public function get_available_acf_fields() {
+		$fields = [];
+		
+		if ( ! function_exists( 'acf_get_field_groups' ) ) {
+			return $fields;
+		}
+
+		$field_groups = acf_get_field_groups();
+		foreach ( $field_groups as $field_group ) {
+			$acf_fields = acf_get_fields( $field_group );
+			if ( $acf_fields ) {
+				foreach ( $acf_fields as $field ) {
+					// Only include text-based fields.
+					if ( in_array( $field['type'], [ 'text', 'textarea', 'wysiwyg' ], true ) ) {
+						$fields[] = [
+							'key'   => $field['key'],
+							'label' => $field['label'],
+							'group' => $field_group['title'],
+						];
+					}
+				}
+			}
+		}
+
+		return $fields;
+	}
 }

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -460,7 +460,7 @@ class ExcerptGeneration extends Feature {
 			$this->get_option_name() . '_section',
 			[
 				'label_for'     => 'target_field',
-				'default_value' => $settings['target_field'] ?? 'post_excerpt',
+				'default_value' => $settings['target_field_type'] ?? 'post_excerpt',
 				'description'   => __( 'Choose where to save the generated excerpt. You can target the default excerpt field, custom meta fields, or ACF fields.', 'classifai' ),
 			]
 		);
@@ -473,7 +473,6 @@ class ExcerptGeneration extends Feature {
 	 */
 	public function render_target_field_settings( $args ) {
 		$settings     = $this->get_settings();
-		$target_field = $settings['target_field'] ?? 'post_excerpt';
 		$field_type   = $settings['target_field_type'] ?? 'post_excerpt';
 		$custom_field = $settings['target_custom_field'] ?? '';
 
@@ -518,7 +517,7 @@ class ExcerptGeneration extends Feature {
 					if ( function_exists( 'acf_get_field_groups' ) ) {
 						$field_groups = acf_get_field_groups();
 						foreach ( $field_groups as $field_group ) {
-							$fields = acf_get_fields( $field_group );
+							$fields = function_exists( 'acf_get_fields' ) ? acf_get_fields( $field_group ) : array();
 							if ( $fields ) {
 								echo '<optgroup label="' . esc_attr( $field_group['title'] ) . '">';
 								foreach ( $fields as $field ) {
@@ -759,19 +758,7 @@ class ExcerptGeneration extends Feature {
 				return new WP_Error( 'acf_not_available', __( 'ACF plugin is not available.', 'classifai' ) );
 
 			default:
-				/**
-				 * Filter for custom target field types.
-				 *
-				 * @since 3.x.x
-				 * @hook classifai_excerpt_save_to_custom_target
-				 *
-				 * @param {string} $excerpt    The generated excerpt.
-				 * @param {int}    $post_id    The post ID.
-				 * @param {string} $field_type The target field type.
-				 *
-				 * @return {bool|WP_Error} True on success, WP_Error on failure.
-				 */
-				return apply_filters( 'classifai_excerpt_save_to_custom_target', new WP_Error( 'invalid_field_type', __( 'Invalid target field type.', 'classifai' ) ), $excerpt, $post_id, $field_type );
+				return new WP_Error( 'invalid_field_type', __( 'Invalid target field type.', 'classifai' ) );
 		}
 	}
 
@@ -831,7 +818,7 @@ class ExcerptGeneration extends Feature {
 
 		$field_groups = acf_get_field_groups();
 		foreach ( $field_groups as $field_group ) {
-			$acf_fields = acf_get_fields( $field_group );
+			$acf_fields = function_exists( 'acf_get_fields' ) ? acf_get_fields( $field_group ) : array();
 			if ( $acf_fields ) {
 				foreach ( $acf_fields as $field ) {
 					// Only include text-based fields.

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -413,6 +413,95 @@ class ExcerptGeneration extends Feature {
 	}
 
 	/**
+	 * Render the target field settings.
+	 *
+	 * @param array $args Field arguments.
+	 */
+	public function render_target_field_settings( $args ) {
+		$settings     = $this->get_settings();
+		$target_field = $settings['target_field'] ?? 'post_excerpt';
+		$field_type   = $settings['target_field_type'] ?? 'post_excerpt';
+		$custom_field = $settings['target_custom_field'] ?? '';
+
+		?>
+		<div class="classifai-target-field-settings">
+			<select name="<?php echo esc_attr( $this->get_option_name() ); ?>[target_field_type]" id="target_field_type">
+				<option value="post_excerpt" <?php selected( $field_type, 'post_excerpt' ); ?>>
+					<?php esc_html_e( 'Default excerpt field', 'classifai' ); ?>
+				</option>
+				<option value="custom_meta" <?php selected( $field_type, 'custom_meta' ); ?>>
+					<?php esc_html_e( 'Custom meta field', 'classifai' ); ?>
+				</option>
+				<?php if ( function_exists( 'acf_get_field_groups' ) ) : ?>
+				<option value="acf_field" <?php selected( $field_type, 'acf_field' ); ?>>
+					<?php esc_html_e( 'ACF field', 'classifai' ); ?>
+				</option>
+				<?php endif; ?>
+			</select>
+
+			<div id="custom_meta_field_container" style="<?php echo 'custom_meta' === $field_type ? '' : 'display: none;'; ?>">
+				<br>
+				<label for="target_custom_field">
+					<?php esc_html_e( 'Meta key:', 'classifai' ); ?>
+				</label>
+				<input 
+					type="text" 
+					id="target_custom_field" 
+					name="<?php echo esc_attr( $this->get_option_name() ); ?>[target_custom_field]" 
+					value="<?php echo esc_attr( $custom_field ); ?>"
+					placeholder="<?php esc_attr_e( 'e.g., editorial_subtitle, custom_excerpt', 'classifai' ); ?>"
+				/>
+			</div>
+
+			<div id="acf_field_container" style="<?php echo 'acf_field' === $field_type ? '' : 'display: none;'; ?>">
+				<br>
+				<label for="target_acf_field">
+					<?php esc_html_e( 'ACF field key:', 'classifai' ); ?>
+				</label>
+				<select id="target_acf_field" name="<?php echo esc_attr( $this->get_option_name() ); ?>[target_acf_field]">
+					<option value=""><?php esc_html_e( 'Select ACF field', 'classifai' ); ?></option>
+					<?php
+					if ( function_exists( 'acf_get_field_groups' ) ) {
+						$field_groups = acf_get_field_groups();
+						foreach ( $field_groups as $field_group ) {
+							$fields = acf_get_fields( $field_group );
+							if ( $fields ) {
+								echo '<optgroup label="' . esc_attr( $field_group['title'] ) . '">';
+								foreach ( $fields as $field ) {
+									if ( in_array( $field['type'], [ 'text', 'textarea', 'wysiwyg' ], true ) ) {
+										$selected = ( $settings['target_acf_field'] ?? '' ) === $field['key'] ? 'selected' : '';
+										echo '<option value="' . esc_attr( $field['key'] ) . '" ' . $selected . '>';
+										echo esc_html( $field['label'] );
+										echo '</option>';
+									}
+								}
+								echo '</optgroup>';
+							}
+						}
+					}
+					?>
+				</select>
+			</div>
+		</div>
+
+		<script>
+		jQuery(document).ready(function($) {
+			$('#target_field_type').on('change', function() {
+				var fieldType = $(this).val();
+				$('#custom_meta_field_container, #acf_field_container').hide();
+				
+				if (fieldType === 'custom_meta') {
+					$('#custom_meta_field_container').show();
+				} else if (fieldType === 'acf_field') {
+					$('#acf_field_container').show();
+				}
+			});
+		});
+		</script>
+		<?php
+	}
+
+	/**
 	 * Returns the default settings for the feature.
 	 *
 	 * @return array

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -396,6 +396,20 @@ class ExcerptGeneration extends Feature {
 				'description'   => __( 'How many words should the excerpt be? Note that the final result may not exactly match this, it often tends to exceed this number by 10-15 words.', 'classifai' ),
 			]
 		);
+
+		// Add target field settings.
+		add_settings_field(
+			'target_field',
+			esc_html__( 'Target field', 'classifai' ),
+			[ $this, 'render_target_field_settings' ],
+			$this->get_option_name(),
+			$this->get_option_name() . '_section',
+			[
+				'label_for'     => 'target_field',
+				'default_value' => $settings['target_field'] ?? 'post_excerpt',
+				'description'   => __( 'Choose where to save the generated excerpt. You can target the default excerpt field, custom meta fields, or ACF fields.', 'classifai' ),
+			]
+		);
 	}
 
 	/**

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -143,6 +143,25 @@ class ExcerptGeneration extends Feature {
 				],
 			]
 		);
+
+		// Add endpoint to get target field value.
+		register_rest_route(
+			'classifai/v1',
+			'get-target-field-value/(?P<id>\d+)',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_target_field_value_callback' ],
+				'args'                => [
+					'id' => [
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+						'description'       => esc_html__( 'Post ID to get target field value for.', 'classifai' ),
+					],
+				],
+				'permission_callback' => [ $this, 'generate_excerpt_permissions_check' ],
+			]
+		);
 	}
 
 	/**

--- a/includes/Classifai/Helpers/CredentialReuse.php
+++ b/includes/Classifai/Helpers/CredentialReuse.php
@@ -13,14 +13,14 @@ use function Classifai\get_plugin;
  *
  * Handles detection and reuse of service provider credentials across features.
  *
- * @since x.x.x
+ * @since 3.6.0
  */
 class CredentialReuse {
 
 	/**
 	 * Provider groups that share the same API key.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @var array
 	 */
@@ -48,7 +48,7 @@ class CredentialReuse {
 	/**
 	 * Get all configured providers across all features.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @return array Array of configured providers with their credentials.
 	 */
@@ -76,7 +76,7 @@ class CredentialReuse {
 	/**
 	 * Get the provider group for a given provider ID.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @param string $provider_id The provider ID.
 	 * @return string|null The provider group name or null if not found.
@@ -93,7 +93,7 @@ class CredentialReuse {
 	/**
 	 * Get all providers in the same group as the given provider.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @param string $provider_id The provider ID.
 	 * @return array Array of provider IDs in the same group.
@@ -109,7 +109,7 @@ class CredentialReuse {
 	/**
 	 * Check if a provider is compatible with a feature.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @param string $provider_id The provider ID to check.
 	 * @param string $feature_id  The feature ID to check against.
@@ -129,7 +129,7 @@ class CredentialReuse {
 	/**
 	 * Check if any provider in the same group is compatible with a feature.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @param string $provider_id The provider ID to check.
 	 * @param string $feature_id  The feature ID to check against.
@@ -150,7 +150,7 @@ class CredentialReuse {
 	/**
 	 * Get the best matching provider ID for a feature from a provider group.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @param string $source_provider_id The source provider ID.
 	 * @param string $feature_id         The target feature ID.
@@ -177,7 +177,7 @@ class CredentialReuse {
 	/**
 	 * Get reusable credentials for a feature.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @param string $feature_id The feature ID to get credentials for.
 	 * @return array Array of compatible providers with existing credentials.
@@ -216,7 +216,7 @@ class CredentialReuse {
 		/**
 		 * Filter the reusable credentials for a feature.
 		 *
-		 * @since x.x.x
+		 * @since 3.6.0
 		 * @hook classifai_reusable_credentials
 		 *
 		 * @param {array}  $reusable   Array of reusable credentials.
@@ -230,7 +230,7 @@ class CredentialReuse {
 	/**
 	 * Copy credentials from one feature to another.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @param string $source_feature_id Source feature ID.
 	 * @param string $target_feature_id Target feature ID.
@@ -278,7 +278,7 @@ class CredentialReuse {
 		/**
 		 * Fires after credentials are copied between features.
 		 *
-		 * @since x.x.x
+		 * @since 3.6.0
 		 * @hook classifai_credentials_copied
 		 *
 		 * @param {string} $source_feature_id Source feature ID.
@@ -293,7 +293,7 @@ class CredentialReuse {
 	/**
 	 * Get all feature instances.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @return array Array of feature instances.
 	 */
@@ -320,7 +320,7 @@ class CredentialReuse {
 	/**
 	 * Get a user-friendly provider name.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @param string $provider_id The provider ID.
 	 * @return string The formatted provider name.
@@ -352,7 +352,7 @@ class CredentialReuse {
 	/**
 	 * Get provider groups for external use.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.0
 	 *
 	 * @return array Array of provider groups.
 	 */

--- a/src/js/features/excerpt-generation/classic/index.js
+++ b/src/js/features/excerpt-generation/classic/index.js
@@ -140,6 +140,27 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 							? __( 'Re-generate short description', 'classifai' )
 							: classifaiExcerptData?.regenerateText ?? ''
 					);
+
+					// Show notification about target field if different from excerpt.
+					if ( classifaiExcerptData?.target_field_info ) {
+						const targetInfo = classifaiExcerptData.target_field_info;
+						if ( targetInfo.field_type !== 'post_excerpt' ) {
+							const notification = $( '<div>', {
+								class: 'notice notice-success',
+								style: 'margin-top: 10px;',
+							} ).append(
+								$( '<p>', {
+									text: __( 'Excerpt generated and saved to target field: ', 'classifai' ) + targetInfo.field_name,
+								} )
+							);
+							$( excerptContainer ).after( notification );
+							
+							// Remove notification after 5 seconds.
+							setTimeout( () => {
+								notification.fadeOut();
+							}, 5000 );
+						}
+					}
 				} )
 				.catch( ( error ) => {
 					generateTextEl.css( 'opacity', '1' );

--- a/src/js/features/excerpt-generation/classic/index.js
+++ b/src/js/features/excerpt-generation/classic/index.js
@@ -139,11 +139,11 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 			}
 
 			// Make sure the regenerate button is visible.
-			const regenerateButton = $(
+			const existingRegenerateButton = $(
 				'#classifai-excerpt-generation__excerpt-generate-btn'
 			);
-			if ( regenerateButton.length ) {
-				regenerateButton.show();
+			if ( existingRegenerateButton.length ) {
+				existingRegenerateButton.show();
 			}
 		}
 
@@ -244,11 +244,11 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 						postExcerptDiv.append( customFieldContainer );
 
 						// Move the regenerate button to after the custom field container.
-						const regenerateButton = $(
+						const existingRegenerateButton = $(
 							'#classifai-excerpt-generation__excerpt-generate-btn'
 						);
-						if ( regenerateButton.length ) {
-							regenerateButton
+						if ( existingRegenerateButton.length ) {
+							existingRegenerateButton
 								.detach()
 								.insertAfter( customFieldContainer )
 								.show();
@@ -261,7 +261,7 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 						if ( errorMessage.length ) {
 							errorMessage
 								.detach()
-								.insertAfter( regenerateButton );
+								.insertAfter( existingRegenerateButton );
 						}
 
 						// Move the disable link as well
@@ -373,11 +373,11 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 				postExcerptDiv.append( customFieldContainer );
 
 				// Move the regenerate button to after the custom field container.
-				const regenerateButton = $(
+				const existingRegenerateButton = $(
 					'#classifai-excerpt-generation__excerpt-generate-btn'
 				);
-				if ( regenerateButton.length ) {
-					regenerateButton
+				if ( existingRegenerateButton.length ) {
+					existingRegenerateButton
 						.detach()
 						.insertAfter( customFieldContainer )
 						.show();
@@ -388,7 +388,9 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 					'.classifai-excerpt-generation__excerpt-generate-error'
 				);
 				if ( errorMessage.length ) {
-					errorMessage.detach().insertAfter( regenerateButton );
+					errorMessage
+						.detach()
+						.insertAfter( existingRegenerateButton );
 				}
 
 				// Move the disable link as well.
@@ -448,28 +450,24 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 						} else {
 							$( excerptContainer ).val( result );
 						}
-					} else {
-						// Check if we should update the custom field or default excerpt.
-						if (
-							targetFieldSettings &&
-							targetFieldSettings.field_type !== 'post_excerpt'
-						) {
-							// Update custom field display first.
-							const customField = $(
-								'#classifai-custom-excerpt'
-							);
-							if ( customField.length ) {
-								customField.text( result );
-								targetFieldValue = result;
-							}
-
-							// Update visible meta field values on the page (this also updates custom field display).
-							updateVisibleMetaFields( result );
-						} else {
-							// Update default excerpt field.
-							$( excerptContainer ).val( result );
+					} else if (
+						targetFieldSettings &&
+						targetFieldSettings.field_type !== 'post_excerpt'
+					) {
+						// Update custom field display first.
+						const customField = $( '#classifai-custom-excerpt' );
+						if ( customField.length ) {
+							customField.text( result );
+							targetFieldValue = result;
 						}
+
+						// Update visible meta field values on the page (this also updates custom field display).
+						updateVisibleMetaFields( result );
+					} else {
+						// Update default excerpt field.
+						$( excerptContainer ).val( result );
 					}
+
 					$( excerptContainer ).trigger( 'input' );
 					generateTextEl.text(
 						isProduct

--- a/src/js/features/excerpt-generation/classic/index.js
+++ b/src/js/features/excerpt-generation/classic/index.js
@@ -39,8 +39,13 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 		// Boolean indicating whether generation is in progress.
 		let isProcessing = false;
 
+		// Get target field settings and value.
+		let targetFieldSettings = null;
+		let targetFieldValue = '';
+		const postId = $( '#post_ID' ).val();
+
 		// Creates and appends the "Generate excerpt" button.
-		$( '<span />', {
+		const regenerateButton = $( '<span />', {
 			text: buttonText,
 			class: 'classifai-excerpt-generation__excerpt-generate-btn--text',
 		} )
@@ -52,8 +57,10 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 				$( '<span />', {
 					class: 'classifai-excerpt-generation__excerpt-generate-btn--spinner',
 				} )
-			)
-			.insertAfter( excerptContainer );
+			);
+
+		// Insert the button after the excerpt container, but we'll move it later if custom field is enabled.
+		regenerateButton.insertAfter( excerptContainer );
 
 		$( '<p>', {
 			class: 'classifai-excerpt-generation__excerpt-generate-error',
@@ -87,10 +94,210 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 				);
 		}
 
-		// The current post ID.
-		const postId = $( '#post_ID' ).val();
+		// Get target field settings.
+		apiFetch( {
+			path: '/classifai/v1/get-target-field-settings/',
+		} ).then( ( result ) => {
+			targetFieldSettings = result;
+			
+			// If custom field is enabled, hide the default excerpt field and show custom field info.
+			if ( targetFieldSettings && targetFieldSettings.field_type !== 'post_excerpt' ) {
+				hideDefaultExcerptField();
+				showCustomFieldInfo();
+			}
+		} ).catch( () => {
+			// If endpoint doesn't exist, use default settings.
+			targetFieldSettings = {
+				field_type: 'post_excerpt',
+				field_name: __( 'Default excerpt field', 'classifai' ),
+			};
+		} );
 
-		// Callback to generate the excerpt.
+		// Function to hide the default excerpt field.
+		function hideDefaultExcerptField() {
+			// Hide the default excerpt textarea and label, but keep the #postexcerpt container.
+			const excerptTextarea = $( '#excerpt' );
+			const excerptLabel = $( 'label[for="excerpt"]' );
+			
+			if ( excerptTextarea.length ) {
+				excerptTextarea.hide();
+			}
+			
+			if ( excerptLabel.length ) {
+				excerptLabel.hide();
+			}
+			
+			// Hide any other default excerpt content, but not the regenerate button.
+			const defaultExcerptContent = $( '#postexcerpt .inside' );
+			if ( defaultExcerptContent.length ) {
+				defaultExcerptContent.hide();
+			}
+			
+			// Make sure the regenerate button is visible.
+			const regenerateButton = $( '#classifai-excerpt-generation__excerpt-generate-btn' );
+			if ( regenerateButton.length ) {
+				regenerateButton.show();
+			}
+		}
+
+		// Function to show custom field info.
+		function showCustomFieldInfo() {
+			if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+				return;
+			}
+
+			// Get the current value.
+			apiFetch( {
+				path: `/classifai/v1/get-target-field-value/${ postId }`,
+			} ).then( ( result ) => {
+				targetFieldValue = result.value || '';
+				
+				// Create custom field info container.
+				const customFieldContainer = $( '<div>', {
+					class: 'classifai-custom-excerpt-info',
+					style: 'margin: 0; padding: 15px; background: #f9f9f9; border: 1px solid #ddd; border-radius: 4px;',
+				} );
+
+				const label = $( '<label>', {
+					text: targetFieldSettings.field_name || __( 'Custom excerpt', 'classifai' ),
+					style: 'display: block; margin-bottom: 8px; font-weight: 600; color: #23282d;',
+				} );
+
+				const textarea = $( '<textarea>', {
+					id: 'classifai-custom-excerpt',
+					text: targetFieldValue, // Use text() instead of value for textarea.
+					style: 'width: 100%; min-height: 120px; padding: 8px; border: 1px solid #ddd; border-radius: 3px; font-family: inherit; font-size: 14px; line-height: 1.4; resize: vertical; background: #f5f5f5;',
+					readonly: true,
+					placeholder: __( 'This field is read-only. The value is stored in a custom field.', 'classifai' ),
+				} );
+
+				const notice = $( '<div>', {
+					class: 'notice notice-info',
+					style: 'margin-top: 10px;',
+				} ).append(
+					$( '<p>', {
+						html: __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' ) +
+							'<ul style="margin: 5px 0 0 20px;">' +
+							'<li>' + __( 'Use the regenerate excerpt button to regenerate it', 'classifai' ) + '</li>' +
+							'<li>' + __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' ) + '</li>' +
+							'<li>' + __( 'Change the target field in ', 'classifai' ) + 
+							'<a href="' + window.location.origin + '/wp-admin/tools.php?page=classifai&tab=language_processing&feature=feature_excerpt_generation" target="_blank" rel="noopener noreferrer">' + 
+							__( 'ClassifAI Settings', 'classifai' ) + '</a></li>' +
+							'</ul>'
+					} )
+				);
+
+				customFieldContainer.append( label, textarea, notice );
+
+				// Insert inside the #postexcerpt div.
+				const postExcerptDiv = $( '#postexcerpt' );
+				if ( postExcerptDiv.length ) {
+					postExcerptDiv.append( customFieldContainer );
+					
+					// Move the regenerate button to after the custom field container.
+					const regenerateButton = $( '#classifai-excerpt-generation__excerpt-generate-btn' );
+					if ( regenerateButton.length ) {
+						regenerateButton.detach().insertAfter( customFieldContainer ).show();
+					}
+					
+					// Move the error message as well.
+					const errorMessage = $( '.classifai-excerpt-generation__excerpt-generate-error' );
+					if ( errorMessage.length ) {
+						errorMessage.detach().insertAfter( regenerateButton );
+					}
+					
+					// Move the disable link as well
+					const disableLink = $( '.classifai-excerpt-generation__excerpt-generate-disable-link' );
+					if ( disableLink.length ) {
+						disableLink.detach().insertAfter( errorMessage );
+					}
+				} else {
+					// Fallback: insert after the title
+					$( '#title' ).closest( 'tr' ).after( customFieldContainer );
+				}
+
+				// Set up listeners for meta field changes
+				setupMetaFieldListenersAfterCustomField();
+			} ).catch( () => {
+				// If error, show custom field info with empty value.
+				showCustomFieldInfoWithValue( '' );
+			} );
+		}
+
+		// Function to show custom field info with a specific value
+		function showCustomFieldInfoWithValue( value ) {
+			if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+				return;
+			}
+
+			const customFieldContainer = $( '<div>', {
+				class: 'classifai-custom-excerpt-info',
+				style: 'margin: 0; padding: 15px; background: #f9f9f9; border: 1px solid #ddd; border-radius: 4px;',
+			} );
+
+			const label = $( '<label>', {
+				text: targetFieldSettings.field_name || __( 'Custom excerpt', 'classifai' ),
+				style: 'display: block; margin-bottom: 8px; font-weight: 600; color: #23282d;',
+			} );
+
+			const textarea = $( '<textarea>', {
+				id: 'classifai-custom-excerpt',
+				text: value,
+				style: 'width: 100%; min-height: 120px; padding: 8px; border: 1px solid #ddd; border-radius: 3px; font-family: inherit; font-size: 14px; line-height: 1.4; resize: vertical; background: #f5f5f5;',
+				readonly: true,
+				placeholder: __( 'This field is read-only. The value is stored in a custom field.', 'classifai' ),
+			} );
+
+			const notice = $( '<div>', {
+				class: 'notice notice-info',
+				style: 'margin-top: 10px;',
+			} ).append(
+				$( '<p>', {
+					html: __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' ) +
+						'<ul style="margin: 5px 0 0 20px;">' +
+						'<li>' + __( 'Use the regenerate excerpt button to regenerate it', 'classifai' ) + '</li>' +
+						'<li>' + __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' ) + '</li>' +
+						'<li>' + __( 'Change the target field in ', 'classifai' ) + 
+						'<a href="' + window.location.origin + '/wp-admin/tools.php?page=classifai&tab=language_processing&feature=feature_excerpt_generation" target="_blank" rel="noopener noreferrer">' + 
+						__( 'ClassifAI Settings', 'classifai' ) + '</a></li>' +
+						'</ul>'
+				} )
+			);
+
+			customFieldContainer.append( label, textarea, notice );
+
+			// Insert inside the #postexcerpt div.
+			const postExcerptDiv = $( '#postexcerpt' );
+			if ( postExcerptDiv.length ) {
+				postExcerptDiv.append( customFieldContainer );
+				
+				// Move the regenerate button to after the custom field container.
+				const regenerateButton = $( '#classifai-excerpt-generation__excerpt-generate-btn' );
+				if ( regenerateButton.length ) {
+					regenerateButton.detach().insertAfter( customFieldContainer ).show();
+				}
+				
+				// Move the error message as well.
+				const errorMessage = $( '.classifai-excerpt-generation__excerpt-generate-error' );
+				if ( errorMessage.length ) {
+					errorMessage.detach().insertAfter( regenerateButton );
+				}
+				
+				// Move the disable link as well.
+				const disableLink = $( '.classifai-excerpt-generation__excerpt-generate-disable-link' );
+				if ( disableLink.length ) {
+					disableLink.detach().insertAfter( errorMessage );
+				}
+			} else {
+				// Fallback: insert after the title.
+				$( '#title' ).closest( 'tr' ).after( customFieldContainer );
+			}
+
+			// Set up listeners for meta field changes.
+			setupMetaFieldListenersAfterCustomField();
+		}
+
+		// Function to generate the excerpt.
 		const generateExcerpt = () => {
 			if ( isProcessing ) {
 				return;
@@ -122,7 +329,7 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 					isProcessing = false;
 
 					if ( isProduct ) {
-						// For WooCommerce products, we need to update the TinyMCE editor
+						// For WooCommerce products, we need to update the TinyMCE editor.
 						if (
 							typeof tinyMCE !== 'undefined' &&
 							tinyMCE.get( 'excerpt' )
@@ -132,7 +339,21 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 							$( excerptContainer ).val( result );
 						}
 					} else {
-						$( excerptContainer ).val( result );
+						// Check if we should update the custom field or default excerpt.
+						if ( targetFieldSettings && targetFieldSettings.field_type !== 'post_excerpt' ) {
+							// Update custom field display first.
+							const customField = $( '#classifai-custom-excerpt' );
+							if ( customField.length ) {
+								customField.text( result );
+								targetFieldValue = result;
+							}
+							
+							// Update visible meta field values on the page (this also updates custom field display).
+							updateVisibleMetaFields( result );
+						} else {
+							// Update default excerpt field.
+							$( excerptContainer ).val( result );
+						}
 					}
 					$( excerptContainer ).trigger( 'input' );
 					generateTextEl.text(
@@ -169,6 +390,154 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 					errorEl.text( error?.message ).show();
 				} );
 		};
+
+		// Function to update visible meta field values on the page.
+		function updateVisibleMetaFields( value ) {
+			if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+				return;
+			}
+
+			const metaKey = targetFieldSettings.meta_key || targetFieldSettings.field_name;
+			if ( ! metaKey ) {
+				return;
+			}
+
+			// Update meta field input that is visible on the page.
+			// Try multiple selectors to find the meta field.
+			let metaInput = document.querySelector( `textarea[name="meta[${ metaKey }][value]"]` );
+			
+			// If not found with exact match, try a more flexible approach.
+			if ( ! metaInput ) {
+				const allMetaInputs = document.querySelectorAll( 'textarea[name*="[value]"]' );
+				allMetaInputs.forEach( ( input ) => {
+					const name = input.getAttribute( 'name' );
+					if ( name && name.includes( '[value]' ) ) {
+						// Check if this is the meta field we want to update.
+						const row = input.closest( 'tr' );
+						if ( row ) {
+							const keyInput = row.querySelector( 'input[name*="[key]"]' );
+							if ( keyInput && keyInput.value === metaKey ) {
+								metaInput = input;
+							}
+						}
+					}
+				} );
+			}
+
+			if ( metaInput ) {
+				metaInput.value = value;
+
+				// Trigger input event to notify any listeners.
+				const inputEvent = new Event( 'input', { bubbles: true } );
+				metaInput.dispatchEvent( inputEvent );
+
+				// Also trigger change event.
+				const changeEvent = new Event( 'change', { bubbles: true } );
+				metaInput.dispatchEvent( changeEvent );
+			}
+
+			// Also check for ACF fields if this is an ACF field.
+			if ( targetFieldSettings.field_type === 'acf_field' && targetFieldSettings.meta_key ) {
+				const acfInputs = document.querySelectorAll( `input[name*="${targetFieldSettings.meta_key}"], textarea[name*="${targetFieldSettings.meta_key}"]` );
+				acfInputs.forEach( ( input ) => {
+					input.value = value;
+					
+					// Trigger change events.
+					const inputEvent = new Event( 'input', { bubbles: true } );
+					input.dispatchEvent( inputEvent );
+					
+					const changeEvent = new Event( 'change', { bubbles: true } );
+					input.dispatchEvent( changeEvent );
+				} );
+			}
+
+			// Always update our custom field display, regardless of whether meta field was found.
+			updateCustomFieldDisplay( value );
+		}
+
+		// Function to update the custom field display when meta field values change.
+		function updateCustomFieldDisplay( value ) {
+			const customField = $( '#classifai-custom-excerpt' );
+			if ( customField.length ) {
+				customField.text( value );
+				targetFieldValue = value;
+			} else {
+				// If custom field is not found, try to find it with a more flexible selector.
+				const customFieldAlt = $( '.classifai-custom-excerpt-info textarea' );
+				if ( customFieldAlt.length ) {
+					customFieldAlt.text( value );
+					targetFieldValue = value;
+				}
+			}
+		}
+
+		// Function to listen for changes in meta fields and update our custom field display.
+		function setupMetaFieldListeners() {
+			if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+				return;
+			}
+
+			const metaKey = targetFieldSettings.meta_key || targetFieldSettings.field_name;
+			if ( ! metaKey ) {
+				return;
+			}
+
+			// Listen for changes in meta field inputs (including both textarea and input for consistency).
+			// Try multiple selectors to find the meta field.
+			let metaInput = document.querySelector( `textarea[name="meta[${ metaKey }][value]"]` );
+			
+			// If not found with exact match, try a more flexible approach
+			if ( ! metaInput ) {
+				const allMetaInputs = document.querySelectorAll( 'textarea[name*="[value]"]' );
+				allMetaInputs.forEach( ( input ) => {
+					const name = input.getAttribute( 'name' );
+					if ( name && name.includes( '[value]' ) ) {
+						// Check if this is the meta field we want to update.
+						const row = input.closest( 'tr' );
+						if ( row ) {
+							const keyInput = row.querySelector( 'input[name*="[key]"]' );
+							if ( keyInput && keyInput.value === metaKey ) {
+								metaInput = input;
+							}
+						}
+					}
+				} );
+			}
+
+			if ( metaInput ) {
+				metaInput.addEventListener( 'input', ( event ) => {
+					updateCustomFieldDisplay( event.target.value );
+				} );
+				
+				metaInput.addEventListener( 'change', ( event ) => {
+					updateCustomFieldDisplay( event.target.value );
+				} );
+			}
+
+			// Listen for ACF field changes.
+			if ( targetFieldSettings.field_type === 'acf_field' && targetFieldSettings.meta_key ) {
+				const acfInputs = document.querySelectorAll( `input[name*="${targetFieldSettings.meta_key}"], textarea[name*="${targetFieldSettings.meta_key}"]` );
+				acfInputs.forEach( ( input ) => {
+					input.addEventListener( 'input', ( event ) => {
+						updateCustomFieldDisplay( event.target.value );
+					} );
+					
+					input.addEventListener( 'change', ( event ) => {
+						updateCustomFieldDisplay( event.target.value );
+					} );
+				} );
+			}
+		}
+
+		// Set up listeners when custom field info is shown.
+		function setupMetaFieldListenersAfterCustomField() {
+			if ( targetFieldSettings && targetFieldSettings.field_type !== 'post_excerpt' ) {
+				// Small delay to ensure DOM elements are available.
+				setTimeout( () => {
+					setupMetaFieldListeners();
+				}, 200 ); // Increased delay to ensure DOM is ready.
+			}
+		}
 
 		// Event handler registration to generate the excerpt.
 		$( document ).on(

--- a/src/js/features/excerpt-generation/classic/index.js
+++ b/src/js/features/excerpt-generation/classic/index.js
@@ -99,7 +99,7 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 			path: '/classifai/v1/get-target-field-settings/',
 		} ).then( ( result ) => {
 			targetFieldSettings = result;
-			
+
 			// If custom field is enabled, hide the default excerpt field and show custom field info.
 			if ( targetFieldSettings && targetFieldSettings.field_type !== 'post_excerpt' ) {
 				hideDefaultExcerptField();
@@ -176,10 +176,16 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 					style: 'margin-top: 10px;',
 				} ).append(
 					$( '<p>', {
-						html: __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' ) +
+						html: ( targetFieldSettings.field_type === 'acf_field' 
+							? __( 'This excerpt is stored in an ACF field. To edit it, you can:', 'classifai' )
+							: __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' )
+						) +
 							'<ul style="margin: 5px 0 0 20px;">' +
 							'<li>' + __( 'Use the regenerate excerpt button to regenerate it', 'classifai' ) + '</li>' +
-							'<li>' + __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' ) + '</li>' +
+							( targetFieldSettings.field_type === 'acf_field'
+								? '<li>' + __( 'Edit the ACF field directly in the post editor or ACF fields panel', 'classifai' ) + '</li>'
+								: '<li>' + __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' ) + '</li>'
+							) +
 							'<li>' + __( 'Change the target field in ', 'classifai' ) + 
 							'<a href="' + window.location.origin + '/wp-admin/tools.php?page=classifai&tab=language_processing&feature=feature_excerpt_generation" target="_blank" rel="noopener noreferrer">' + 
 							__( 'ClassifAI Settings', 'classifai' ) + '</a></li>' +
@@ -253,10 +259,16 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 				style: 'margin-top: 10px;',
 			} ).append(
 				$( '<p>', {
-					html: __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' ) +
+					html: ( targetFieldSettings.field_type === 'acf_field' 
+						? __( 'This excerpt is stored in an ACF field. To edit it, you can:', 'classifai' )
+						: __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' )
+					) +
 						'<ul style="margin: 5px 0 0 20px;">' +
 						'<li>' + __( 'Use the regenerate excerpt button to regenerate it', 'classifai' ) + '</li>' +
-						'<li>' + __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' ) + '</li>' +
+						( targetFieldSettings.field_type === 'acf_field'
+							? '<li>' + __( 'Edit the ACF field directly in the post editor or ACF fields panel', 'classifai' ) + '</li>'
+							: '<li>' + __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' ) + '</li>'
+						) +
 						'<li>' + __( 'Change the target field in ', 'classifai' ) + 
 						'<a href="' + window.location.origin + '/wp-admin/tools.php?page=classifai&tab=language_processing&feature=feature_excerpt_generation" target="_blank" rel="noopener noreferrer">' + 
 						__( 'ClassifAI Settings', 'classifai' ) + '</a></li>' +

--- a/src/js/features/excerpt-generation/classic/index.js
+++ b/src/js/features/excerpt-generation/classic/index.js
@@ -97,44 +97,51 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 		// Get target field settings.
 		apiFetch( {
 			path: '/classifai/v1/get-target-field-settings/',
-		} ).then( ( result ) => {
-			targetFieldSettings = result;
+		} )
+			.then( ( result ) => {
+				targetFieldSettings = result;
 
-			// If custom field is enabled, hide the default excerpt field and show custom field info.
-			if ( targetFieldSettings && targetFieldSettings.field_type !== 'post_excerpt' ) {
-				hideDefaultExcerptField();
-				showCustomFieldInfo();
-			}
-		} ).catch( () => {
-			// If endpoint doesn't exist, use default settings.
-			targetFieldSettings = {
-				field_type: 'post_excerpt',
-				field_name: __( 'Default excerpt field', 'classifai' ),
-			};
-		} );
+				// If custom field is enabled, hide the default excerpt field and show custom field info.
+				if (
+					targetFieldSettings &&
+					targetFieldSettings.field_type !== 'post_excerpt'
+				) {
+					hideDefaultExcerptField();
+					showCustomFieldInfo();
+				}
+			} )
+			.catch( () => {
+				// If endpoint doesn't exist, use default settings.
+				targetFieldSettings = {
+					field_type: 'post_excerpt',
+					field_name: __( 'Default excerpt field', 'classifai' ),
+				};
+			} );
 
 		// Function to hide the default excerpt field.
 		function hideDefaultExcerptField() {
 			// Hide the default excerpt textarea and label, but keep the #postexcerpt container.
 			const excerptTextarea = $( '#excerpt' );
 			const excerptLabel = $( 'label[for="excerpt"]' );
-			
+
 			if ( excerptTextarea.length ) {
 				excerptTextarea.hide();
 			}
-			
+
 			if ( excerptLabel.length ) {
 				excerptLabel.hide();
 			}
-			
+
 			// Hide any other default excerpt content, but not the regenerate button.
 			const defaultExcerptContent = $( '#postexcerpt .inside' );
 			if ( defaultExcerptContent.length ) {
 				defaultExcerptContent.hide();
 			}
-			
+
 			// Make sure the regenerate button is visible.
-			const regenerateButton = $( '#classifai-excerpt-generation__excerpt-generate-btn' );
+			const regenerateButton = $(
+				'#classifai-excerpt-generation__excerpt-generate-btn'
+			);
 			if ( regenerateButton.length ) {
 				regenerateButton.show();
 			}
@@ -142,97 +149,150 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 
 		// Function to show custom field info.
 		function showCustomFieldInfo() {
-			if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+			if (
+				! targetFieldSettings ||
+				targetFieldSettings.field_type === 'post_excerpt'
+			) {
 				return;
 			}
 
 			// Get the current value.
 			apiFetch( {
 				path: `/classifai/v1/get-target-field-value/${ postId }`,
-			} ).then( ( result ) => {
-				targetFieldValue = result.value || '';
-				
-				// Create custom field info container.
-				const customFieldContainer = $( '<div>', {
-					class: 'classifai-custom-excerpt-info',
-					style: 'margin: 0; padding: 15px; background: #f9f9f9; border: 1px solid #ddd; border-radius: 4px;',
-				} );
+			} )
+				.then( ( result ) => {
+					targetFieldValue = result.value || '';
 
-				const label = $( '<label>', {
-					text: targetFieldSettings.field_name || __( 'Custom excerpt', 'classifai' ),
-					style: 'display: block; margin-bottom: 8px; font-weight: 600; color: #23282d;',
-				} );
+					// Create custom field info container.
+					const customFieldContainer = $( '<div>', {
+						class: 'classifai-custom-excerpt-info',
+						style: 'margin: 0; padding: 15px; background: #f9f9f9; border: 1px solid #ddd; border-radius: 4px;',
+					} );
 
-				const textarea = $( '<textarea>', {
-					id: 'classifai-custom-excerpt',
-					text: targetFieldValue, // Use text() instead of value for textarea.
-					style: 'width: 100%; min-height: 120px; padding: 8px; border: 1px solid #ddd; border-radius: 3px; font-family: inherit; font-size: 14px; line-height: 1.4; resize: vertical; background: #f5f5f5;',
-					readonly: true,
-					placeholder: __( 'This field is read-only. The value is stored in a custom field.', 'classifai' ),
-				} );
+					const label = $( '<label>', {
+						text:
+							targetFieldSettings.field_name ||
+							__( 'Custom excerpt', 'classifai' ),
+						style: 'display: block; margin-bottom: 8px; font-weight: 600; color: #23282d;',
+					} );
 
-				const notice = $( '<div>', {
-					class: 'notice notice-info',
-					style: 'margin-top: 10px;',
-				} ).append(
-					$( '<p>', {
-						html: ( targetFieldSettings.field_type === 'acf_field' 
-							? __( 'This excerpt is stored in an ACF field. To edit it, you can:', 'classifai' )
-							: __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' )
-						) +
-							'<ul style="margin: 5px 0 0 20px;">' +
-							'<li>' + __( 'Use the regenerate excerpt button to regenerate it', 'classifai' ) + '</li>' +
-							( targetFieldSettings.field_type === 'acf_field'
-								? '<li>' + __( 'Edit the ACF field directly in the post editor or ACF fields panel', 'classifai' ) + '</li>'
-								: '<li>' + __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' ) + '</li>'
-							) +
-							'<li>' + __( 'Change the target field in ', 'classifai' ) + 
-							'<a href="' + window.location.origin + '/wp-admin/tools.php?page=classifai&tab=language_processing&feature=feature_excerpt_generation" target="_blank" rel="noopener noreferrer">' + 
-							__( 'ClassifAI Settings', 'classifai' ) + '</a></li>' +
-							'</ul>'
-					} )
-				);
+					const textarea = $( '<textarea>', {
+						id: 'classifai-custom-excerpt',
+						text: targetFieldValue, // Use text() instead of value for textarea.
+						style: 'width: 100%; min-height: 120px; padding: 8px; border: 1px solid #ddd; border-radius: 3px; font-family: inherit; font-size: 14px; line-height: 1.4; resize: vertical; background: #f5f5f5;',
+						readonly: true,
+						placeholder: __(
+							'This field is read-only. The value is stored in a custom field.',
+							'classifai'
+						),
+					} );
 
-				customFieldContainer.append( label, textarea, notice );
+					const notice = $( '<div>', {
+						class: 'notice notice-info',
+						style: 'margin-top: 10px;',
+					} ).append(
+						$( '<p>', {
+							html:
+								( targetFieldSettings.field_type === 'acf_field'
+									? __(
+											'This excerpt is stored in an ACF field. To edit it, you can:',
+											'classifai'
+									  )
+									: __(
+											'This excerpt is stored in a custom field. To edit it, you can:',
+											'classifai'
+									  ) ) +
+								'<ul style="margin: 5px 0 0 20px;">' +
+								'<li>' +
+								__(
+									'Use the regenerate excerpt button to regenerate it',
+									'classifai'
+								) +
+								'</li>' +
+								( targetFieldSettings.field_type === 'acf_field'
+									? '<li>' +
+									  __(
+											'Edit the ACF field directly in the post editor or ACF fields panel',
+											'classifai'
+									  ) +
+									  '</li>'
+									: '<li>' +
+									  __(
+											'Edit the custom field directly in the post editor or custom fields panel',
+											'classifai'
+									  ) +
+									  '</li>' ) +
+								'<li>' +
+								__(
+									'Change the target field in',
+									'classifai'
+								) +
+								'<a href="' +
+								window.location.origin +
+								'/wp-admin/tools.php?page=classifai&tab=language_processing&feature=feature_excerpt_generation" target="_blank" rel="noopener noreferrer">' +
+								__( 'ClassifAI Settings', 'classifai' ) +
+								'</a></li>' +
+								'</ul>',
+						} )
+					);
 
-				// Insert inside the #postexcerpt div.
-				const postExcerptDiv = $( '#postexcerpt' );
-				if ( postExcerptDiv.length ) {
-					postExcerptDiv.append( customFieldContainer );
-					
-					// Move the regenerate button to after the custom field container.
-					const regenerateButton = $( '#classifai-excerpt-generation__excerpt-generate-btn' );
-					if ( regenerateButton.length ) {
-						regenerateButton.detach().insertAfter( customFieldContainer ).show();
+					customFieldContainer.append( label, textarea, notice );
+
+					// Insert inside the #postexcerpt div.
+					const postExcerptDiv = $( '#postexcerpt' );
+					if ( postExcerptDiv.length ) {
+						postExcerptDiv.append( customFieldContainer );
+
+						// Move the regenerate button to after the custom field container.
+						const regenerateButton = $(
+							'#classifai-excerpt-generation__excerpt-generate-btn'
+						);
+						if ( regenerateButton.length ) {
+							regenerateButton
+								.detach()
+								.insertAfter( customFieldContainer )
+								.show();
+						}
+
+						// Move the error message as well.
+						const errorMessage = $(
+							'.classifai-excerpt-generation__excerpt-generate-error'
+						);
+						if ( errorMessage.length ) {
+							errorMessage
+								.detach()
+								.insertAfter( regenerateButton );
+						}
+
+						// Move the disable link as well
+						const disableLink = $(
+							'.classifai-excerpt-generation__excerpt-generate-disable-link'
+						);
+						if ( disableLink.length ) {
+							disableLink.detach().insertAfter( errorMessage );
+						}
+					} else {
+						// Fallback: insert after the title
+						$( '#title' )
+							.closest( 'tr' )
+							.after( customFieldContainer );
 					}
-					
-					// Move the error message as well.
-					const errorMessage = $( '.classifai-excerpt-generation__excerpt-generate-error' );
-					if ( errorMessage.length ) {
-						errorMessage.detach().insertAfter( regenerateButton );
-					}
-					
-					// Move the disable link as well
-					const disableLink = $( '.classifai-excerpt-generation__excerpt-generate-disable-link' );
-					if ( disableLink.length ) {
-						disableLink.detach().insertAfter( errorMessage );
-					}
-				} else {
-					// Fallback: insert after the title
-					$( '#title' ).closest( 'tr' ).after( customFieldContainer );
-				}
 
-				// Set up listeners for meta field changes
-				setupMetaFieldListenersAfterCustomField();
-			} ).catch( () => {
-				// If error, show custom field info with empty value.
-				showCustomFieldInfoWithValue( '' );
-			} );
+					// Set up listeners for meta field changes
+					setupMetaFieldListenersAfterCustomField();
+				} )
+				.catch( () => {
+					// If error, show custom field info with empty value.
+					showCustomFieldInfoWithValue( '' );
+				} );
 		}
 
 		// Function to show custom field info with a specific value
 		function showCustomFieldInfoWithValue( value ) {
-			if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+			if (
+				! targetFieldSettings ||
+				targetFieldSettings.field_type === 'post_excerpt'
+			) {
 				return;
 			}
 
@@ -242,7 +302,9 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 			} );
 
 			const label = $( '<label>', {
-				text: targetFieldSettings.field_name || __( 'Custom excerpt', 'classifai' ),
+				text:
+					targetFieldSettings.field_name ||
+					__( 'Custom excerpt', 'classifai' ),
 				style: 'display: block; margin-bottom: 8px; font-weight: 600; color: #23282d;',
 			} );
 
@@ -251,7 +313,10 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 				text: value,
 				style: 'width: 100%; min-height: 120px; padding: 8px; border: 1px solid #ddd; border-radius: 3px; font-family: inherit; font-size: 14px; line-height: 1.4; resize: vertical; background: #f5f5f5;',
 				readonly: true,
-				placeholder: __( 'This field is read-only. The value is stored in a custom field.', 'classifai' ),
+				placeholder: __(
+					'This field is read-only. The value is stored in a custom field.',
+					'classifai'
+				),
 			} );
 
 			const notice = $( '<div>', {
@@ -259,20 +324,44 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 				style: 'margin-top: 10px;',
 			} ).append(
 				$( '<p>', {
-					html: ( targetFieldSettings.field_type === 'acf_field' 
-						? __( 'This excerpt is stored in an ACF field. To edit it, you can:', 'classifai' )
-						: __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' )
-					) +
-						'<ul style="margin: 5px 0 0 20px;">' +
-						'<li>' + __( 'Use the regenerate excerpt button to regenerate it', 'classifai' ) + '</li>' +
+					html:
 						( targetFieldSettings.field_type === 'acf_field'
-							? '<li>' + __( 'Edit the ACF field directly in the post editor or ACF fields panel', 'classifai' ) + '</li>'
-							: '<li>' + __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' ) + '</li>'
+							? __(
+									'This excerpt is stored in an ACF field. To edit it, you can:',
+									'classifai'
+							  )
+							: __(
+									'This excerpt is stored in a custom field. To edit it, you can:',
+									'classifai'
+							  ) ) +
+						'<ul style="margin: 5px 0 0 20px;">' +
+						'<li>' +
+						__(
+							'Use the regenerate excerpt button to regenerate it',
+							'classifai'
 						) +
-						'<li>' + __( 'Change the target field in ', 'classifai' ) + 
-						'<a href="' + window.location.origin + '/wp-admin/tools.php?page=classifai&tab=language_processing&feature=feature_excerpt_generation" target="_blank" rel="noopener noreferrer">' + 
-						__( 'ClassifAI Settings', 'classifai' ) + '</a></li>' +
-						'</ul>'
+						'</li>' +
+						( targetFieldSettings.field_type === 'acf_field'
+							? '<li>' +
+							  __(
+									'Edit the ACF field directly in the post editor or ACF fields panel',
+									'classifai'
+							  ) +
+							  '</li>'
+							: '<li>' +
+							  __(
+									'Edit the custom field directly in the post editor or custom fields panel',
+									'classifai'
+							  ) +
+							  '</li>' ) +
+						'<li>' +
+						__( 'Change the target field in', 'classifai' ) +
+						'<a href="' +
+						window.location.origin +
+						'/wp-admin/tools.php?page=classifai&tab=language_processing&feature=feature_excerpt_generation" target="_blank" rel="noopener noreferrer">' +
+						__( 'ClassifAI Settings', 'classifai' ) +
+						'</a></li>' +
+						'</ul>',
 				} )
 			);
 
@@ -282,21 +371,30 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 			const postExcerptDiv = $( '#postexcerpt' );
 			if ( postExcerptDiv.length ) {
 				postExcerptDiv.append( customFieldContainer );
-				
+
 				// Move the regenerate button to after the custom field container.
-				const regenerateButton = $( '#classifai-excerpt-generation__excerpt-generate-btn' );
+				const regenerateButton = $(
+					'#classifai-excerpt-generation__excerpt-generate-btn'
+				);
 				if ( regenerateButton.length ) {
-					regenerateButton.detach().insertAfter( customFieldContainer ).show();
+					regenerateButton
+						.detach()
+						.insertAfter( customFieldContainer )
+						.show();
 				}
-				
+
 				// Move the error message as well.
-				const errorMessage = $( '.classifai-excerpt-generation__excerpt-generate-error' );
+				const errorMessage = $(
+					'.classifai-excerpt-generation__excerpt-generate-error'
+				);
 				if ( errorMessage.length ) {
 					errorMessage.detach().insertAfter( regenerateButton );
 				}
-				
+
 				// Move the disable link as well.
-				const disableLink = $( '.classifai-excerpt-generation__excerpt-generate-disable-link' );
+				const disableLink = $(
+					'.classifai-excerpt-generation__excerpt-generate-disable-link'
+				);
 				if ( disableLink.length ) {
 					disableLink.detach().insertAfter( errorMessage );
 				}
@@ -352,14 +450,19 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 						}
 					} else {
 						// Check if we should update the custom field or default excerpt.
-						if ( targetFieldSettings && targetFieldSettings.field_type !== 'post_excerpt' ) {
+						if (
+							targetFieldSettings &&
+							targetFieldSettings.field_type !== 'post_excerpt'
+						) {
 							// Update custom field display first.
-							const customField = $( '#classifai-custom-excerpt' );
+							const customField = $(
+								'#classifai-custom-excerpt'
+							);
 							if ( customField.length ) {
 								customField.text( result );
 								targetFieldValue = result;
 							}
-							
+
 							// Update visible meta field values on the page (this also updates custom field display).
 							updateVisibleMetaFields( result );
 						} else {
@@ -376,18 +479,23 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 
 					// Show notification about target field if different from excerpt.
 					if ( classifaiExcerptData?.target_field_info ) {
-						const targetInfo = classifaiExcerptData.target_field_info;
+						const targetInfo =
+							classifaiExcerptData.target_field_info;
 						if ( targetInfo.field_type !== 'post_excerpt' ) {
 							const notification = $( '<div>', {
 								class: 'notice notice-success',
 								style: 'margin-top: 10px;',
 							} ).append(
 								$( '<p>', {
-									text: __( 'Excerpt generated and saved to target field: ', 'classifai' ) + targetInfo.field_name,
+									text:
+										__(
+											'Excerpt generated and saved to target field:',
+											'classifai'
+										) + targetInfo.field_name,
 								} )
 							);
 							$( excerptContainer ).after( notification );
-							
+
 							// Remove notification after 5 seconds.
 							setTimeout( () => {
 								notification.fadeOut();
@@ -405,29 +513,39 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 
 		// Function to update visible meta field values on the page.
 		function updateVisibleMetaFields( value ) {
-			if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+			if (
+				! targetFieldSettings ||
+				targetFieldSettings.field_type === 'post_excerpt'
+			) {
 				return;
 			}
 
-			const metaKey = targetFieldSettings.meta_key || targetFieldSettings.field_name;
+			const metaKey =
+				targetFieldSettings.meta_key || targetFieldSettings.field_name;
 			if ( ! metaKey ) {
 				return;
 			}
 
 			// Update meta field input that is visible on the page.
 			// Try multiple selectors to find the meta field.
-			let metaInput = document.querySelector( `textarea[name="meta[${ metaKey }][value]"]` );
-			
+			let metaInput = document.querySelector(
+				`textarea[name="meta[${ metaKey }][value]"]`
+			);
+
 			// If not found with exact match, try a more flexible approach.
 			if ( ! metaInput ) {
-				const allMetaInputs = document.querySelectorAll( 'textarea[name*="[value]"]' );
+				const allMetaInputs = document.querySelectorAll(
+					'textarea[name*="[value]"]'
+				);
 				allMetaInputs.forEach( ( input ) => {
 					const name = input.getAttribute( 'name' );
 					if ( name && name.includes( '[value]' ) ) {
 						// Check if this is the meta field we want to update.
 						const row = input.closest( 'tr' );
 						if ( row ) {
-							const keyInput = row.querySelector( 'input[name*="[key]"]' );
+							const keyInput = row.querySelector(
+								'input[name*="[key]"]'
+							);
 							if ( keyInput && keyInput.value === metaKey ) {
 								metaInput = input;
 							}
@@ -449,16 +567,23 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 			}
 
 			// Also check for ACF fields if this is an ACF field.
-			if ( targetFieldSettings.field_type === 'acf_field' && targetFieldSettings.meta_key ) {
-				const acfInputs = document.querySelectorAll( `input[name*="${targetFieldSettings.meta_key}"], textarea[name*="${targetFieldSettings.meta_key}"]` );
+			if (
+				targetFieldSettings.field_type === 'acf_field' &&
+				targetFieldSettings.meta_key
+			) {
+				const acfInputs = document.querySelectorAll(
+					`input[name*="${ targetFieldSettings.meta_key }"], textarea[name*="${ targetFieldSettings.meta_key }"]`
+				);
 				acfInputs.forEach( ( input ) => {
 					input.value = value;
-					
+
 					// Trigger change events.
 					const inputEvent = new Event( 'input', { bubbles: true } );
 					input.dispatchEvent( inputEvent );
-					
-					const changeEvent = new Event( 'change', { bubbles: true } );
+
+					const changeEvent = new Event( 'change', {
+						bubbles: true,
+					} );
 					input.dispatchEvent( changeEvent );
 				} );
 			}
@@ -475,7 +600,9 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 				targetFieldValue = value;
 			} else {
 				// If custom field is not found, try to find it with a more flexible selector.
-				const customFieldAlt = $( '.classifai-custom-excerpt-info textarea' );
+				const customFieldAlt = $(
+					'.classifai-custom-excerpt-info textarea'
+				);
 				if ( customFieldAlt.length ) {
 					customFieldAlt.text( value );
 					targetFieldValue = value;
@@ -485,29 +612,39 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 
 		// Function to listen for changes in meta fields and update our custom field display.
 		function setupMetaFieldListeners() {
-			if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+			if (
+				! targetFieldSettings ||
+				targetFieldSettings.field_type === 'post_excerpt'
+			) {
 				return;
 			}
 
-			const metaKey = targetFieldSettings.meta_key || targetFieldSettings.field_name;
+			const metaKey =
+				targetFieldSettings.meta_key || targetFieldSettings.field_name;
 			if ( ! metaKey ) {
 				return;
 			}
 
 			// Listen for changes in meta field inputs (including both textarea and input for consistency).
 			// Try multiple selectors to find the meta field.
-			let metaInput = document.querySelector( `textarea[name="meta[${ metaKey }][value]"]` );
-			
+			let metaInput = document.querySelector(
+				`textarea[name="meta[${ metaKey }][value]"]`
+			);
+
 			// If not found with exact match, try a more flexible approach
 			if ( ! metaInput ) {
-				const allMetaInputs = document.querySelectorAll( 'textarea[name*="[value]"]' );
+				const allMetaInputs = document.querySelectorAll(
+					'textarea[name*="[value]"]'
+				);
 				allMetaInputs.forEach( ( input ) => {
 					const name = input.getAttribute( 'name' );
 					if ( name && name.includes( '[value]' ) ) {
 						// Check if this is the meta field we want to update.
 						const row = input.closest( 'tr' );
 						if ( row ) {
-							const keyInput = row.querySelector( 'input[name*="[key]"]' );
+							const keyInput = row.querySelector(
+								'input[name*="[key]"]'
+							);
 							if ( keyInput && keyInput.value === metaKey ) {
 								metaInput = input;
 							}
@@ -520,20 +657,25 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 				metaInput.addEventListener( 'input', ( event ) => {
 					updateCustomFieldDisplay( event.target.value );
 				} );
-				
+
 				metaInput.addEventListener( 'change', ( event ) => {
 					updateCustomFieldDisplay( event.target.value );
 				} );
 			}
 
 			// Listen for ACF field changes.
-			if ( targetFieldSettings.field_type === 'acf_field' && targetFieldSettings.meta_key ) {
-				const acfInputs = document.querySelectorAll( `input[name*="${targetFieldSettings.meta_key}"], textarea[name*="${targetFieldSettings.meta_key}"]` );
+			if (
+				targetFieldSettings.field_type === 'acf_field' &&
+				targetFieldSettings.meta_key
+			) {
+				const acfInputs = document.querySelectorAll(
+					`input[name*="${ targetFieldSettings.meta_key }"], textarea[name*="${ targetFieldSettings.meta_key }"]`
+				);
 				acfInputs.forEach( ( input ) => {
 					input.addEventListener( 'input', ( event ) => {
 						updateCustomFieldDisplay( event.target.value );
 					} );
-					
+
 					input.addEventListener( 'change', ( event ) => {
 						updateCustomFieldDisplay( event.target.value );
 					} );
@@ -543,7 +685,10 @@ const classifaiExcerptData = window.classifaiGenerateExcerpt || {};
 
 		// Set up listeners when custom field info is shown.
 		function setupMetaFieldListenersAfterCustomField() {
-			if ( targetFieldSettings && targetFieldSettings.field_type !== 'post_excerpt' ) {
+			if (
+				targetFieldSettings &&
+				targetFieldSettings.field_type !== 'post_excerpt'
+			) {
 				// Small delay to ensure DOM elements are available.
 				setTimeout( () => {
 					setupMetaFieldListeners();

--- a/src/js/features/excerpt-generation/panel.js
+++ b/src/js/features/excerpt-generation/panel.js
@@ -3,9 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button, ExternalLink, TextareaControl } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withSelect, withDispatch, useSelect, select } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -172,7 +172,7 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 			) }
 			{ targetFieldValue && targetFieldValue !== excerpt && (
 				<div style={ { marginTop: '1rem', padding: '10px', backgroundColor: '#f0f0f0', borderRadius: '4px' } }>
-					<strong>{ __( 'Target field value:', 'classifai' ) }</strong>
+					<strong>{ __( 'Custom excerpt:', 'classifai' ) }</strong>
 					<p style={ { margin: '5px 0 0 0' } }>{ targetFieldValue }</p>
 				</div>
 			) }

--- a/src/js/features/excerpt-generation/panel.js
+++ b/src/js/features/excerpt-generation/panel.js
@@ -294,13 +294,19 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 						isDismissible={ false }
 						className="classifai-custom-field-notice"
 					>
-						{ __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' ) }
+						{ targetFieldSettings?.field_type === 'acf_field' 
+							? __( 'This excerpt is stored in an ACF field. To edit it, you can:', 'classifai' )
+							: __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' )
+						}
 						<ul style={ { margin: '5px 0 0 20px' } }>
 							<li>
 								{ __( 'Use the button below to regenerate it', 'classifai' ) }
 							</li>
 							<li>
-								{ __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' ) }
+								{ targetFieldSettings?.field_type === 'acf_field'
+									? __( 'Edit the ACF field directly in the post editor or ACF fields panel', 'classifai' )
+									: __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' )
+								}
 							</li>
 							<li>
 								{ __( 'Change the target field in ', 'classifai' ) }

--- a/src/js/features/excerpt-generation/panel.js
+++ b/src/js/features/excerpt-generation/panel.js
@@ -2,7 +2,7 @@
  * External Dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { Button, ExternalLink, TextareaControl } from '@wordpress/components';
+import { Button, ExternalLink, TextareaControl, Notice } from '@wordpress/components';
 import { withSelect, withDispatch, useSelect, select } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { useState, useEffect } from '@wordpress/element';
@@ -29,6 +29,7 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ error, setError ] = useState( false );
 	const [ targetFieldValue, setTargetFieldValue ] = useState( '' );
+	const [ targetFieldSettings, setTargetFieldSettings ] = useState( null );
 
 	const postId = useSelect( ( select ) =>
 		select( 'core/editor' ).getCurrentPostId()
@@ -37,15 +38,29 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 		select( 'core/edit-post' ).isPublishSidebarOpened()
 	);
 
-	// Get target field value on component mount.
+	// Get target field settings and value on component mount.
 	useEffect( () => {
 		if ( postId ) {
+			// Get target field settings
+			apiFetch( {
+				path: '/classifai/v1/get-target-field-settings/',
+			} ).then( ( result ) => {
+				setTargetFieldSettings( result );
+			} ).catch( () => {
+				// Fall back to default settings.
+				setTargetFieldSettings( {
+					field_type: 'post_excerpt',
+					field_name: __( 'Default excerpt field', 'classifai' ),
+				} );
+			} );
+
+			// Get target field value
 			apiFetch( {
 				path: `/classifai/v1/get-target-field-value/${ postId }`,
 			} ).then( ( result ) => {
 				setTargetFieldValue( result.value || '' );
 			} ).catch( () => {
-				// If endpoint doesn't exist, fall back to excerpt.
+				// Fall back to default excerpt.
 				setTargetFieldValue( excerpt || '' );
 			} );
 		}
@@ -110,6 +125,9 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 				setTargetFieldValue( res.trim() );
 				setError( false );
 				setIsLoading( false );
+
+				// Update visible meta field values on the page if they exist.
+				updateVisibleMetaFields( res.trim() );
 			},
 			( err ) => {
 				setError( err?.message );
@@ -118,28 +136,187 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 		);
 	};
 
+	// Function to update visible meta field values on the page.
+	const updateVisibleMetaFields = ( value ) => {
+		if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+			return;
+		}
+
+		const metaKey = targetFieldSettings.meta_key || targetFieldSettings.field_name;
+		if ( ! metaKey ) {
+			return;
+		}
+
+		// Update meta field input that is visible on the page.
+		// Directly target the textarea by its name attribute using the metaKey.
+		const metaInput = document.querySelector( `textarea[name="meta[${ metaKey }][value]"]` );
+		if ( metaInput ) {
+			metaInput.value = value;
+
+			// Trigger input event to notify any listeners.
+			const inputEvent = new Event( 'input', { bubbles: true } );
+			metaInput.dispatchEvent( inputEvent );
+
+			// Also trigger change event.
+			const changeEvent = new Event( 'change', { bubbles: true } );
+			metaInput.dispatchEvent( changeEvent );
+		}
+
+		// Also check for ACF fields if this is an ACF field
+		if ( targetFieldSettings.field_type === 'acf_field' && targetFieldSettings.meta_key ) {
+			const acfInputs = document.querySelectorAll( `input[name*="${targetFieldSettings.meta_key}"], textarea[name*="${targetFieldSettings.meta_key}"]` );
+			acfInputs.forEach( ( input ) => {
+				input.value = value;
+				
+				// Trigger change events
+				const inputEvent = new Event( 'input', { bubbles: true } );
+				input.dispatchEvent( inputEvent );
+				
+				const changeEvent = new Event( 'change', { bubbles: true } );
+				input.dispatchEvent( changeEvent );
+			} );
+		}
+	};
+
+	// Function to update the custom field display when meta field values change
+	const updateCustomFieldDisplay = ( value ) => {
+		if ( ! shouldShowCustomField ) {
+			return;
+		}
+
+		// Update the target field value state
+		setTargetFieldValue( value );
+	};
+
+	// Function to listen for changes in meta fields and update our custom field display
+	const setupMetaFieldListeners = () => {
+		if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+			return;
+		}
+
+		const metaKey = targetFieldSettings.meta_key || targetFieldSettings.field_name;
+		if ( ! metaKey ) {
+			return;
+		}
+
+		// Listen for changes in meta field inputs (including both textarea and input for consistency).
+		// Directly target the textarea by its name attribute using the metaKey.
+		const metaInput = document.querySelector( `textarea[name="meta[${ metaKey }][value]"]` );
+
+		if ( metaInput ) {
+			metaInput.addEventListener( 'input', ( event ) => {
+				updateCustomFieldDisplay( event.target.value );
+			} );
+			
+			metaInput.addEventListener( 'change', ( event ) => {
+				updateCustomFieldDisplay( event.target.value );
+			} );
+		}
+
+		// Listen for ACF field changes
+		if ( targetFieldSettings.field_type === 'acf_field' && targetFieldSettings.meta_key ) {
+			const acfInputs = document.querySelectorAll( `input[name*="${targetFieldSettings.meta_key}"], textarea[name*="${targetFieldSettings.meta_key}"]` );
+			acfInputs.forEach( ( input ) => {
+				input.addEventListener( 'input', ( event ) => {
+					updateCustomFieldDisplay( event.target.value );
+				} );
+				
+				input.addEventListener( 'change', ( event ) => {
+					updateCustomFieldDisplay( event.target.value );
+				} );
+			} );
+		}
+	};
+
+	// Set up listeners when component mounts or target field settings change
+	useEffect( () => {
+		if ( targetFieldSettings && targetFieldSettings.field_type !== 'post_excerpt' ) {
+			// Small delay to ensure DOM elements are available.
+			const timer = setTimeout( () => {
+				setupMetaFieldListeners();
+			}, 100 );
+
+			return () => {
+				clearTimeout( timer );
+			};
+		}
+	}, [ targetFieldSettings ] );
+
+	// Check if we should show the custom field instead of the default excerpt field
+	const shouldShowCustomField = targetFieldSettings && targetFieldSettings.field_type !== 'post_excerpt';
+	const fieldLabel = shouldShowCustomField 
+		? targetFieldSettings?.field_name || __( 'Custom excerpt', 'classifai' )
+		: __( 'Write an excerpt (optional)', 'classifai' );
+
 	return (
 		<div className="editor-post-excerpt">
-			<TextareaControl
-				__nextHasNoMarginBottom
-				label={
-					! isPublishPanelOpen
-						? __( 'Write an excerpt (optional)' )
-						: null
-				}
-				className="editor-post-excerpt__textarea"
-				onChange={ ( value ) => onUpdateExcerpt( value ) }
-				value={ excerpt }
-			/>
-			{ ! isPublishPanelOpen && (
-				<ExternalLink
-					href={ __(
-						'https://wordpress.org/support/article/settings-sidebar/#excerpt'
+			{ ! shouldShowCustomField && (
+				<>
+					<TextareaControl
+						__nextHasNoMarginBottom
+						label={
+							! isPublishPanelOpen
+								? __( 'Write an excerpt (optional)' )
+								: null
+						}
+						className="editor-post-excerpt__textarea"
+						onChange={ ( value ) => onUpdateExcerpt( value ) }
+						value={ excerpt }
+					/>
+					{ ! isPublishPanelOpen && (
+						<ExternalLink
+							href={ __(
+								'https://wordpress.org/support/article/settings-sidebar/#excerpt'
+							) }
+						>
+							{ __( 'Learn more about manual excerpts' ) }
+						</ExternalLink>
 					) }
-				>
-					{ __( 'Learn more about manual excerpts' ) }
-				</ExternalLink>
+				</>
 			) }
+			
+			{ shouldShowCustomField && (
+				<>
+					<TextareaControl
+						__nextHasNoMarginBottom
+						label={
+							! isPublishPanelOpen
+								? fieldLabel
+								: null
+						}
+						className="editor-post-excerpt__textarea"
+						value={ targetFieldValue }
+						readOnly
+						help={ __( 'This field is read-only. The value is stored in a custom field.', 'classifai' ) }
+					/>
+					<Notice 
+						status="info" 
+						isDismissible={ false }
+						className="classifai-custom-field-notice"
+					>
+						{ __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' ) }
+						<ul style={ { margin: '5px 0 0 20px' } }>
+							<li>
+								{ __( 'Use the button below to regenerate it', 'classifai' ) }
+							</li>
+							<li>
+								{ __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' ) }
+							</li>
+							<li>
+								{ __( 'Change the target field in ', 'classifai' ) }
+								<a 
+									href={ `${ window.location.origin }/wp-admin/tools.php?page=classifai&tab=language_processing&feature=feature_excerpt_generation` }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{ __( 'ClassifAI Settings', 'classifai' ) }
+								</a>
+							</li>
+						</ul>
+					</Notice>
+				</>
+			) }
+
 			<Button
 				className="classifai-post-excerpt"
 				variant={ 'secondary' }
@@ -169,12 +346,6 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 				>
 					{ error }
 				</span>
-			) }
-			{ targetFieldValue && targetFieldValue !== excerpt && (
-				<div style={ { marginTop: '1rem', padding: '10px', backgroundColor: '#f0f0f0', borderRadius: '4px' } }>
-					<strong>{ __( 'Custom excerpt:', 'classifai' ) }</strong>
-					<p style={ { margin: '5px 0 0 0' } }>{ targetFieldValue }</p>
-				</div>
 			) }
 			<DisableFeatureButton feature="feature_excerpt_generation" />
 		</div>

--- a/src/js/features/excerpt-generation/panel.js
+++ b/src/js/features/excerpt-generation/panel.js
@@ -36,11 +36,11 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	const [ targetFieldValue, setTargetFieldValue ] = useState( '' );
 	const [ targetFieldSettings, setTargetFieldSettings ] = useState( null );
 
-	const postId = useSelect( ( select ) =>
-		select( 'core/editor' ).getCurrentPostId()
+	const postId = useSelect( ( wpSelect ) =>
+		wpSelect( 'core/editor' ).getCurrentPostId()
 	);
-	const isPublishPanelOpen = useSelect( ( select ) =>
-		select( 'core/edit-post' ).isPublishSidebarOpened()
+	const isPublishPanelOpen = useSelect( ( wpSelect ) =>
+		wpSelect( 'core/edit-post' ).isPublishSidebarOpened()
 	);
 
 	// Get target field settings and value on component mount.
@@ -411,10 +411,10 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 }
 
 export default compose( [
-	withSelect( ( select ) => {
+	withSelect( ( wpSelect ) => {
 		return {
 			excerpt:
-				select( 'core/editor' ).getEditedPostAttribute( 'excerpt' ),
+				wpSelect( 'core/editor' ).getEditedPostAttribute( 'excerpt' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/src/js/features/excerpt-generation/panel.js
+++ b/src/js/features/excerpt-generation/panel.js
@@ -2,7 +2,12 @@
  * External Dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { Button, ExternalLink, TextareaControl, Notice } from '@wordpress/components';
+import {
+	Button,
+	ExternalLink,
+	TextareaControl,
+	Notice,
+} from '@wordpress/components';
 import { withSelect, withDispatch, useSelect, select } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { useState, useEffect } from '@wordpress/element';
@@ -44,25 +49,29 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 			// Get target field settings
 			apiFetch( {
 				path: '/classifai/v1/get-target-field-settings/',
-			} ).then( ( result ) => {
-				setTargetFieldSettings( result );
-			} ).catch( () => {
-				// Fall back to default settings.
-				setTargetFieldSettings( {
-					field_type: 'post_excerpt',
-					field_name: __( 'Default excerpt field', 'classifai' ),
+			} )
+				.then( ( result ) => {
+					setTargetFieldSettings( result );
+				} )
+				.catch( () => {
+					// Fall back to default settings.
+					setTargetFieldSettings( {
+						field_type: 'post_excerpt',
+						field_name: __( 'Default excerpt field', 'classifai' ),
+					} );
 				} );
-			} );
 
 			// Get target field value
 			apiFetch( {
 				path: `/classifai/v1/get-target-field-value/${ postId }`,
-			} ).then( ( result ) => {
-				setTargetFieldValue( result.value || '' );
-			} ).catch( () => {
-				// Fall back to default excerpt.
-				setTargetFieldValue( excerpt || '' );
-			} );
+			} )
+				.then( ( result ) => {
+					setTargetFieldValue( result.value || '' );
+				} )
+				.catch( () => {
+					// Fall back to default excerpt.
+					setTargetFieldValue( excerpt || '' );
+				} );
 		}
 	}, [ postId, excerpt ] );
 
@@ -138,18 +147,24 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 
 	// Function to update visible meta field values on the page.
 	const updateVisibleMetaFields = ( value ) => {
-		if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+		if (
+			! targetFieldSettings ||
+			targetFieldSettings.field_type === 'post_excerpt'
+		) {
 			return;
 		}
 
-		const metaKey = targetFieldSettings.meta_key || targetFieldSettings.field_name;
+		const metaKey =
+			targetFieldSettings.meta_key || targetFieldSettings.field_name;
 		if ( ! metaKey ) {
 			return;
 		}
 
 		// Update meta field input that is visible on the page.
 		// Directly target the textarea by its name attribute using the metaKey.
-		const metaInput = document.querySelector( `textarea[name="meta[${ metaKey }][value]"]` );
+		const metaInput = document.querySelector(
+			`textarea[name="meta[${ metaKey }][value]"]`
+		);
 		if ( metaInput ) {
 			metaInput.value = value;
 
@@ -163,15 +178,20 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 		}
 
 		// Also check for ACF fields if this is an ACF field
-		if ( targetFieldSettings.field_type === 'acf_field' && targetFieldSettings.meta_key ) {
-			const acfInputs = document.querySelectorAll( `input[name*="${targetFieldSettings.meta_key}"], textarea[name*="${targetFieldSettings.meta_key}"]` );
+		if (
+			targetFieldSettings.field_type === 'acf_field' &&
+			targetFieldSettings.meta_key
+		) {
+			const acfInputs = document.querySelectorAll(
+				`input[name*="${ targetFieldSettings.meta_key }"], textarea[name*="${ targetFieldSettings.meta_key }"]`
+			);
 			acfInputs.forEach( ( input ) => {
 				input.value = value;
-				
+
 				// Trigger change events
 				const inputEvent = new Event( 'input', { bubbles: true } );
 				input.dispatchEvent( inputEvent );
-				
+
 				const changeEvent = new Event( 'change', { bubbles: true } );
 				input.dispatchEvent( changeEvent );
 			} );
@@ -190,37 +210,48 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 
 	// Function to listen for changes in meta fields and update our custom field display
 	const setupMetaFieldListeners = () => {
-		if ( ! targetFieldSettings || targetFieldSettings.field_type === 'post_excerpt' ) {
+		if (
+			! targetFieldSettings ||
+			targetFieldSettings.field_type === 'post_excerpt'
+		) {
 			return;
 		}
 
-		const metaKey = targetFieldSettings.meta_key || targetFieldSettings.field_name;
+		const metaKey =
+			targetFieldSettings.meta_key || targetFieldSettings.field_name;
 		if ( ! metaKey ) {
 			return;
 		}
 
 		// Listen for changes in meta field inputs (including both textarea and input for consistency).
 		// Directly target the textarea by its name attribute using the metaKey.
-		const metaInput = document.querySelector( `textarea[name="meta[${ metaKey }][value]"]` );
+		const metaInput = document.querySelector(
+			`textarea[name="meta[${ metaKey }][value]"]`
+		);
 
 		if ( metaInput ) {
 			metaInput.addEventListener( 'input', ( event ) => {
 				updateCustomFieldDisplay( event.target.value );
 			} );
-			
+
 			metaInput.addEventListener( 'change', ( event ) => {
 				updateCustomFieldDisplay( event.target.value );
 			} );
 		}
 
 		// Listen for ACF field changes
-		if ( targetFieldSettings.field_type === 'acf_field' && targetFieldSettings.meta_key ) {
-			const acfInputs = document.querySelectorAll( `input[name*="${targetFieldSettings.meta_key}"], textarea[name*="${targetFieldSettings.meta_key}"]` );
+		if (
+			targetFieldSettings.field_type === 'acf_field' &&
+			targetFieldSettings.meta_key
+		) {
+			const acfInputs = document.querySelectorAll(
+				`input[name*="${ targetFieldSettings.meta_key }"], textarea[name*="${ targetFieldSettings.meta_key }"]`
+			);
 			acfInputs.forEach( ( input ) => {
 				input.addEventListener( 'input', ( event ) => {
 					updateCustomFieldDisplay( event.target.value );
 				} );
-				
+
 				input.addEventListener( 'change', ( event ) => {
 					updateCustomFieldDisplay( event.target.value );
 				} );
@@ -230,7 +261,10 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 
 	// Set up listeners when component mounts or target field settings change
 	useEffect( () => {
-		if ( targetFieldSettings && targetFieldSettings.field_type !== 'post_excerpt' ) {
+		if (
+			targetFieldSettings &&
+			targetFieldSettings.field_type !== 'post_excerpt'
+		) {
 			// Small delay to ensure DOM elements are available.
 			const timer = setTimeout( () => {
 				setupMetaFieldListeners();
@@ -243,8 +277,10 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	}, [ targetFieldSettings ] );
 
 	// Check if we should show the custom field instead of the default excerpt field
-	const shouldShowCustomField = targetFieldSettings && targetFieldSettings.field_type !== 'post_excerpt';
-	const fieldLabel = shouldShowCustomField 
+	const shouldShowCustomField =
+		targetFieldSettings &&
+		targetFieldSettings.field_type !== 'post_excerpt';
+	const fieldLabel = shouldShowCustomField
 		? targetFieldSettings?.field_name || __( 'Custom excerpt', 'classifai' )
 		: __( 'Write an excerpt (optional)', 'classifai' );
 
@@ -274,43 +310,59 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 					) }
 				</>
 			) }
-			
+
 			{ shouldShowCustomField && (
 				<>
 					<TextareaControl
 						__nextHasNoMarginBottom
-						label={
-							! isPublishPanelOpen
-								? fieldLabel
-								: null
-						}
+						label={ ! isPublishPanelOpen ? fieldLabel : null }
 						className="editor-post-excerpt__textarea"
 						value={ targetFieldValue }
 						readOnly
-						help={ __( 'This field is read-only. The value is stored in a custom field.', 'classifai' ) }
+						help={ __(
+							'This field is read-only. The value is stored in a custom field.',
+							'classifai'
+						) }
 					/>
-					<Notice 
-						status="info" 
+					<Notice
+						status="info"
 						isDismissible={ false }
 						className="classifai-custom-field-notice"
 					>
-						{ targetFieldSettings?.field_type === 'acf_field' 
-							? __( 'This excerpt is stored in an ACF field. To edit it, you can:', 'classifai' )
-							: __( 'This excerpt is stored in a custom field. To edit it, you can:', 'classifai' )
-						}
+						{ targetFieldSettings?.field_type === 'acf_field'
+							? __(
+									'This excerpt is stored in an ACF field. To edit it, you can:',
+									'classifai'
+							  )
+							: __(
+									'This excerpt is stored in a custom field. To edit it, you can:',
+									'classifai'
+							  ) }
 						<ul style={ { margin: '5px 0 0 20px' } }>
 							<li>
-								{ __( 'Use the button below to regenerate it', 'classifai' ) }
+								{ __(
+									'Use the button below to regenerate it',
+									'classifai'
+								) }
 							</li>
 							<li>
-								{ targetFieldSettings?.field_type === 'acf_field'
-									? __( 'Edit the ACF field directly in the post editor or ACF fields panel', 'classifai' )
-									: __( 'Edit the custom field directly in the post editor or custom fields panel', 'classifai' )
-								}
+								{ targetFieldSettings?.field_type ===
+								'acf_field'
+									? __(
+											'Edit the ACF field directly in the post editor or ACF fields panel',
+											'classifai'
+									  )
+									: __(
+											'Edit the custom field directly in the post editor or custom fields panel',
+											'classifai'
+									  ) }
 							</li>
 							<li>
-								{ __( 'Change the target field in ', 'classifai' ) }
-								<a 
+								{ __(
+									'Change the target field in',
+									'classifai'
+								) }
+								<a
 									href={ `${ window.location.origin }/wp-admin/tools.php?page=classifai&tab=language_processing&feature=feature_excerpt_generation` }
 									target="_blank"
 									rel="noopener noreferrer"

--- a/src/js/features/excerpt-generation/panel.js
+++ b/src/js/features/excerpt-generation/panel.js
@@ -28,14 +28,32 @@ import { browserAITextGeneration } from '../../helpers';
 function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ error, setError ] = useState( false );
+	const [ targetFieldValue, setTargetFieldValue ] = useState( '' );
 
-	const { select } = wp.data;
-	const postId = select( 'core/editor' ).getCurrentPostId();
-	const buttonText =
-		'' === excerpt
-			? __( 'Generate excerpt', 'classifai' )
-			: __( 'Re-generate excerpt', 'classifai' );
-	const isPublishPanelOpen = select( 'core/editor' ).isPublishSidebarOpened();
+	const postId = useSelect( ( select ) =>
+		select( 'core/editor' ).getCurrentPostId()
+	);
+	const isPublishPanelOpen = useSelect( ( select ) =>
+		select( 'core/edit-post' ).isPublishSidebarOpened()
+	);
+
+	// Get target field value on component mount.
+	useEffect( () => {
+		if ( postId ) {
+			apiFetch( {
+				path: `/classifai/v1/get-target-field-value/${ postId }`,
+			} ).then( ( result ) => {
+				setTargetFieldValue( result.value || '' );
+			} ).catch( () => {
+				// If endpoint doesn't exist, fall back to excerpt.
+				setTargetFieldValue( excerpt || '' );
+			} );
+		}
+	}, [ postId, excerpt ] );
+
+	const buttonText = excerpt
+		? __( 'Re-generate excerpt', 'classifai' )
+		: __( 'Generate excerpt', 'classifai' );
 
 	const buttonClick = async ( path ) => {
 		const postContent =
@@ -87,7 +105,9 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 					}
 				}
 
+				// Update both the excerpt field and target field value.
 				onUpdateExcerpt( res.trim() );
+				setTargetFieldValue( res.trim() );
 				setError( false );
 				setIsLoading( false );
 			},
@@ -149,6 +169,12 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 				>
 					{ error }
 				</span>
+			) }
+			{ targetFieldValue && targetFieldValue !== excerpt && (
+				<div style={ { marginTop: '1rem', padding: '10px', backgroundColor: '#f0f0f0', borderRadius: '4px' } }>
+					<strong>{ __( 'Target field value:', 'classifai' ) }</strong>
+					<p style={ { margin: '5px 0 0 0' } }>{ targetFieldValue }</p>
+				</div>
 			) }
 			<DisableFeatureButton feature="feature_excerpt_generation" />
 		</div>

--- a/src/js/settings/components/feature-additional-settings/excerpt-generation.js
+++ b/src/js/settings/components/feature-additional-settings/excerpt-generation.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	__experimentalInputControl as InputControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	CheckboxControl,
+	SelectControl,
 } from '@wordpress/components';
 
 /**
@@ -33,6 +34,9 @@ export const ExcerptGenerationSettings = () => {
 			generate_excerpt_prompt: prompts,
 		} );
 	};
+
+	// Get available ACF fields if ACF is active.
+	const acfFields = window.classifAISettings?.acfFields || [];
 
 	return (
 		<>
@@ -93,6 +97,65 @@ export const ExcerptGenerationSettings = () => {
 						setFeatureSettings( { length: value } )
 					}
 				/>
+			</SettingsRow>
+			<SettingsRow
+				label={ __( 'Target field', 'classifai' ) }
+				description={ __(
+					'Choose where to save the generated excerpt. You can target the default excerpt field, custom meta fields, or ACF fields.',
+					'classifai'
+				) }
+			>
+				<SelectControl
+					value={ featureSettings.target_field_type || 'post_excerpt' }
+					options={ [
+						{
+							label: __( 'Default excerpt field', 'classifai' ),
+							value: 'post_excerpt',
+						},
+						{
+							label: __( 'Custom meta field', 'classifai' ),
+							value: 'custom_meta',
+						},
+						...( acfFields.length > 0 ? [
+							{
+								label: __( 'ACF field', 'classifai' ),
+								value: 'acf_field',
+							},
+						] : [] ),
+					] }
+					onChange={ ( value ) =>
+						setFeatureSettings( { target_field_type: value } )
+					}
+				/>
+				{ featureSettings.target_field_type === 'custom_meta' && (
+					<InputControl
+						label={ __( 'Meta key', 'classifai' ) }
+						value={ featureSettings.target_custom_field || '' }
+						onChange={ ( value ) =>
+							setFeatureSettings( { target_custom_field: value } )
+						}
+						placeholder={ __( 'e.g., editorial_subtitle, custom_excerpt', 'classifai' ) }
+					/>
+				) }
+				{ featureSettings.target_field_type === 'acf_field' && (
+					<SelectControl
+						label={ __( 'ACF field', 'classifai' ) }
+						value={ featureSettings.target_acf_field || '' }
+						options={ [
+							{
+								label: __( 'Select ACF field', 'classifai' ),
+								value: '',
+							},
+							...acfFields.map( ( field ) => ( {
+								label: field.label,
+								value: field.key,
+							} ) ),
+						] }
+						onChange={ ( value ) =>
+							setFeatureSettings( { target_acf_field: value } )
+						}
+					/>
+				) }
 			</SettingsRow>
 		</>
 	);

--- a/src/js/settings/components/feature-additional-settings/excerpt-generation.js
+++ b/src/js/settings/components/feature-additional-settings/excerpt-generation.js
@@ -106,7 +106,9 @@ export const ExcerptGenerationSettings = () => {
 				) }
 			>
 				<SelectControl
-					value={ featureSettings.target_field_type || 'post_excerpt' }
+					value={
+						featureSettings.target_field_type || 'post_excerpt'
+					}
 					options={ [
 						{
 							label: __( 'Default excerpt field', 'classifai' ),
@@ -116,12 +118,14 @@ export const ExcerptGenerationSettings = () => {
 							label: __( 'Custom meta field', 'classifai' ),
 							value: 'custom_meta',
 						},
-						...( acfFields.length > 0 ? [
-							{
-								label: __( 'ACF field', 'classifai' ),
-								value: 'acf_field',
-							},
-						] : [] ),
+						...( acfFields.length > 0
+							? [
+									{
+										label: __( 'ACF field', 'classifai' ),
+										value: 'acf_field',
+									},
+							  ]
+							: [] ),
 					] }
 					onChange={ ( value ) =>
 						setFeatureSettings( { target_field_type: value } )
@@ -134,7 +138,10 @@ export const ExcerptGenerationSettings = () => {
 						onChange={ ( value ) =>
 							setFeatureSettings( { target_custom_field: value } )
 						}
-						placeholder={ __( 'e.g., editorial_subtitle, custom_excerpt', 'classifai' ) }
+						placeholder={ __(
+							'e.g., editorial_subtitle, custom_excerpt',
+							'classifai'
+						) }
 					/>
 				) }
 				{ featureSettings.target_field_type === 'acf_field' && (


### PR DESCRIPTION
### Description of the Change

This PR implements **custom field targeting** for the ClassifAI excerpt generation feature, allowing users to save generated excerpts to custom fields beyond the default WordPress excerpt field. This enhancement supports editorial workflows that use structured content blocks, custom meta fields, or ACF fields for storing excerpts, etc.

  - Added support for targeting custom meta fields (e.g., `editorial_subtitle`, `custom_excerpt`, `dek`)
  - Integrated ACF field support for seamless ACF integration
  - Maintained default excerpt field as primary option
  - Added fallback mechanisms for field detection and value retrieval
  - New "Target field" setting in excerpt generation configuration
  - Dropdown selection for field type (Default excerpt, Custom meta, ACF field)
  - Dynamic field selection based on chosen field type
  - ACF field integration with automatic field detection
  - **Classic Editor**: Full custom field support with real-time updates and field detection
  - **Block Editor**: Integrated custom field display and synchronization
  - Context-aware messaging for different field types
  - Multiple detection methods for ACF fields (data attributes, field keys, DOM structure)
  - Flexible meta field detection and updating

---

### New Setting Field:

<img width="1018" height="195" alt="image" src="https://github.com/user-attachments/assets/dc352a9c-e091-42e3-8b57-c3072f5baf55" />

### Block Editor (Custom Field):

<img width="1219" height="591" alt="image" src="https://github.com/user-attachments/assets/abef0f45-7403-484d-900a-080411256da4" />

### Block Editor (ACF):

<img width="1220" height="567" alt="image" src="https://github.com/user-attachments/assets/0db3435d-73ca-4cf3-b76b-ad7ff3ba223c" />

### Classic Editor (ACF):

<img width="732" height="883" alt="image" src="https://github.com/user-attachments/assets/57dcb5c1-23a8-485f-b9b2-fae726159db6" />


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #921

### How to test the Change

1. **Custom Meta Field Testing:**
   - Create custom meta fields (e.g., `editorial_subtitle`, `custom_excerpt`)
   - Configure excerpt generation to target custom meta fields
   - Generate excerpts and verify they save to the correct fields

2. **ACF Field Testing:**
   - Install/activate ACF plugin
   - Create ACF fields (text/textarea)
   - Configure excerpt generation to target ACF fields
   - Test excerpt generation and field updates

3. **Editor Testing:**
   - Test in both classic and block editors
   - Verify real-time field updates
   - Confirm proper field detection and synchronization

4. **Settings Testing:**
   - Navigate to ClassifAI settings > Language Processing > Excerpt Generation
   - Verify "Target field" dropdown with all options
   - Test field type switching and configuration saving

### Credits

Props @jeffpaul @faisal-alvi @iamdharmesh 

### Changelog Entry

> Added - Add custom field targeting for Excerpt Generation