### PR TITLE
When requesting multiple results, increase the `temperature` parameter

### DIFF
--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -956,3 +956,23 @@ function safe_wp_remote_post( string $url, array $args = [] ) {
 	return safe_wp_remote_request( 'POST', $url, $args );
 }
 
+/**
+ * Get the temperature for the request.
+ *
+ * We increase the base temperature proportionally
+ * to the number of results, ensuring it never exceeds 2.
+ *
+ * The goal here is to get more diverse results when
+ * we are requesting more results.
+ *
+ * @param float $temperature The temperature.
+ * @param int   $results The number of results.
+ * @return float The temperature.
+ */
+function get_temperature( float $temperature, int $results = 1 ): float {
+	if ( 1 === $results ) {
+		return $temperature;
+	}
+
+	return (float) min( 2.0, $temperature + ( $results / 10 ) );
+}

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -17,6 +17,7 @@ use WP_Error;
 use function Classifai\get_default_prompt;
 use function Classifai\sanitize_number_of_responses_field;
 use function Classifai\safe_wp_remote_post;
+use function Classifai\get_temperature;
 
 class OpenAI extends Provider {
 
@@ -553,7 +554,7 @@ class OpenAI extends Provider {
 			'classifai_azure_openai_title_request_body',
 			[
 				'messages'    => $this->get_request_messages( $post_id, $prompt, $message_content ),
-				'temperature' => 0.9,
+				'temperature' => get_temperature( 0.9, absint( $args['num'] ) ),
 				'n'           => absint( $args['num'] ),
 			],
 			$post_id
@@ -660,7 +661,7 @@ class OpenAI extends Provider {
 						'content' => '"""' . esc_html( $args['content'] ) . '"""',
 					],
 				],
-				'temperature' => 0.9,
+				'temperature' => get_temperature( 0.9, absint( $args['num'] ) ),
 				'n'           => absint( $args['num'] ),
 			],
 			$post_id

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -21,6 +21,7 @@ use function Classifai\get_default_prompt;
 use function Classifai\sanitize_number_of_responses_field;
 use function Classifai\get_modified_image_source_url;
 use function Classifai\get_largest_size_and_dimensions_image_url;
+use function Classifai\get_temperature;
 
 class ChatGPT extends Provider {
 
@@ -762,7 +763,7 @@ class ChatGPT extends Provider {
 			[
 				'model'       => $this->chatgpt_model,
 				'messages'    => $this->get_request_messages( $post_id, $prompt, $message_content ),
-				'temperature' => 0.9,
+				'temperature' => get_temperature( 0.9, absint( $args['num'] ) ),
 				'n'           => absint( $args['num'] ),
 			],
 			$post_id
@@ -867,7 +868,7 @@ class ChatGPT extends Provider {
 						'content' => '"""' . esc_html( $args['content'] ) . '"""',
 					],
 				],
-				'temperature' => 0.9,
+				'temperature' => get_temperature( 0.9, absint( $args['num'] ) ),
 				'n'           => absint( $args['num'] ),
 			],
 			$post_id

--- a/includes/Classifai/Providers/XAI/Grok.php
+++ b/includes/Classifai/Providers/XAI/Grok.php
@@ -18,6 +18,7 @@ use function Classifai\get_default_prompt;
 use function Classifai\sanitize_number_of_responses_field;
 use function Classifai\get_modified_image_source_url;
 use function Classifai\get_largest_size_and_dimensions_image_url;
+use function Classifai\get_temperature;
 
 class Grok extends Provider {
 	/**
@@ -628,7 +629,7 @@ class Grok extends Provider {
 			[
 				'model'       => $this->get_model(),
 				'messages'    => $this->get_request_messages( $post_id, $prompt, $message_content ),
-				'temperature' => 0.9,
+				'temperature' => get_temperature( 0.9, absint( $args['num'] ) ),
 				'stream'      => false,
 				'n'           => absint( $args['num'] ),
 			],
@@ -733,7 +734,7 @@ class Grok extends Provider {
 						'content' => '"""' . esc_html( $args['content'] ) . '"""',
 					],
 				],
-				'temperature' => 0.9,
+				'temperature' => get_temperature( 0.9, absint( $args['num'] ) ),
 				'stream'      => false,
 				'n'           => absint( $args['num'] ),
 			],

--- a/src/js/settings/components/provider-settings/azure-openai.js
+++ b/src/js/settings/components/provider-settings/azure-openai.js
@@ -107,6 +107,8 @@ export const AzureOpenAISettings = ( {
 					<InputControl
 						id={ `${ providerName }_number_of_suggestions` }
 						type="number"
+						min={ 1 }
+						max={ 10 }
 						value={ providerSettings.number_of_suggestions || 1 }
 						onChange={ ( value ) =>
 							onChange( { number_of_suggestions: value } )

--- a/src/js/settings/components/provider-settings/openai-chatgpt.js
+++ b/src/js/settings/components/provider-settings/openai-chatgpt.js
@@ -97,6 +97,8 @@ export const OpenAIChatGPTSettings = ( { isConfigured = false } ) => {
 					<InputControl
 						id={ `${ providerName }_number_of_suggestions` }
 						type="number"
+						min={ 1 }
+						max={ 10 }
 						value={ providerSettings.number_of_suggestions || 1 }
 						onChange={ ( value ) =>
 							onChange( { number_of_suggestions: value } )

--- a/src/js/settings/components/provider-settings/xai-grok.js
+++ b/src/js/settings/components/provider-settings/xai-grok.js
@@ -153,6 +153,8 @@ export const XAIGrokSettings = ( { isConfigured = false } ) => {
 					<InputControl
 						id={ `${ providerName }_number_of_suggestions` }
 						type="number"
+						min={ 1 }
+						max={ 10 }
 						value={ providerSettings.number_of_suggestions || 1 }
 						onChange={ ( value ) =>
 							onChange( { number_of_suggestions: value } )


### PR DESCRIPTION
### Description of the Change

Our Title Generation and Resize Content Features allow you to choose how many results you want returned (if using OpenAI, Azure OpenAI or xAI). It was reported though that often the results returned are pretty similar, if not exactly the same. While we don't have control over what results the LLMs return, one parameter we currently set is `temperature`. This is supposed to determine how random the results are, from 0 to 2, 0 meaning the results should be the same each time and 2 meaning you should see significant randomness.

We default that to `0.9` and in this PR, a new helper function has been added that will take that default value and increase it proportionally to the number of results you want. So if you want 2 results, it will go from `0.9` to `1.1`. If you want 5 it goes from `0.9` to `1.4`. If you want 10 it goes from `0.9` to `1.9`. In theory, this should mean you get more random results as you request more results, hopefully making each result more unique.

In addition, noticed we didn't have any minimum or maximum attributes on these selectors, meaning someone could enter a negative number or a super high number. Have added that in this PR to limit these from 1 to 10. There may be someone that is currently requesting more than 10 results but I'm assuming that's rare and we can adjust if someone complains :)

Closes #996

### How to test the Change

1. Enable the Title Generation and Content Resizing Features, with either OpenAI, Azure OpenAI or xAI
2. Try out these Features with different combinations of results
3. Ensure things work and you seem to be getting unique results (kind of hard to tell this, mostly a judgement call)

### Changelog Entry

> Added - Increase the temperature value when requesting more results, hopefully leading to more unique results
> Changed - Limit our number of suggestions input from 1 to 10

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
