### PR TITLE
Fix display of Smart Crop thumbnails on WordPress UI

### DIFF
--- a/includes/Classifai/Features/ImageCropping.php
+++ b/includes/Classifai/Features/ImageCropping.php
@@ -170,8 +170,8 @@ class ImageCropping extends Feature {
 	 * @param array $response Array of prepared attachment data.
 	 * @return array
 	 */
-	public function set_media_library_attachment_size( array $response ): array {
-		if ( 'image' !== $response['type'] ) {
+	public function set_media_library_attachment_size( $response ) {
+		if ( ! isset( $response['type'] ) || 'image' !== $response['type'] ) {
 			return $response;
 		}
 

--- a/includes/Classifai/Features/ImageCropping.php
+++ b/includes/Classifai/Features/ImageCropping.php
@@ -63,6 +63,7 @@ class ImageCropping extends Feature {
 		add_action( 'edit_attachment', [ $this, 'maybe_crop_image' ] );
 
 		add_filter( 'attachment_fields_to_edit', [ $this, 'add_rescan_button_to_media_modal' ], 10, 2 );
+		add_filter( 'wp_prepare_attachment_for_js', [ $this, 'set_media_library_attachment_size' ], 10, 1 );
 		add_filter( 'wp_generate_attachment_metadata', [ $this, 'generate_smart_crops' ], 7, 2 );
 	}
 
@@ -161,6 +162,28 @@ class ImageCropping extends Feature {
 		}
 
 		return $metadata;
+	}
+
+	/**
+	 * Adjust the media library attachment size to account for cropped thumbnails.
+	 *
+	 * @param array $response Array of prepared attachment data.
+	 * @return array
+	 */
+	public function set_media_library_attachment_size( array $response ): array {
+		if ( 'image' !== $response['type'] ) {
+			return $response;
+		}
+
+		/*
+		 * Replace the `medium` thumbnail with the original `thumbnail` size, which has been
+		 * smart cropped to show the actual cropped image on the media library thumbnail.
+		 */
+		if ( isset( $response['sizes']['thumbnail'] ) && isset( $response['sizes']['medium'] ) ) {
+			$response['sizes']['medium'] = $response['sizes']['thumbnail'];
+		}
+
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Introduces a filter on  [wp_prepare_attachment_for_js](https://developer.wordpress.org/reference/functions/wp_prepare_attachment_for_js/) and replaces the `medium` thumbnail size (150x300) with the `thumbnail` thumbnail size (150x150), which effectively displays the cropped image thumbnail on the WordPress Media Library. 

> :bulb: Since the `wp_prepare_attachment_for_js` filter works within `wp-ajax.php`, there is no way to access the `$pagenow` global, to possibly filter the current page to the WordPress Media Library and potentially make the thumbnail override on that page only, and not globally (within the JavaScript data, that is).

This change replaces the `medium` thumbnail with the `thumbnail` size only for the JavaScript data used with the frontend Backbone models. It is a global change, but only within JavaScript.
&nbsp;
<img width="723" height="397" alt="Screenshot 2025-08-12 at 4 52 15 PM" src="https://github.com/user-attachments/assets/7415704c-cabd-4512-be70-453349c6e590" />

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #768

### How to test the Change

1. Ensure ClassifAI is active and the Smart Crop feature
2. Upload an image to the Media Library
3. View the image and its thumbnail in the uploads directory, see properly smart-cropped image
4. Confirm within the WP UI that the cropped image is shown instead of the default center-crop one

<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Smart crop thumbnails not showing in WordPress UI

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis , @dkotter 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
