### PR TITLE
Don't run the Title Generation Feature on attachments

### DIFF
--- a/includes/Classifai/Features/TitleGeneration.php
+++ b/includes/Classifai/Features/TitleGeneration.php
@@ -236,40 +236,50 @@ class TitleGeneration extends Feature {
 	 * @param string $hook_suffix The current admin page.
 	 */
 	public function enqueue_admin_assets( string $hook_suffix ) {
-		// Load asset in new post and edit post screens.
-		if ( 'post.php' === $hook_suffix || 'post-new.php' === $hook_suffix ) {
-			$screen = get_current_screen();
-
-			// Load the assets for the classic editor.
-			if ( $screen && ! $screen->is_block_editor() ) {
-				if ( post_type_supports( $screen->post_type, 'title' ) ) {
-					wp_enqueue_style(
-						'classifai-plugin-classic-title-generation-css',
-						CLASSIFAI_PLUGIN_URL . 'dist/classifai-plugin-classic-title-generation.css',
-						[],
-						get_asset_info( 'classifai-plugin-classic-title-generation', 'version' ),
-						'all'
-					);
-
-					wp_enqueue_script(
-						'classifai-plugin-classic-title-generation-js',
-						CLASSIFAI_PLUGIN_URL . 'dist/classifai-plugin-classic-title-generation.js',
-						array_merge( get_asset_info( 'classifai-plugin-classic-title-generation', 'dependencies' ), array( 'wp-api' ) ),
-						get_asset_info( 'generate-title-classic', 'version' ),
-						true
-					);
-
-					wp_add_inline_script(
-						'classifai-plugin-classic-title-generation-js',
-						sprintf(
-							'var classifaiChatGPTData = %s;',
-							wp_json_encode( $this->get_localised_vars() )
-						),
-						'before'
-					);
-				}
-			}
+		// Load asset in new post and edit post screens only.
+		if ( 'post.php' !== $hook_suffix && 'post-new.php' !== $hook_suffix ) {
+			return;
 		}
+
+		$screen = get_current_screen();
+
+		// Load the assets for the classic editor only.
+		if ( ! $screen || $screen->is_block_editor() ) {
+			return;
+		}
+
+		// Load the assets only if the post type supports titles and is not an attachment.
+		if (
+			! post_type_supports( $screen->post_type, 'title' ) ||
+			in_array( $screen->post_type, [ 'attachment' ], true )
+		) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'classifai-plugin-classic-title-generation-css',
+			CLASSIFAI_PLUGIN_URL . 'dist/classifai-plugin-classic-title-generation.css',
+			[],
+			get_asset_info( 'classifai-plugin-classic-title-generation', 'version' ),
+			'all'
+		);
+
+		wp_enqueue_script(
+			'classifai-plugin-classic-title-generation-js',
+			CLASSIFAI_PLUGIN_URL . 'dist/classifai-plugin-classic-title-generation.js',
+			array_merge( get_asset_info( 'classifai-plugin-classic-title-generation', 'dependencies' ), array( 'wp-api' ) ),
+			get_asset_info( 'generate-title-classic', 'version' ),
+			true
+		);
+
+		wp_add_inline_script(
+			'classifai-plugin-classic-title-generation-js',
+			sprintf(
+				'var classifaiChatGPTData = %s;',
+				wp_json_encode( $this->get_localised_vars() )
+			),
+			'before'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Right now the `Generate Titles` button will show if you land on the attachment edit screen. At the moment, clicking the button won't work as expected so this PR removes that from showing if the post type is attachment. Also does some minor cleanup to the code to avoid nested conditionals.

We could look at adding a new setting to the Title Generation Feature to allow someone to choose which post types should work, similar to a few of our other Features but wanted a quicker fix for now.

Closes #995 

### How to test the Change

1. Enable the Title Generation Feature
2. Go to the edit screen for an attachment and ensure the Generate Titles button no longer shows
3. Enable the Classic Editor plugin
4. Edit a post and ensure the button shows and works

### Changelog Entry

> Fixed - Remove the Generate Titles button from attachments

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
