### PR TITLE
Add support for OpenAI text-to-speech `instructions` parameter

### DIFF
--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -87,7 +87,7 @@ class TextToSpeech extends Provider {
 		 *
 		 * Useful if you want to modify the instructions for certain use cases.
 		 *
-		 * @since 3.8.0
+		 * @since x.x.x
 		 * @hook classifai_openai_text_to_speech_instructions
 		 *
 		 * @param string $instructions The current instructions to use.
@@ -444,7 +444,7 @@ class TextToSpeech extends Provider {
 		/**
 		 * Filter the request body before sending to OpenAI.
 		 *
-		 * @since 3.8.0
+		 * @since x.x.x
 		 * @hook classifai_openai_text_to_speech_request_body
 		 *
 		 * @param array  $request_body The request body that will be sent to OpenAI.

--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -87,7 +87,7 @@ class TextToSpeech extends Provider {
 		 *
 		 * Useful if you want to modify the instructions for certain use cases.
 		 *
-		 * @since 3.4.0
+		 * @since 3.8.0
 		 * @hook classifai_openai_text_to_speech_instructions
 		 *
 		 * @param string $instructions The current instructions to use.
@@ -444,7 +444,7 @@ class TextToSpeech extends Provider {
 		/**
 		 * Filter the request body before sending to OpenAI.
 		 *
-		 * @since 3.4.0
+		 * @since 3.8.0
 		 * @hook classifai_openai_text_to_speech_request_body
 		 *
 		 * @param array  $request_body The request body that will be sent to OpenAI.

--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -76,11 +76,14 @@ class TextToSpeech extends Provider {
 	/**
 	 * Get the instructions for voice control.
 	 *
+	 * @param string $instructions The instructions to use. If empty, the instructions from the settings will be used.
 	 * @return string
 	 */
-	public function get_instructions(): string {
-		$settings     = $this->feature_instance->get_settings();
-		$instructions = $settings[ static::ID ]['instructions'] ?? '';
+	public function get_instructions( string $instructions = '' ): string {
+		if ( empty( $instructions ) ) {
+			$settings     = $this->feature_instance->get_settings();
+			$instructions = $settings[ static::ID ]['instructions'] ?? '';
+		}
 
 		/**
 		 * Filter the instructions for voice control.
@@ -436,7 +439,7 @@ class TextToSpeech extends Provider {
 		);
 
 		// Add instructions if provided.
-		$instructions = $this->get_instructions();
+		$instructions = $this->get_instructions( $settings[ static::ID ]['instructions'] ?? '' );
 		if ( ! empty( $instructions ) ) {
 			$request_body['instructions'] = $instructions;
 		}

--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -74,6 +74,30 @@ class TextToSpeech extends Provider {
 	}
 
 	/**
+	 * Get the instructions for voice control.
+	 *
+	 * @return string
+	 */
+	public function get_instructions(): string {
+		$settings     = $this->feature_instance->get_settings();
+		$instructions = $settings[ static::ID ]['instructions'] ?? '';
+
+		/**
+		 * Filter the instructions for voice control.
+		 *
+		 * Useful if you want to modify the instructions for certain use cases.
+		 *
+		 * @since 3.4.0
+		 * @hook classifai_openai_text_to_speech_instructions
+		 *
+		 * @param string $instructions The current instructions to use.
+		 *
+		 * @return string The instructions to use.
+		 */
+		return apply_filters( 'classifai_openai_text_to_speech_instructions', $instructions );
+	}
+
+	/**
 	 * Register settings for the provider.
 	 */
 	public function render_provider_fields(): void {
@@ -216,6 +240,51 @@ class TextToSpeech extends Provider {
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID,
 			]
 		);
+
+		add_settings_field(
+			static::ID . '_instructions',
+			esc_html__( 'Voice instructions', 'classifai' ),
+			[ $this, 'render_textarea' ],
+			$this->feature_instance->get_option_name(),
+			$this->feature_instance->get_option_name() . '_section',
+			[
+				'option_index'  => static::ID,
+				'label_for'     => 'instructions',
+				'default_value' => $settings['instructions'],
+				'description'   => __( 'Optional instructions to control the voice characteristics of the generated audio. For example: "Speak in a calm, professional tone" or "Use a more energetic delivery".', 'classifai' ),
+				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID,
+				'rows'          => 3,
+			]
+		);
+	}
+
+	/**
+	 * Render a textarea field.
+	 *
+	 * @param array $args The args passed to add_settings_field.
+	 */
+	public function render_textarea( array $args ) {
+		$option_index  = isset( $args['option_index'] ) ? $args['option_index'] : false;
+		$setting_index = $this->feature_instance->get_settings( $option_index );
+		$value         = ( isset( $setting_index[ $args['label_for'] ] ) ) ? $setting_index[ $args['label_for'] ] : '';
+
+		// Check for a default value.
+		$value = ( empty( $value ) && isset( $args['default_value'] ) ) ? $args['default_value'] : $value;
+		$rows  = isset( $args['rows'] ) ? $args['rows'] : 3;
+		?>
+
+		<textarea
+			id="<?php echo esc_attr( $args['label_for'] ); ?>"
+			name="<?php echo esc_attr( $this->feature_instance->get_option_name() ); ?><?php echo $option_index ? '[' . esc_attr( $option_index ) . ']' : ''; ?>[<?php echo esc_attr( $args['label_for'] ); ?>]"
+			rows="<?php echo esc_attr( $rows ); ?>"
+			class="large-text"
+			placeholder="<?php esc_attr_e( 'Enter instructions to control voice characteristics...', 'classifai' ); ?>"
+		><?php echo esc_textarea( $value ); ?></textarea>
+
+		<?php
+		if ( ! empty( $args['description'] ) ) {
+			echo '<br /><span class="description">' . wp_kses_post( $args['description'] ) . '</span>';
+		}
 	}
 
 	/**
@@ -234,10 +303,11 @@ class TextToSpeech extends Provider {
 				return array_merge(
 					$common_settings,
 					[
-						'tts_model' => 'gpt-4o-mini-tts',
-						'voice'     => 'alloy',
-						'format'    => 'mp3',
-						'speed'     => 1,
+						'tts_model'    => 'gpt-4o-mini-tts',
+						'voice'        => 'alloy',
+						'format'       => 'mp3',
+						'speed'        => 1,
+						'instructions' => '',
 					]
 				);
 		}
@@ -275,6 +345,9 @@ class TextToSpeech extends Provider {
 			if ( 0.25 <= $speed || 4.00 >= $speed ) {
 				$new_settings[ static::ID ]['speed'] = sanitize_text_field( $new_settings[ static::ID ]['speed'] );
 			}
+
+			// Sanitize instructions field.
+			$new_settings[ static::ID ]['instructions'] = sanitize_textarea_field( $new_settings[ static::ID ]['instructions'] ?? '' );
 		}
 
 		return $new_settings;
@@ -362,6 +435,31 @@ class TextToSpeech extends Provider {
 			'input'           => $post_content,
 		);
 
+		// Add instructions if provided.
+		$instructions = $this->get_instructions();
+		if ( ! empty( $instructions ) ) {
+			$request_body['instructions'] = $instructions;
+		}
+
+		/**
+		 * Filter the request body before sending to OpenAI.
+		 *
+		 * @since 3.4.0
+		 * @hook classifai_openai_text_to_speech_request_body
+		 *
+		 * @param array  $request_body The request body that will be sent to OpenAI.
+		 * @param int    $post_id      Post ID.
+		 * @param string $post_content Post content.
+		 *
+		 * @return array The filtered request body.
+		 */
+		$request_body = apply_filters(
+			'classifai_openai_text_to_speech_request_body',
+			$request_body,
+			$post_id,
+			$post_content
+		);
+
 		$response = $request->post(
 			$this->get_api_url(),
 			[
@@ -397,6 +495,7 @@ class TextToSpeech extends Provider {
 			$debug_info[ __( 'Model', 'classifai' ) ]        = $provider_settings['tts_model'] ?? '';
 			$debug_info[ __( 'Voice', 'classifai' ) ]        = $provider_settings['voice'] ?? '';
 			$debug_info[ __( 'Audio format', 'classifai' ) ] = $provider_settings['format'] ?? '';
+			$debug_info[ __( 'Instructions', 'classifai' ) ] = $provider_settings['instructions'] ?? '';
 
 			// We don't save the response transient because WP does not support serialized binary data to be inserted to the options.
 		}

--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -243,51 +243,6 @@ class TextToSpeech extends Provider {
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID,
 			]
 		);
-
-		add_settings_field(
-			static::ID . '_instructions',
-			esc_html__( 'Voice instructions', 'classifai' ),
-			[ $this, 'render_textarea' ],
-			$this->feature_instance->get_option_name(),
-			$this->feature_instance->get_option_name() . '_section',
-			[
-				'option_index'  => static::ID,
-				'label_for'     => 'instructions',
-				'default_value' => $settings['instructions'],
-				'description'   => __( 'Optional instructions to control the voice characteristics of the generated audio. For example: "Speak in a calm, professional tone" or "Use a more energetic delivery".', 'classifai' ),
-				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID,
-				'rows'          => 3,
-			]
-		);
-	}
-
-	/**
-	 * Render a textarea field.
-	 *
-	 * @param array $args The args passed to add_settings_field.
-	 */
-	public function render_textarea( array $args ) {
-		$option_index  = isset( $args['option_index'] ) ? $args['option_index'] : false;
-		$setting_index = $this->feature_instance->get_settings( $option_index );
-		$value         = ( isset( $setting_index[ $args['label_for'] ] ) ) ? $setting_index[ $args['label_for'] ] : '';
-
-		// Check for a default value.
-		$value = ( empty( $value ) && isset( $args['default_value'] ) ) ? $args['default_value'] : $value;
-		$rows  = isset( $args['rows'] ) ? $args['rows'] : 3;
-		?>
-
-		<textarea
-			id="<?php echo esc_attr( $args['label_for'] ); ?>"
-			name="<?php echo esc_attr( $this->feature_instance->get_option_name() ); ?><?php echo $option_index ? '[' . esc_attr( $option_index ) . ']' : ''; ?>[<?php echo esc_attr( $args['label_for'] ); ?>]"
-			rows="<?php echo esc_attr( $rows ); ?>"
-			class="large-text"
-			placeholder="<?php esc_attr_e( 'Enter instructions to control voice characteristics...', 'classifai' ); ?>"
-		><?php echo esc_textarea( $value ); ?></textarea>
-
-		<?php
-		if ( ! empty( $args['description'] ) ) {
-			echo '<br /><span class="description">' . wp_kses_post( $args['description'] ) . '</span>';
-		}
 	}
 
 	/**

--- a/src/js/settings/components/provider-settings/openai-text-to-speech.js
+++ b/src/js/settings/components/provider-settings/openai-text-to-speech.js
@@ -4,6 +4,7 @@
 import {
 	__experimentalInputControl as InputControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	SelectControl,
+	TextareaControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -186,6 +187,32 @@ export const OpenAITextToSpeechSettings = ( { isConfigured = false } ) => {
 					step="0.25"
 					min="0.25"
 					max="4"
+				/>
+			</SettingsRow>
+			<SettingsRow
+				label={ __( 'Voice instructions', 'classifai' ) }
+				description={
+					<>
+						{ __(
+							'Optional instructions to control the voice characteristics of the generated audio.',
+							'classifai'
+						) }{ ' ' }
+						{ __(
+							'For example: "Speak in a calm, professional tone" or "Use a more energetic delivery".',
+							'classifai'
+						) }
+					</>
+				}
+			>
+				<TextareaControl
+					id={ `${ providerName }_instructions` }
+					onChange={ ( value ) => onChange( { instructions: value } ) }
+					value={ providerSettings.instructions || '' }
+					rows={ 3 }
+					placeholder={ __(
+						'Enter instructions to control voice characteristics...',
+						'classifai'
+					) }
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/openai-text-to-speech.js
+++ b/src/js/settings/components/provider-settings/openai-text-to-speech.js
@@ -85,6 +85,7 @@ export const OpenAITextToSpeechSettings = ( { isConfigured = false } ) => {
 						},
 					] }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -146,47 +147,7 @@ export const OpenAITextToSpeechSettings = ( { isConfigured = false } ) => {
 						},
 					] }
 					__nextHasNoMarginBottom
-				/>
-			</SettingsRow>
-			<SettingsRow
-				label={ __( 'Audio format', 'classifai' ) }
-				description={ __(
-					'Select the desired audio format.',
-					'classifai'
-				) }
-			>
-				<SelectControl
-					id={ `${ providerName }_format` }
-					onChange={ ( value ) => onChange( { format: value } ) }
-					value={ providerSettings.format || '.mp3' }
-					options={ [
-						{
-							label: __( '.mp3', 'classifai' ),
-							value: 'mp3',
-						},
-						{
-							label: __( '.wav', 'classifai' ),
-							value: 'wav',
-						},
-					] }
-					__nextHasNoMarginBottom
-				/>
-			</SettingsRow>
-			<SettingsRow
-				label={ __( 'Audio speed', 'classifai' ) }
-				description={ __(
-					'Select the desired speed of the generated audio.',
-					'classifai'
-				) }
-			>
-				<InputControl
-					id={ `${ providerName }_speed` }
-					onChange={ ( value ) => onChange( { speed: value } ) }
-					value={ providerSettings.speed || 1 }
-					type="number"
-					step="0.25"
-					min="0.25"
-					max="4"
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -215,6 +176,50 @@ export const OpenAITextToSpeechSettings = ( { isConfigured = false } ) => {
 						'Enter instructions to control voice characteristics…',
 						'classifai'
 					) }
+					__nextHasNoMarginBottom
+				/>
+			</SettingsRow>
+			<SettingsRow
+				label={ __( 'Audio format', 'classifai' ) }
+				description={ __(
+					'Select the desired audio format.',
+					'classifai'
+				) }
+			>
+				<SelectControl
+					id={ `${ providerName }_format` }
+					onChange={ ( value ) => onChange( { format: value } ) }
+					value={ providerSettings.format || '.mp3' }
+					options={ [
+						{
+							label: __( '.mp3', 'classifai' ),
+							value: 'mp3',
+						},
+						{
+							label: __( '.wav', 'classifai' ),
+							value: 'wav',
+						},
+					] }
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+			</SettingsRow>
+			<SettingsRow
+				label={ __( 'Audio speed', 'classifai' ) }
+				description={ __(
+					'Select the desired speed of the generated audio.',
+					'classifai'
+				) }
+			>
+				<InputControl
+					id={ `${ providerName }_speed` }
+					onChange={ ( value ) => onChange( { speed: value } ) }
+					value={ providerSettings.speed || 1 }
+					type="number"
+					step="0.25"
+					min="0.25"
+					max="4"
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/openai-text-to-speech.js
+++ b/src/js/settings/components/provider-settings/openai-text-to-speech.js
@@ -206,11 +206,13 @@ export const OpenAITextToSpeechSettings = ( { isConfigured = false } ) => {
 			>
 				<TextareaControl
 					id={ `${ providerName }_instructions` }
-					onChange={ ( value ) => onChange( { instructions: value } ) }
+					onChange={ ( value ) =>
+						onChange( { instructions: value } )
+					}
 					value={ providerSettings.instructions || '' }
 					rows={ 3 }
 					placeholder={ __(
-						'Enter instructions to control voice characteristics...',
+						'Enter instructions to control voice characteristics…',
 						'classifai'
 					) }
 				/>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR adds support for OpenAI's `instructions` parameter in the text-to-speech feature, allowing users to control voice characteristics using natural language instructions.

<img width="1287" height="970" alt="image" src="https://github.com/user-attachments/assets/523796fc-b3c4-4c20-8ce2-9c98df8e8c78" />

**Changes made:**
- Added a new "Voice instructions" textarea field to the OpenAI Text-to-Speech settings
- Updated default settings to include the `instructions` parameter
- Modified the API request to include instructions when provided
- Added `get_instructions()` method with filter support
- Added two new filters: `classifai_openai_text_to_speech_instructions` and `classifai_openai_text_to_speech_request_body`

- Users can now control voice characteristics with natural language (e.g., "Speak in a calm, professional tone")
- Provides more flexibility in audio generation
- Maintains backward compatibility (instructions are optional)

**Approaches considered:**
- Initially considered making this a universal setting across all TTS providers, but research showed that each provider uses different approaches (OpenAI uses natural language, Amazon Polly uses SSML, Azure uses SSML tags, ElevenLabs uses technical parameters)
- Decided to keep this OpenAI-specific to maintain clean separation of concerns

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #998, Closes #997

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. **Build the frontend assets:**
   ```bash
   npm run build
   ```

2. **Access the settings:**
   - Go to WordPress Admin > Tools > ClassifAI > Language Processing > Text to Speech > Settings
   - Select "OpenAI Text to Speech" as provider
   - Verify the new "Voice instructions" field appears below "Audio speed"

3. **Test the functionality:**
   - Enter test instructions like "Say Welcome before starting", "Speak in a calm, professional tone" or "Use a more energetic delivery"
   - Save settings
   - Create/edit a post and generate text-to-speech audio
   - Verify the audio reflects the voice characteristics specified in instructions

4. **Test filters:**
   ```php
   add_filter( 'classifai_openai_text_to_speech_instructions', function( $instructions ) {
       return $instructions . ' Speak with enthusiasm.';
   });
   ```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Support for OpenAI text-to-speech instructions parameter to control voice characteristics

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @swissky @dkotter @faisalalvi

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.