### PR TITLE
Add the running of Plugin Check back to our helper files

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -37,6 +37,5 @@ jobs:
           build-dir: ${{ github.event.repository.name }}
           exclude-checks: 'plugin_readme,plugin_updater' # Plugin isn't on .org so excluding these for now.
           exclude-directories: 'assets,dist,vendor'
-          exclude-files: 'includes/Classifai/Providers/Watson/Helpers.php,includes/Classifai/Helpers.php' # These files are included via composer and cause errors with PHPCS if we fix the "prevent direct access" check.
           ignore-codes: 'PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound' # Plugin isn't on .org so we load the textdomain manually.
           ignore-warnings: true

--- a/includes/Classifai/Features/ContentGeneration.php
+++ b/includes/Classifai/Features/ContentGeneration.php
@@ -41,7 +41,7 @@ class ContentGeneration extends Feature {
 	 *
 	 * @var string
 	 */
-	public $return_format = <<<EOD
+	public $return_format = <<<'INSTRUCTION'
 The content returned should be valid WordPress block markup as described below, using elements like paragraphs and headings where appropriate. Be selective on the elements you use, defaulting to paragraphs. Please check the content before returning to ensure each element has proper opening and closing block markup and HTML tags and any required block attributes. Ensure elements don't nest inside each other, i.e. don't put a paragraph inside another paragraph or a list within a paragraph. Don't start the content with a heading, start with a paragraph.
 
 Markup available to use; don't use any other blocks, even if requested:
@@ -78,8 +78,8 @@ Markup available to use; don't use any other blocks, even if requested:
 <li>CONTENT</li>
 </ol>
 <!-- /wp:list -->
-EOD;
-	// phpcs:enable Squiz.PHP.Heredoc.NotAllowed
+INSTRUCTION;
+	// phpcs:enable
 
 	/**
 	 * Constructor.

--- a/includes/Classifai/Features/ImageTagsGenerator.php
+++ b/includes/Classifai/Features/ImageTagsGenerator.php
@@ -34,12 +34,12 @@ class ImageTagsGenerator extends Feature {
 	 *
 	 * @var string
 	 */
-	public $prompt = <<<EOD
+	public $prompt = <<<'INSTRUCTION'
 You are an assistant that generates image tags. You will be provided with an image and will generate a list of tags that best represent the image. Ensure the tags are short. Return at most the best 5 tags and return these in the following format:
 - Tag
 - Another tag
 - ...
-EOD;
+INSTRUCTION;
 	// phpcs:enable
 
 	/**

--- a/includes/Classifai/Helpers.php
+++ b/includes/Classifai/Helpers.php
@@ -12,6 +12,11 @@ use Classifai\Services\Service;
 use Classifai\Services\ServicesManager;
 use WP_Error;
 
+// Using return instead of exit to prevent errors running PHPCS.
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
 /**
  * Miscellaneous Helper functions to access different parts of the
  * ClassifAI plugin.

--- a/includes/Classifai/Providers/Watson/Helpers.php
+++ b/includes/Classifai/Providers/Watson/Helpers.php
@@ -7,6 +7,11 @@ namespace Classifai\Providers\Watson;
 
 use Classifai\Features\Classification;
 
+// Using return instead of exit to prevent errors running PHPCS.
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
 /**
  * Returns the currently configured Watson API URL. Lookup order is,
  *


### PR DESCRIPTION
### Description of the Change

Coming out of #1023, we removed the scanning of our helper files from Plugin Check as it wanted us to add a code snippet to prevent direct file access but this caused issues with PHPCS. After doing some more digging, found that when PHPCS is run, it will load your composer autoload file and this in turn will load any files you are directly loading via composer (as opposed to loading via psr-4). We do this for our helper files and so when you add an `exit` statement to these files, this stops PHPCS from running.

There are a few fixes for this but seemed the easiest was to change from using `exit` to using `return` so that's what I've done in this PR. In addition, noticed a few PHPCS warnings around the use of heredoc instead of nowdoc so fixed those up as well.

### How to test the Change

Nothing really needed other than ensuring Plugin Check passes and PHPCS also passes

> [!NOTE]  
> E2E tests aren't working on WP trunk, assuming due to upstream issues

### Changelog Entry

> Fixed - Ensure our helper files don't allow direct file access

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
