### PR TITLE
Fix default_value for OpenAI voice dropdown

### DIFF
--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -186,7 +186,7 @@ class TextToSpeech extends Provider {
 					'nova'    => __( 'Nova (female)', 'classifai' ),
 					'shimmer' => __( 'Shimmer (female)', 'classifai' ),
 				],
-				'default_value' => $settings['voice'],
+				'default_value' => $settings['alloy'],
 				'description'   => $this->feature_instance->is_configured_with_provider( static::ID ) ?
 					'' :
 					sprintf(


### PR DESCRIPTION
While working with a fresh installation of ClassifAI, I added the API key for OpenAI Text to Speech and saved it, then tried generating text-to-speech for a post, but it was failing with their API returning the following error:

```
"[{'type': 'enum', 'loc': ('body', 'voice'), 'msg': "Input should be 'nova', 'shimmer', 'echo', 'onyx', 'fable', 'alloy', 'ash', 'sage' or 'coral'", 'input': 'voice', 'ctx': {'expected': "'nova', 'shimmer', 'echo', 'onyx', 'fable', 'alloy', 'ash', 'sage' or 'coral'"}}]"
```

After some debugging, I found that that the default_value for the voice selection was set to `voice`, and it reflected this in the `classifai_feature_text_to_speech_generation` option:

```
'openai_text_to_speech' =>
array (
  'api_key' => 'redacted',
  'authenticated' => true,
  'tts_model' => 'tts-1',
  'voice' => 'voice',
  'format' => 'mp3',
  'speed' => '1',
),
```

After changing the voice value to something else, saving it, then setting it to Alloy and saving it again, the the correct value showed up for voice:
```
'openai_text_to_speech' =>
array (
  'api_key' => 'redacted',
  'authenticated' => true,
  'tts_model' => 'tts-1',
  'voice' => 'alloy',
  'format' => 'mp3',
  'speed' => '1',
),
```

And generating text-to-speech for the post was working correctly. This PR sets a valid value for the default voice.
