### PR TITLE
Update Azure OpenAI to the latest GA API version

### DIFF
--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -273,7 +273,8 @@ class OpenAI extends Provider {
 			( $feature instanceof ContentResizing ||
 			$feature instanceof ExcerptGeneration ||
 			$feature instanceof TitleGeneration ||
-			$feature instanceof KeyTakeaways ) &&
+			$feature instanceof KeyTakeaways ||
+			$feature instanceof ContentGeneration ) &&
 			$deployment
 		) {
 			$endpoint = trailingslashit( $endpoint ) . str_replace( '{deployment-id}', $deployment, $this->chat_completion_url );

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -46,14 +46,14 @@ class OpenAI extends Provider {
 	 *
 	 * @var string
 	 */
-	protected $chat_completion_api_version = '2023-05-15';
+	protected $chat_completion_api_version = '2024-10-21';
 
 	/**
 	 * Completion API version.
 	 *
 	 * @var string
 	 */
-	protected $completion_api_version = '2023-05-15';
+	protected $completion_api_version = '2024-10-21';
 
 	/**
 	 * GeminiAPI constructor.

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -65,6 +65,25 @@ class OpenAI extends Provider {
 	}
 
 	/**
+	 * Get the API version.
+	 *
+	 * @return string
+	 */
+	public function get_api_version(): string {
+		/**
+		 * Filter the API version.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_azure_openai_api_version
+		 *
+		 * @param string $version The default API version.
+		 *
+		 * @return string The API version.
+		 */
+		return apply_filters( 'classifai_azure_openai_api_version', $this->chat_completion_api_version );
+	}
+
+	/**
 	 * Render the provider fields.
 	 */
 	public function render_provider_fields() {
@@ -258,7 +277,7 @@ class OpenAI extends Provider {
 			$deployment
 		) {
 			$endpoint = trailingslashit( $endpoint ) . str_replace( '{deployment-id}', $deployment, $this->chat_completion_url );
-			$endpoint = add_query_arg( 'api-version', $this->chat_completion_api_version, $endpoint );
+			$endpoint = add_query_arg( 'api-version', $this->get_api_version(), $endpoint );
 		}
 
 		return $endpoint;


### PR DESCRIPTION
### Description of the Change

We had a report that if using Azure OpenAI with the Key Takeaways Feature, the response would always fail because we set the `reponse_type` to be `json_schema` and it seems that isn't supported in the API version we were using.

This PR fixes that by updating the API version from `2023-05-15` to the latest GA release, `2024-10-21`. This release does [support structured outputs](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/structured-outputs?tabs=python-secure%2Cdotnet-entra-id&pivots=programming-language-csharp#api-support) but worth noting that only works if using a [compatible model](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/structured-outputs?tabs=python-secure%2Cdotnet-entra-id&pivots=programming-language-csharp#supported-models).

In addition, this PR adds a new helper method to get the API version and wraps the response of that in a new filter, `classifai_azure_openai_api_version`, making it easier for others to change the API version that is used (if, for instance, you want to use a preview version).

And finally, in testing to ensure this new API version works for all the Features we support, discovered that the Content Generation Feature wasn't working due to an existing bug so that is fixed here as well.

### How to test the Change

Azure OpenAI supports the following Language Processing Features:

- Title Generation
- Excerpt Generation
- Content Generation
- Content Resizing
- Key Takeaways

Configure each of these to use Azure OpenAI and ensure they all still work. Note that for the Key Takeaways Feature, you need to test with a compatible model (not GPT-3.5 Turbo for instance).

### Changelog Entry
> Changed - Update the Azure OpenAI API version from `2023-05-15` to `2024-10-21`
> Fixed - Ensure the Content Generation Feature works when using Azure OpenAI as the Provider
> Developer - New filter, `classifai_azure_openai_api_version`, that makes it easier to change the API version Azure OpenAI uses

### Credits

Props @gsarig, @dkotter 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
