### PR TITLE
Update our WordPress Playground integration

### DIFF
--- a/.github/blueprints/blueprint.json
+++ b/.github/blueprints/blueprint.json
@@ -12,8 +12,9 @@
     {
       "step": "installPlugin",
       "pluginData": {
-        "resource": "url",
-        "url": "https://github-proxy.com/proxy/?repo=10up/classifai&branch=stable"
+        "resource": "git:directory",
+        "url": "https://github.com/10up/classifai",
+        "ref": "stable"
       },
       "options": {
         "activate": true


### PR DESCRIPTION
### Description of the Change

Our WordPress Playground integration uses the `github-proxy.com` approach to load in ClassifAI. This is now [deprecated](https://make.wordpress.org/playground/2025/12/19/action-required-github-proxy-com-shutdown/) so this PR updates that approach with the new recommendations.

### How to test the Change

Load a WordPress Playground with the new blueprint and ensure things work:

[Playground](https://playground.wordpress.net/#{%22$schema%22:%22https://playground.wordpress.net/blueprint-schema.json%22,%22landingPage%22:%22/wp-admin/tools.php?welcome_guide=1&page=classifai#/language_processing%22,%22preferredVersions%22:{%22php%22:%227.4%22,%22wp%22:%22latest%22},%22features%22:{%22networking%22:true},%22steps%22:[{%22step%22:%22installPlugin%22,%22pluginData%22:{%22resource%22:%22git:directory%22,%22url%22:%22https://github.com/10up/classifai%22,%22ref%22:%22stable%22},%22options%22:{%22activate%22:true}}]})

### Changelog Entry

> Fixed - Resolve deprecation warnings in our WordPress Playground integration

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
