### PR TITLE
Allow setting the number of responses when using Ollama as the Provider in Title Generation and Content Resizing Features

### DIFF
--- a/includes/Classifai/Providers/Localhost/Ollama.php
+++ b/includes/Classifai/Providers/Localhost/Ollama.php
@@ -478,30 +478,51 @@ class Ollama extends Provider {
 					],
 				],
 				'stream'   => false,
+				'format'   => [
+					'type'       => 'object',
+					'properties' => [
+						'content' => [
+							'type' => 'string',
+						],
+					],
+					'required'   => [ 'content' ],
+				],
 			],
 			$post_id
 		);
 
-		// Make our API request.
-		$request  = new APIRequest( 'test' );
-		$response = $request->post(
-			$this->get_api_chat_url( $settings[ static::ID ]['endpoint_url'] ?? '' ),
-			[
-				'body' => wp_json_encode( $body ),
-			]
-		);
+		// Make our API requests.
+		$request = new APIRequest( 'test', $feature->get_option_name() );
 
-		if ( is_wp_error( $response ) ) {
-			return $response;
+		$responses = [];
+		for ( $i = 0; $i < $args['num']; $i++ ) {
+			$responses[] = $request->post(
+				$this->get_api_chat_url( $settings[ static::ID ]['endpoint_url'] ?? '' ),
+				[
+					'body' => wp_json_encode( $body ),
+				]
+			);
 		}
 
-		// If we have a message, return it.
-		$return = [];
-		if ( isset( $response['message'], $response['message']['content'] ) ) {
-			$return[] = sanitize_text_field( trim( $response['message']['content'], ' "\'' ) );
+		$cleaned_responses = [];
+
+		foreach ( $responses as $response ) {
+			// Extract out the response, if it exists.
+			if ( ! is_wp_error( $response ) && isset( $response['message'], $response['message']['content'] ) ) {
+				// We expect the response to be valid json since we requested that schema.
+				$content = json_decode( $response['message']['content'], true );
+
+				if ( isset( $content['content'] ) ) {
+					$cleaned_responses[] = sanitize_text_field( trim( $content['content'], ' "\'' ) );
+				} else {
+					return new WP_Error( 'refusal', esc_html__( 'Request failed', 'classifai' ) );
+				}
+			} elseif ( is_wp_error( $response ) ) {
+				return $response;
+			}
 		}
 
-		return $return;
+		return $cleaned_responses;
 	}
 
 	/**

--- a/includes/Classifai/Providers/Localhost/Ollama.php
+++ b/includes/Classifai/Providers/Localhost/Ollama.php
@@ -16,6 +16,7 @@ use Classifai\Normalizer;
 use WP_Error;
 
 use function Classifai\get_default_prompt;
+use function Classifai\sanitize_number_of_responses_field;
 
 /**
  * Ollama class
@@ -48,6 +49,16 @@ class Ollama extends Provider {
 			'model'         => '',
 			'models'        => [],
 		];
+
+		/**
+		 * Default values for feature specific settings.
+		 */
+		switch ( $this->feature_instance::ID ) {
+			case ContentResizing::ID:
+			case TitleGeneration::ID:
+				$common_settings['number_of_suggestions'] = 1;
+				break;
+		}
 
 		return $common_settings;
 	}
@@ -101,6 +112,13 @@ class Ollama extends Provider {
 		}
 
 		$new_settings[ static::ID ]['model'] = sanitize_text_field( $new_settings[ static::ID ]['model'] ?? $settings[ static::ID ]['model'] );
+
+		switch ( $this->feature_instance::ID ) {
+			case ContentResizing::ID:
+			case TitleGeneration::ID:
+				$new_settings[ static::ID ]['number_of_suggestions'] = sanitize_number_of_responses_field( 'number_of_suggestions', $new_settings[ static::ID ], $settings[ static::ID ] );
+				break;
+		}
 
 		return $new_settings;
 	}
@@ -286,6 +304,7 @@ class Ollama extends Provider {
 		$args      = wp_parse_args(
 			array_filter( $args ),
 			[
+				'num'     => $settings[ static::ID ]['number_of_suggestions'] ?? 1,
 				'content' => '',
 			]
 		);
@@ -343,30 +362,51 @@ class Ollama extends Provider {
 				'model'    => $settings[ static::ID ]['model'] ?? '',
 				'messages' => $this->get_request_messages( $post_id, $prompt, $message_content ),
 				'stream'   => false,
+				'format'   => [
+					'type'       => 'object',
+					'properties' => [
+						'title' => [
+							'type' => 'string',
+						],
+					],
+					'required'   => [ 'title' ],
+				],
 			],
 			$post_id
 		);
 
-		// Make our API request.
-		$request  = new APIRequest( 'test' );
-		$response = $request->post(
-			$this->get_api_chat_url( $settings[ static::ID ]['endpoint_url'] ?? '' ),
-			[
-				'body' => wp_json_encode( $body ),
-			]
-		);
+		// Make our API requests.
+		$request = new APIRequest( 'test', $feature->get_option_name() );
 
-		if ( is_wp_error( $response ) ) {
-			return $response;
+		$responses = [];
+		for ( $i = 0; $i < $args['num']; $i++ ) {
+			$responses[] = $request->post(
+				$this->get_api_chat_url( $settings[ static::ID ]['endpoint_url'] ?? '' ),
+				[
+					'body' => wp_json_encode( $body ),
+				]
+			);
 		}
 
-		// If we have a message, return it.
-		$return = [];
-		if ( isset( $response['message'], $response['message']['content'] ) ) {
-			$return[] = sanitize_text_field( trim( $response['message']['content'], ' "\'' ) );
+		$cleaned_responses = [];
+
+		foreach ( $responses as $response ) {
+			// Extract out the response, if it exists.
+			if ( ! is_wp_error( $response ) && isset( $response['message'], $response['message']['content'] ) ) {
+				// We expect the response to be valid json since we requested that schema.
+				$title = json_decode( $response['message']['content'], true );
+
+				if ( isset( $title['title'] ) ) {
+					$cleaned_responses[] = sanitize_text_field( trim( $title['title'], ' "\'' ) );
+				} else {
+					return new WP_Error( 'refusal', esc_html__( 'Request failed', 'classifai' ) );
+				}
+			} elseif ( is_wp_error( $response ) ) {
+				return $response;
+			}
 		}
 
-		return $return;
+		return $cleaned_responses;
 	}
 
 	/**
@@ -387,6 +427,7 @@ class Ollama extends Provider {
 		$args = wp_parse_args(
 			array_filter( $args ),
 			[
+				'num'     => $settings[ static::ID ]['number_of_suggestions'] ?? 1,
 				'content' => '',
 			]
 		);

--- a/src/js/settings/components/provider-settings/ollama-embeddings.js
+++ b/src/js/settings/components/provider-settings/ollama-embeddings.js
@@ -36,7 +36,7 @@ export const OllamaEmbeddingsSettings = ( { isConfigured = false } ) => {
 	return (
 		<OllamaBaseSettings
 			providerSettings={ providerSettings }
-			providerName
+			providerName={ providerName }
 			onChange={ onChange }
 		/>
 	);

--- a/src/js/settings/components/provider-settings/ollama.js
+++ b/src/js/settings/components/provider-settings/ollama.js
@@ -2,12 +2,17 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+import { __experimentalInputControl as InputControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { STORE_NAME } from '../../data/store';
 import { OllamaBaseSettings } from './ollama-base';
+import { useFeatureContext } from '../feature-settings/context';
+import { SettingsRow } from '../settings-row';
 
 /**
  * Component for Ollama Provider settings.
@@ -21,6 +26,7 @@ import { OllamaBaseSettings } from './ollama-base';
  * @return {React.ReactElement} OllamaSettings component.
  */
 export const OllamaSettings = ( { isConfigured = false } ) => {
+	const { featureName } = useFeatureContext();
 	const providerName = 'ollama';
 	const providerSettings = useSelect(
 		( select ) =>
@@ -29,15 +35,38 @@ export const OllamaSettings = ( { isConfigured = false } ) => {
 	const { setProviderSettings } = useDispatch( STORE_NAME );
 	const onChange = ( data ) => setProviderSettings( providerName, data );
 
-	if ( isConfigured ) {
-		return null;
-	}
-
 	return (
-		<OllamaBaseSettings
-			providerSettings={ providerSettings }
-			providerName
-			onChange={ onChange }
-		/>
+		<>
+			{ ! isConfigured && (
+				<OllamaBaseSettings
+					providerSettings={ providerSettings }
+					providerName={ providerName }
+					onChange={ onChange }
+				/>
+			) }
+			{ [
+				'feature_content_resizing',
+				'feature_title_generation',
+			].includes( featureName ) && (
+				<SettingsRow
+					label={ __( 'Number of suggestions', 'classifai' ) }
+					description={ __(
+						'Number of suggestions that will be generated in one request.',
+						'classifai'
+					) }
+				>
+					<InputControl
+						id={ `${ providerName }_number_of_suggestions` }
+						type="number"
+						min={ 1 }
+						max={ 10 }
+						value={ providerSettings.number_of_suggestions || 1 }
+						onChange={ ( value ) =>
+							onChange( { number_of_suggestions: value } )
+						}
+					/>
+				</SettingsRow>
+			) }
+		</>
 	);
 };

--- a/tests/cypress/integration/language-processing/classify-content-ollama-embeddings.test.js
+++ b/tests/cypress/integration/language-processing/classify-content-ollama-embeddings.test.js
@@ -17,12 +17,16 @@ describe( '[Language processing] Classify Content (Ollama) Tests', () => {
 		cy.visitFeatureSettings( 'language_processing/feature_classification' );
 
 		cy.selectProvider( 'ollama_embeddings' );
-		cy.get( '#ollama_model' ).select( 'nomic-embed-text:latest' );
+
+		cy.get( '#ollama_embeddings_model' ).select(
+			'nomic-embed-text:latest'
+		);
 		cy.get(
 			'.settings-allowed-post-statuses input#post_status_publish'
 		).check();
 		cy.get( '#category-enabled' ).check();
-		cy.get( '#category-threshold' ).clear().type( 100 ); // "Test" requires 80% confidence. At 81%, it does not apply.
+		cy.get( '#category-threshold' ).clear().type( 100 );
+
 		cy.saveFeatureSettings();
 	} );
 

--- a/tests/cypress/integration/language-processing/classify-content-ollama-embeddings.test.js
+++ b/tests/cypress/integration/language-processing/classify-content-ollama-embeddings.test.js
@@ -17,7 +17,7 @@ describe( '[Language processing] Classify Content (Ollama) Tests', () => {
 		cy.visitFeatureSettings( 'language_processing/feature_classification' );
 
 		cy.selectProvider( 'ollama_embeddings' );
-		cy.get( '#true_model' ).select( 'nomic-embed-text:latest' );
+		cy.get( '#ollama_model' ).select( 'nomic-embed-text:latest' );
 		cy.get(
 			'.settings-allowed-post-statuses input#post_status_publish'
 		).check();

--- a/tests/cypress/integration/language-processing/content-generation.test.js
+++ b/tests/cypress/integration/language-processing/content-generation.test.js
@@ -39,7 +39,7 @@ describe( '[Language processing] Content Generation Tests', () => {
 		cy.selectProvider( 'ollama' );
 
 		cy.saveFeatureSettings();
-		cy.get( '#true_model' ).select( 'deepseek-llm:latest' );
+		cy.get( '#ollama_model' ).select( 'deepseek-llm:latest' );
 		cy.saveFeatureSettings();
 	} );
 

--- a/tests/cypress/integration/language-processing/excerpt-generation-ollama.test.js
+++ b/tests/cypress/integration/language-processing/excerpt-generation-ollama.test.js
@@ -29,7 +29,7 @@ describe( '[Language processing] Excerpt Generation Tests', () => {
 		cy.allowFeatureToAdmin();
 		cy.saveFeatureSettings();
 
-		cy.get( '#true_model' ).select( 'deepseek-llm:latest' );
+		cy.get( '#ollama_model' ).select( 'deepseek-llm:latest' );
 		cy.saveFeatureSettings();
 	} );
 

--- a/tests/cypress/integration/language-processing/key-takeaways-ollama.test.js
+++ b/tests/cypress/integration/language-processing/key-takeaways-ollama.test.js
@@ -22,7 +22,7 @@ describe( '[Language processing] Key Takeaways Tests', () => {
 		cy.allowFeatureToAdmin();
 		cy.saveFeatureSettings();
 
-		cy.get( '#true_model' ).select( 'deepseek-llm:latest' );
+		cy.get( '#ollama_model' ).select( 'deepseek-llm:latest' );
 		cy.saveFeatureSettings();
 	} );
 

--- a/tests/cypress/integration/language-processing/resize_content-ollama.test.js
+++ b/tests/cypress/integration/language-processing/resize_content-ollama.test.js
@@ -7,7 +7,7 @@ describe( '[Language processing] Resize Content Tests', () => {
 		cy.enableFeature();
 		cy.selectProvider( 'ollama' );
 		cy.saveFeatureSettings();
-		cy.get( '#true_model' ).select( 'deepseek-llm:latest' );
+		cy.get( '#ollama_model' ).select( 'deepseek-llm:latest' );
 		cy.optInAllFeatures();
 		cy.disableClassicEditor();
 	} );

--- a/tests/cypress/integration/language-processing/title-generation-ollama.test.js
+++ b/tests/cypress/integration/language-processing/title-generation-ollama.test.js
@@ -21,7 +21,7 @@ describe( '[Language processing] Title Generation Tests', () => {
 		cy.allowFeatureToAdmin();
 		cy.saveFeatureSettings();
 
-		cy.get( '#true_model' ).select( 'deepseek-llm:latest' );
+		cy.get( '#ollama_model' ).select( 'deepseek-llm:latest' );
 		cy.saveFeatureSettings();
 	} );
 

--- a/tests/test-plugin/e2e-test-plugin.php
+++ b/tests/test-plugin/e2e-test-plugin.php
@@ -129,6 +129,8 @@ function classifai_test_mock_http_requests( $preempt, $parsed_args, $url ) {
 
 			if ( str_contains( $prompt, 'Increase the content' ) || str_contains( $prompt, 'Decrease the content' ) ) {
 				$response = file_get_contents( __DIR__ . '/ollama-chat-resize.json' );
+			} else if ( str_contains( $prompt, 'Write an SEO-friendly title' ) ) {
+				$response = file_get_contents( __DIR__ . '/ollama-structured-title.json' );
 			}
 		}
 	}

--- a/tests/test-plugin/ollama-chat-resize.json
+++ b/tests/test-plugin/ollama-chat-resize.json
@@ -3,7 +3,7 @@
   "created_at": "2025-01-29T23:53:09.959396Z",
   "message": {
     "role": "assistant",
-    "content": "Start with the basic building block of one narrative."
+    "content": "{\"content\": \"Start with the basic building block of one narrative.\" }"
   },
   "done_reason": "stop",
   "done": true,

--- a/tests/test-plugin/ollama-structured-title.json
+++ b/tests/test-plugin/ollama-structured-title.json
@@ -1,0 +1,16 @@
+{
+  "model": "llama3.1:latest",
+  "created_at": "2025-08-15T18:11:59.18395Z",
+  "message": {
+    "role": "assistant",
+    "content": "{\"title\": \"Hello there, how may I assist you today?\" }"
+  },
+  "done_reason": "stop",
+  "done": true,
+  "total_duration": 9147498458,
+  "load_duration": 4301577750,
+  "prompt_eval_count": 139,
+  "prompt_eval_duration": 4015511708,
+  "eval_count": 23,
+  "eval_duration": 814617125
+}


### PR DESCRIPTION
### Description of the Change

If using OpenAI as the Provider for the Title Generation or Content Resizing Features, we have a setting that allows you to choose how many responses are returned. This is something OpenAI supports natively in their API. If using Ollama, this setting is removed as Ollama itself does not support that API parameter.

This PR brings that setting over to these Features when using Ollama as a Provider and behind the scenes, we end up making multiple requests to support this. For instance, if I want 3 title suggestions, that will end up making 3 separate requests to Ollama to generate those. This isn't perfect, as you can get the same results for each request but in my testing, these results to tend to be different often enough to be of value.

Also changed those two API requests to use JSON structured output, making it easier for us to be sure the response we get is what we want. For instance, prior to that, Ollama would often return something like `Here's the generated title: TITLE`. That is hard for us to properly parse and so we end up just showing that to the user. You can usually address this with a more specific system prompt but seems that using structured output resolves this.

### How to test the Change

1. Install Ollama if you don't have it already and install at least one model
2. Configure both Title Generation and Content Resizing to use Ollama
3. Test that getting a single response from both still works
4. Change the `Number of suggestions` setting to something higher than 1
5. Ensure you get the right number of responses

### Changelog Entry

> Added - Number of suggestions setting added to the Title Generation and Content Resizing Features when using Ollama
> Changed - Request JSON structured output when using Ollama with the Title Generation and Content Resizing Features

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
