### PR TITLE
Ollama support for Smart 404 and Term Cleanup features

### DIFF
--- a/includes/Classifai/Features/Smart404.php
+++ b/includes/Classifai/Features/Smart404.php
@@ -5,6 +5,7 @@ namespace Classifai\Features;
 use Classifai\Services\LanguageProcessing;
 use Classifai\Providers\OpenAI\Embeddings as OpenAIEmbeddings;
 use Classifai\Providers\Azure\Embeddings as AzureEmbeddings;
+use Classifai\Providers\Localhost\OllamaEmbeddings;
 use WP_Error;
 use WP_Query;
 
@@ -35,6 +36,7 @@ class Smart404 extends Feature {
 		$this->supported_providers = [
 			OpenAIEmbeddings::ID => __( 'OpenAI Embeddings', 'classifai' ),
 			AzureEmbeddings::ID  => __( 'Azure OpenAI Embeddings', 'classifai' ),
+			OllamaEmbeddings::ID => __( 'Ollama', 'classifai' ),
 		];
 	}
 

--- a/includes/Classifai/Features/Smart404EPIntegration.php
+++ b/includes/Classifai/Features/Smart404EPIntegration.php
@@ -70,6 +70,8 @@ class Smart404EPIntegration {
 				$this->embeddings_meta_key = 'classifai_openai_embeddings';
 			} elseif ( 'azure_openai_embeddings' === $provider::ID ) {
 				$this->embeddings_meta_key = 'classifai_azure_openai_embeddings';
+			} elseif ( 'ollama_embeddings' === $provider::ID ) {
+				$this->embeddings_meta_key = 'classifai_ollama_embeddings';
 			}
 		}
 	}

--- a/includes/Classifai/Features/TermCleanup.php
+++ b/includes/Classifai/Features/TermCleanup.php
@@ -6,6 +6,7 @@ use Classifai\Admin\SimilarTermsListTable;
 use Classifai\Services\LanguageProcessing;
 use Classifai\Providers\OpenAI\Embeddings as OpenAIEmbeddings;
 use Classifai\Providers\Azure\Embeddings as AzureEmbeddings;
+use Classifai\Providers\Localhost\OllamaEmbeddings;
 use Classifai\Providers\OpenAI\EmbeddingCalculations;
 use Classifai\TermCleanupScheduler;
 use WP_Error;
@@ -65,6 +66,7 @@ class TermCleanup extends Feature {
 		$this->supported_providers = [
 			OpenAIEmbeddings::ID => __( 'OpenAI Embeddings', 'classifai' ),
 			AzureEmbeddings::ID  => __( 'Azure OpenAI Embeddings', 'classifai' ),
+			OllamaEmbeddings::ID => __( 'Ollama', 'classifai' ),
 		];
 	}
 
@@ -309,6 +311,10 @@ class TermCleanup extends Feature {
 
 		if ( $provider instanceof AzureEmbeddings ) {
 			$meta_key = 'classifai_azure_openai_embeddings';
+		}
+
+		if ( $provider instanceof OllamaEmbeddings ) {
+			$meta_key = 'classifai_ollama_embeddings';
 		}
 
 		/**

--- a/tests/cypress/integration/language-processing/smart-404-ollama.test.js
+++ b/tests/cypress/integration/language-processing/smart-404-ollama.test.js
@@ -14,6 +14,9 @@ describe( '[Language processing] Smart 404 - Ollama Tests', () => {
 
 	it( "See error message if ElasticPress isn't activate", () => {
 		cy.disableElasticPress();
+
+		cy.visitFeatureSettings( 'language_processing/feature_smart_404' );
+
 		cy.get( '.elasticpress-required-notice.components-notice ' ).should(
 			'exist'
 		);

--- a/tests/cypress/integration/language-processing/smart-404-ollama.test.js
+++ b/tests/cypress/integration/language-processing/smart-404-ollama.test.js
@@ -31,6 +31,9 @@ describe( '[Language processing] Smart 404 - Ollama Tests', () => {
 		cy.get( 'input#ollama_embeddings_endpoint_url' )
 			.clear()
 			.type( 'https://e2e-test-ollama.test/' );
+		cy.get( '#ollama_embeddings_model' ).select(
+			'nomic-embed-text:latest'
+		);
 
 		// Change all settings.
 		cy.get( '#feature_smart_404_num' ).clear().type( 5 );

--- a/tests/cypress/integration/language-processing/smart-404-ollama.test.js
+++ b/tests/cypress/integration/language-processing/smart-404-ollama.test.js
@@ -1,6 +1,10 @@
 describe( '[Language processing] Smart 404 - Ollama Tests', () => {
 	before( () => {
 		cy.login();
+		cy.visitFeatureSettings( 'language_processing/feature_smart_404' );
+		cy.enableFeature();
+		cy.selectProvider( 'ollama_embeddings' );
+		cy.saveFeatureSettings();
 		cy.optInAllFeatures();
 	} );
 
@@ -10,9 +14,6 @@ describe( '[Language processing] Smart 404 - Ollama Tests', () => {
 
 	it( "See error message if ElasticPress isn't activate", () => {
 		cy.disableElasticPress();
-
-		cy.visitFeatureSettings( 'language_processing/feature_smart_404' );
-
 		cy.get( '.elasticpress-required-notice.components-notice ' ).should(
 			'exist'
 		);
@@ -23,14 +24,8 @@ describe( '[Language processing] Smart 404 - Ollama Tests', () => {
 
 		cy.visitFeatureSettings( 'language_processing/feature_smart_404' );
 
-		// Enabled Feature.
-		cy.enableFeature();
-
 		// Setup Provider.
 		cy.selectProvider( 'ollama_embeddings' );
-		cy.get( 'input#ollama_embeddings_endpoint_url' )
-			.clear()
-			.type( 'http://localhost:11434/api/tags' );
 		cy.get( '#ollama_embeddings_model' ).select(
 			'nomic-embed-text:latest'
 		);

--- a/tests/cypress/integration/language-processing/smart-404-ollama.test.js
+++ b/tests/cypress/integration/language-processing/smart-404-ollama.test.js
@@ -30,7 +30,7 @@ describe( '[Language processing] Smart 404 - Ollama Tests', () => {
 		cy.selectProvider( 'ollama_embeddings' );
 		cy.get( 'input#ollama_embeddings_endpoint_url' )
 			.clear()
-			.type( 'https://e2e-test-ollama.test/' );
+			.type( 'http://localhost:11434/api/tags' );
 		cy.get( '#ollama_embeddings_model' ).select(
 			'nomic-embed-text:latest'
 		);

--- a/tests/cypress/integration/language-processing/smart-404-ollama.test.js
+++ b/tests/cypress/integration/language-processing/smart-404-ollama.test.js
@@ -1,10 +1,6 @@
 describe( '[Language processing] Smart 404 - Ollama Tests', () => {
 	before( () => {
 		cy.login();
-		cy.visitFeatureSettings( 'language_processing/feature_smart_404' );
-		cy.enableFeature();
-		cy.selectProvider( 'ollama_embeddings' );
-		cy.saveFeatureSettings();
 		cy.optInAllFeatures();
 	} );
 
@@ -25,6 +21,12 @@ describe( '[Language processing] Smart 404 - Ollama Tests', () => {
 	it( 'Can save Smart 404 settings', () => {
 		cy.enableElasticPress();
 
+		cy.visitFeatureSettings( 'language_processing/feature_smart_404' );
+
+		// Enabled Feature.
+		cy.enableFeature();
+
+		// The models don't always refresh correctly, without reloading the page.
 		cy.visitFeatureSettings( 'language_processing/feature_smart_404' );
 
 		// Setup Provider.

--- a/tests/cypress/integration/language-processing/smart-404-ollama.test.js
+++ b/tests/cypress/integration/language-processing/smart-404-ollama.test.js
@@ -1,0 +1,49 @@
+describe( '[Language processing] Smart 404 - Ollama Tests', () => {
+	before( () => {
+		cy.login();
+		cy.optInAllFeatures();
+	} );
+
+	beforeEach( () => {
+		cy.login();
+	} );
+
+	it( "See error message if ElasticPress isn't activate", () => {
+		cy.disableElasticPress();
+
+		cy.visitFeatureSettings( 'language_processing/feature_smart_404' );
+
+		cy.get( '.elasticpress-required-notice.components-notice ' ).should(
+			'exist'
+		);
+	} );
+
+	it( 'Can save Smart 404 settings', () => {
+		cy.enableElasticPress();
+
+		cy.visitFeatureSettings( 'language_processing/feature_smart_404' );
+
+		// Enabled Feature.
+		cy.enableFeature();
+
+		// Setup Provider.
+		cy.selectProvider( 'ollama_embeddings' );
+		cy.get( 'input#ollama_embeddings_endpoint_url' )
+			.clear()
+			.type( 'https://e2e-test-ollama.test/' );
+
+		// Change all settings.
+		cy.get( '#feature_smart_404_num' ).clear().type( 5 );
+		cy.get( '#feature_smart_404_num_search' ).clear().type( 8000 );
+		cy.get( '#feature_smart_404_threshold' ).clear().type( 2.55 );
+		cy.get( '#feature_smart_404_rescore' ).check();
+		cy.get( '#feature_smart_404_fallback' ).uncheck();
+		cy.get( '#feature_smart_404_score_function' ).select( 'dot_product' );
+		cy.allowFeatureToAdmin();
+
+		// Save settings.
+		cy.saveFeatureSettings();
+
+		cy.disableElasticPress();
+	} );
+} );

--- a/tests/cypress/integration/language-processing/smart-404-ollama.test.js
+++ b/tests/cypress/integration/language-processing/smart-404-ollama.test.js
@@ -31,9 +31,6 @@ describe( '[Language processing] Smart 404 - Ollama Tests', () => {
 
 		// Setup Provider.
 		cy.selectProvider( 'ollama_embeddings' );
-		cy.get( '#ollama_embeddings_model' ).select(
-			'nomic-embed-text:latest'
-		);
 
 		// Change all settings.
 		cy.get( '#feature_smart_404_num' ).clear().type( 5 );

--- a/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
+++ b/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
@@ -29,6 +29,9 @@ describe( '[Language processing] Term Cleanup - Ollama Tests', () => {
 		cy.get( 'input#ollama_embeddings_endpoint_url' )
 			.clear()
 			.type( 'https://e2e-test-ollama.test/' );
+		cy.get( '#ollama_embeddings_model' ).select(
+			'nomic-embed-text:latest'
+		);
 
 		// Change all settings.
 		cy.get( '#category-enabled' ).uncheck();

--- a/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
+++ b/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
@@ -14,6 +14,9 @@ describe( '[Language processing] Term Cleanup - Ollama Tests', () => {
 
 	it( "ElasticPress option is hidden if the plugin isn't active", () => {
 		cy.disableElasticPress();
+
+		cy.visitFeatureSettings( 'language_processing/feature_term_cleanup' );
+
 		cy.get( '#use_ep' ).should( 'be.disabled' );
 	} );
 

--- a/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
+++ b/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
@@ -1,0 +1,51 @@
+describe( '[Language processing] Term Cleanup - Ollama Tests', () => {
+	before( () => {
+		cy.login();
+		cy.optInAllFeatures();
+	} );
+
+	beforeEach( () => {
+		cy.login();
+	} );
+
+	it( "ElasticPress option is hidden if the plugin isn't active", () => {
+		cy.disableElasticPress();
+
+		cy.visitFeatureSettings( 'language_processing/feature_term_cleanup' );
+
+		cy.get( '#use_ep' ).should( 'be.disabled' );
+	} );
+
+	it( 'Can save Term Cleanup settings', () => {
+		cy.enableElasticPress();
+
+		cy.visitFeatureSettings( 'language_processing/feature_term_cleanup' );
+
+		// Enable Feature.
+		cy.enableFeature();
+
+		// Setup Provider.
+		cy.selectProvider( 'ollama_embeddings' );
+		cy.get( 'input#ollama_embeddings_endpoint_url' )
+			.clear()
+			.type( 'https://e2e-test-ollama.test/' );
+
+		// Change all settings.
+		cy.get( '#category-enabled' ).uncheck();
+		cy.get( '#category-threshold' ).clear().type( 80 );
+		cy.get( '#post_tag-enabled' ).check();
+		cy.get( '#post_tag-threshold' ).clear().type( 80 );
+
+		// Save settings.
+		cy.saveFeatureSettings();
+
+		// Ensure settings page now exists.
+		cy.visit(
+			'/wp-admin/tools.php?page=classifai-term-cleanup&tax=post_tag'
+		);
+
+		cy.get( '.classifai-wrapper .submit-wrapper' ).should( 'exist' );
+
+		cy.disableElasticPress();
+	} );
+} );

--- a/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
+++ b/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
@@ -1,10 +1,6 @@
 describe( '[Language processing] Term Cleanup - Ollama Tests', () => {
 	before( () => {
 		cy.login();
-		cy.visitFeatureSettings( 'language_processing/feature_term_cleanup' );
-		cy.enableFeature();
-		cy.selectProvider( 'ollama_embeddings' );
-		cy.saveFeatureSettings();
 		cy.optInAllFeatures();
 	} );
 
@@ -22,6 +18,9 @@ describe( '[Language processing] Term Cleanup - Ollama Tests', () => {
 
 	it( 'Can save Term Cleanup settings', () => {
 		cy.enableElasticPress();
+
+		cy.visitFeatureSettings( 'language_processing/feature_term_cleanup' );
+		cy.enableFeature();
 
 		// Setup Provider.
 		cy.selectProvider( 'ollama_embeddings' );

--- a/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
+++ b/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
@@ -1,6 +1,10 @@
 describe( '[Language processing] Term Cleanup - Ollama Tests', () => {
 	before( () => {
 		cy.login();
+		cy.visitFeatureSettings( 'language_processing/feature_term_cleanup' );
+		cy.enableFeature();
+		cy.selectProvider( 'ollama_embeddings' );
+		cy.saveFeatureSettings();
 		cy.optInAllFeatures();
 	} );
 
@@ -10,25 +14,14 @@ describe( '[Language processing] Term Cleanup - Ollama Tests', () => {
 
 	it( "ElasticPress option is hidden if the plugin isn't active", () => {
 		cy.disableElasticPress();
-
-		cy.visitFeatureSettings( 'language_processing/feature_term_cleanup' );
-
 		cy.get( '#use_ep' ).should( 'be.disabled' );
 	} );
 
 	it( 'Can save Term Cleanup settings', () => {
 		cy.enableElasticPress();
 
-		cy.visitFeatureSettings( 'language_processing/feature_term_cleanup' );
-
-		// Enable Feature.
-		cy.enableFeature();
-
 		// Setup Provider.
 		cy.selectProvider( 'ollama_embeddings' );
-		cy.get( 'input#ollama_embeddings_endpoint_url' )
-			.clear()
-			.type( 'http://localhost:11434/api/tags' );
 		cy.get( '#ollama_embeddings_model' ).select(
 			'nomic-embed-text:latest'
 		);

--- a/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
+++ b/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
@@ -28,7 +28,7 @@ describe( '[Language processing] Term Cleanup - Ollama Tests', () => {
 		cy.selectProvider( 'ollama_embeddings' );
 		cy.get( 'input#ollama_embeddings_endpoint_url' )
 			.clear()
-			.type( 'https://e2e-test-ollama.test/' );
+			.type( 'http://localhost:11434/api/tags' );
 		cy.get( '#ollama_embeddings_model' ).select(
 			'nomic-embed-text:latest'
 		);

--- a/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
+++ b/tests/cypress/integration/language-processing/term-cleanup-ollama.test.js
@@ -24,9 +24,6 @@ describe( '[Language processing] Term Cleanup - Ollama Tests', () => {
 
 		// Setup Provider.
 		cy.selectProvider( 'ollama_embeddings' );
-		cy.get( '#ollama_embeddings_model' ).select(
-			'nomic-embed-text:latest'
-		);
 
 		// Change all settings.
 		cy.get( '#category-enabled' ).uncheck();


### PR DESCRIPTION
### Description of the Change
Add Ollama support for Smart 404 and Term Cleanup features

Closes #847

### How to test the Change
Term Cleanup
1. Install Ollama
2. Pull in an embeddings model, for example, `ollama pull nomic-embed-text`
3. Tools - ClassifAI - Language Processing - Term Cleanup Settings
4. Enable feature
5. Select Ollama, select the downloaded model (might require a save and page refresh)
6. Go to Tools - Terms Cleanup, run a search - should see some data

Smart 404:
1. Go to Tools - ClassifAI - Language Processing - Smart 404 Settings
2. Enable the feature
3. Select Ollama, select the downloaded model (might require a save and page refresh)
4. Follow the "Display the recommended results" steps in the repo README.md
5. Test on a 404 page - you should see a list of recommendations 

### Changelog Entry
Added - Ollama support for Smart 404 and Term Cleanup

### Credits
Props @av3nger

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
