### PR TITLE
Ensure the Key Takeaways block is registered for all users

### DIFF
--- a/includes/Classifai/Features/Feature.php
+++ b/includes/Classifai/Features/Feature.php
@@ -79,7 +79,7 @@ abstract class Feature {
 	/**
 	 * Setup any hooks the feature needs.
 	 *
-	 * Only fires if the feature is enabled.
+	 * Only fires if the feature is enabled, configured and user has access.
 	 */
 	public function feature_setup() {
 	}

--- a/includes/Classifai/Features/KeyTakeaways.php
+++ b/includes/Classifai/Features/KeyTakeaways.php
@@ -52,19 +52,26 @@ class KeyTakeaways extends Feature {
 	/**
 	 * Set up necessary hooks.
 	 *
-	 * We utilize this so we can register the REST route.
+	 * This is always run so useful if we need to register
+	 * things even if the feature is not enabled, not configured
+	 * or the user does not have access.
 	 */
 	public function setup() {
 		parent::setup();
 		add_action( 'rest_api_init', [ $this, 'register_endpoints' ] );
+
+		if ( $this->is_configured() && $this->is_enabled() ) {
+			add_action( 'enqueue_block_assets', [ $this, 'enqueue_editor_assets' ] );
+			$this->register_block();
+		}
 	}
 
 	/**
 	 * Set up necessary hooks.
+	 *
+	 * Only fires if the feature is enabled, configured and user has access.
 	 */
 	public function feature_setup() {
-		add_action( 'enqueue_block_assets', [ $this, 'enqueue_editor_assets' ] );
-		$this->register_block();
 	}
 
 	/**

--- a/tests/cypress/integration/language-processing/key-takeaways-azure-openai.test.js
+++ b/tests/cypress/integration/language-processing/key-takeaways-azure-openai.test.js
@@ -39,9 +39,13 @@ describe( '[Language processing] Key Takeaways Tests', () => {
 		} ).then( () => {
 			cy.getBlockEditor()
 				.find(
-					'.wp-block-classifai-key-takeaways .components-placeholder__fieldset'
+					'.wp-block-classifai-key-takeaways .wp-block-classifai-key-takeaways__content ul li'
 				)
-				.should( 'contain.text', 'Request failed' );
+				.should(
+					'contain.text',
+					'Spring symbolizes renewal and beauty, inspiring creativity and reflection.'
+				)
+				.should( 'have.length', 4 );
 		} );
 	} );
 } );

--- a/tests/cypress/integration/language-processing/key-takeaways-openai-chatgpt.test.js
+++ b/tests/cypress/integration/language-processing/key-takeaways-openai-chatgpt.test.js
@@ -35,10 +35,37 @@ describe( '[Language processing] Key Takeaways Tests', () => {
 		} ).then( () => {
 			cy.getBlockEditor()
 				.find(
-					'.wp-block-classifai-key-takeaways .components-placeholder__fieldset'
+					'.wp-block-classifai-key-takeaways .wp-block-classifai-key-takeaways__content ul li'
 				)
-				.should( 'contain.text', 'OpenAI request failed' );
+				.should(
+					'contain.text',
+					'Spring symbolizes renewal and beauty, inspiring creativity and reflection.'
+				)
+				.should( 'have.length', 4 );
 		} );
+	} );
+
+	it( 'Block is visible on the front-end for logged in and logged out users', () => {
+		cy.visit( '/test-key-takeaways-post/' );
+		cy.get(
+			'.wp-block-classifai-key-takeaways .wp-block-classifai-key-takeaways__content ul li'
+		)
+			.should(
+				'contain.text',
+				'Spring symbolizes renewal and beauty, inspiring creativity and reflection.'
+			)
+			.should( 'have.length', 4 );
+
+		cy.logout();
+		cy.visit( '/test-key-takeaways-post/' );
+		cy.get(
+			'.wp-block-classifai-key-takeaways .wp-block-classifai-key-takeaways__content ul li'
+		)
+			.should(
+				'contain.text',
+				'Spring symbolizes renewal and beauty, inspiring creativity and reflection.'
+			)
+			.should( 'have.length', 4 );
 	} );
 
 	it( 'Can set multiple custom prompts, select one as the default and delete one.', () => {
@@ -130,8 +157,13 @@ describe( '[Language processing] Key Takeaways Tests', () => {
 			},
 		} ).then( () => {
 			cy.getBlockEditor()
-				.find( '.wp-block-classifai-key-takeaways' )
-				.should( 'not.exist' );
+				.find(
+					'.wp-block-classifai-key-takeaways .components-placeholder__fieldset'
+				)
+				.should(
+					'contain.text',
+					'Key takeaways not currently enabled'
+				);
 		} );
 	} );
 
@@ -152,8 +184,13 @@ describe( '[Language processing] Key Takeaways Tests', () => {
 			},
 		} ).then( () => {
 			cy.getBlockEditor()
-				.find( '.wp-block-classifai-key-takeaways' )
-				.should( 'not.exist' );
+				.find(
+					'.wp-block-classifai-key-takeaways .components-placeholder__fieldset'
+				)
+				.should(
+					'contain.text',
+					'Key takeaways not currently enabled'
+				);
 		} );
 	} );
 
@@ -173,8 +210,13 @@ describe( '[Language processing] Key Takeaways Tests', () => {
 			},
 		} ).then( () => {
 			cy.getBlockEditor()
-				.find( '.wp-block-classifai-key-takeaways' )
-				.should( 'not.exist' );
+				.find(
+					'.wp-block-classifai-key-takeaways .components-placeholder__fieldset'
+				)
+				.should(
+					'contain.text',
+					'Key takeaways not currently enabled'
+				);
 		} );
 	} );
 } );

--- a/tests/test-plugin/chatgpt-key-takeaways.json
+++ b/tests/test-plugin/chatgpt-key-takeaways.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-C6iGWTxOQMxvtOVUHg4974NTAifQo",
+  "object": "chat.completion",
+  "created": 1755716160,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "{\"takeaways\":[\"Spring symbolizes renewal and beauty, inspiring creativity and reflection.\",\"Haikus are effective for capturing the essence of spring with their concise structure and vivid imagery.\",\"Five original haikus celebrate spring, focusing on themes like blooming flowers, awakening nature, and the symphony of life.\",\"The haikus invite readers to appreciate the simple yet profound beauty of the spring season.\"]}",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 371,
+    "completion_tokens": 76,
+    "total_tokens": 447,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_560af6e559"
+}

--- a/tests/test-plugin/e2e-test-plugin.php
+++ b/tests/test-plugin/e2e-test-plugin.php
@@ -48,6 +48,8 @@ function classifai_test_mock_http_requests( $preempt, $parsed_args, $url ) {
 				$response = file_get_contents( __DIR__ . '/chatgpt-custom-title-prompt.json' );
 			} else if ( str_contains( $prompt, 'This is a custom shrink prompt' ) || str_contains( $prompt, 'This is a custom grow prompt' ) ) {
 				$response = file_get_contents( __DIR__ . '/resize-content-custom-prompt.json' );
+			} else if ( str_contains( $prompt, 'provide a summary that captures all the important points' ) ) {
+				$response = file_get_contents( __DIR__ . '/chatgpt-key-takeaways.json' );
 			}
 		}
 	} elseif ( strpos( $url, 'https://api.openai.com/v1/moderations' ) !== false ) {


### PR DESCRIPTION
### Description of the Change

As reported in #983, we have a bug in the Key Takeaways Feature where the block doesn't show up on the front-end if your account doesn't have access to use the Feature. For instance, if you're not logged in, it will never show up.

This was due to registering the block in the `feature_setup` method, which on the surface it seems like that method would register anything needed for the Feature. But unfortuntaely, that method only runs if the Feature is enabled, configured properly and the user has access, so it's really only good for registering admin-related functionality, not front-end functionality.

This PR fixes that by moving our block registration into the `setup` method (which always runs) and wrapped that in a configured and enabled check, so if the Feature is turned off or if the Feature doesn't have a Provider configured, the block won't be registered and won't render.

Closes #983 

### How to test the Change

1. Enable the Key Takeaways Feature
2. Add the Key Takeaways block to a post and ensure content gets generated
3. Save the post and view the front-end to ensure the block shows
4. View the same post with a non-logged in user and ensure the block shows
5. Modify the user permissions to remove the Editor role
6. Log in as an Editor and try adding the Key Takeaways block
7. Ensure you get an error message (note the block will show as available now due to these changes but the block won't work if your user isn't allowed)

### Changelog Entry

> Fixed - Ensure they Key Takeaways block renders properly on the front-end for non-logged in users

### Credits

Props @JeremyEnglert, @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
