### PR TITLE
Allow filtering of Provider credentials

### DIFF
--- a/includes/Classifai/Providers/AWS/AmazonPolly.php
+++ b/includes/Classifai/Providers/AWS/AmazonPolly.php
@@ -225,7 +225,9 @@ class AmazonPolly extends Provider {
 				$new_settings[ static::ID ]['access_key_id']     = $new_access_key_id;
 				$new_settings[ static::ID ]['secret_access_key'] = $new_secret_access_key;
 				$new_settings[ static::ID ]['aws_region']        = $new_aws_region;
-				$new_settings[ static::ID ]['voices']            = $this->connect_to_service(
+
+				// Connect to the service and get voices.
+				$new_settings[ static::ID ]['voices'] = $this->connect_to_service(
 					array(
 						'access_key_id'     => $new_access_key_id,
 						'secret_access_key' => $new_secret_access_key,
@@ -300,7 +302,7 @@ class AmazonPolly extends Provider {
 				return $pre;
 			}
 
-			$polly_client = $this->get_polly_client( $args );
+			$polly_client = $this->get_polly_client( $default );
 			$polly_voices = $polly_client->describeVoices();
 			return $polly_voices->get( 'Voices' );
 		} catch ( \Exception $e ) {
@@ -529,29 +531,21 @@ class AmazonPolly extends Provider {
 	 * @return \Aws\Polly\PollyClient|null
 	 */
 	public function get_polly_client( array $aws_config = array() ) {
-		$settings = $this->feature_instance->get_settings( static::ID );
-
-		$default = array(
-			'access_key_id'     => $settings['access_key_id'] ?? '',
-			'secret_access_key' => $settings['secret_access_key'] ?? '',
-			'aws_region'        => $settings['aws_region'] ?? 'us-east-1',
-		);
-
-		$default = wp_parse_args( $aws_config, $default );
+		$credentials = $this->get_credentials( [ static::ID => $aws_config ] );
 
 		// Return if credentials don't exist.
-		if ( empty( $default['access_key_id'] ) || empty( $default['secret_access_key'] ) ) {
+		if ( empty( $credentials['access_key_id'] ) || empty( $credentials['secret_access_key'] ) ) {
 			return null;
 		}
 
 		// Set the AWS SDK configuration.
 		$aws_sdk_config = [
-			'region'      => $default['aws_region'] ?? 'us-east-1',
+			'region'      => $credentials['aws_region'] ?? 'us-east-1',
 			'version'     => 'latest',
 			'ua_append'   => [ 'request-source/classifai' ],
 			'credentials' => [
-				'key'    => $default['access_key_id'],
-				'secret' => $default['secret_access_key'],
+				'key'    => $credentials['access_key_id'],
+				'secret' => $credentials['secret_access_key'],
 			],
 		];
 

--- a/includes/Classifai/Providers/Azure/ComputerVision.php
+++ b/includes/Classifai/Providers/Azure/ComputerVision.php
@@ -222,10 +222,7 @@ class ComputerVision extends Provider {
 			$is_api_key_same  = $new_settings[ static::ID ]['api_key'] === $settings[ static::ID ]['api_key'];
 
 			if ( ! ( $is_authenticated && $is_endpoint_same && $is_api_key_same ) ) {
-				$auth_check = $this->authenticate_credentials(
-					$new_settings[ static::ID ]['endpoint_url'],
-					$new_settings[ static::ID ]['api_key']
-				);
+				$auth_check = $this->authenticate_credentials( $new_settings );
 
 				if ( is_wp_error( $auth_check ) ) {
 					$new_settings[ static::ID ]['authenticated'] = false;
@@ -335,10 +332,10 @@ class ComputerVision extends Provider {
 	 * @param int    $attachment_id Attachment ID.
 	 */
 	public function do_read_cron( string $operation_url, int $attachment_id ) {
-		$feature  = new PDFTextExtraction();
-		$settings = $feature->get_settings( static::ID );
+		$feature     = new PDFTextExtraction();
+		$credentials = $this->get_credentials();
 
-		( new Read( $settings, intval( $attachment_id ), $feature ) )->check_read_result( $operation_url );
+		( new Read( $credentials, intval( $attachment_id ), $feature ) )->check_read_result( $operation_url );
 	}
 
 	/**
@@ -355,10 +352,10 @@ class ComputerVision extends Provider {
 			return new WP_Error( 'invalid', esc_html__( 'This attachment can\'t be processed.', 'classifai' ) );
 		}
 
-		$feature  = new ImageCropping();
-		$settings = $feature->get_settings( static::ID );
+		$feature     = new ImageCropping();
+		$credentials = $this->get_credentials();
 
-		if ( ! is_array( $metadata ) || ! is_array( $settings ) ) {
+		if ( ! is_array( $metadata ) || ! is_array( $credentials ) ) {
 			return new WP_Error( 'invalid', esc_html__( 'Invalid data found. Please check your settings and try again.', 'classifai' ) );
 		}
 
@@ -390,7 +387,7 @@ class ComputerVision extends Provider {
 			return new WP_Error( 'access', esc_html__( 'Access to the filesystem is required for this feature to work.', 'classifai' ) );
 		}
 
-		$smart_cropping = new SmartCropping( $settings );
+		$smart_cropping = new SmartCropping( $credentials );
 
 		return $smart_cropping->generate_cropped_images( $metadata, intval( $attachment_id ) );
 	}
@@ -551,7 +548,7 @@ class ComputerVision extends Provider {
 	 */
 	public function read_pdf( int $attachment_id ) {
 		$feature         = new PDFTextExtraction();
-		$settings        = $feature->get_settings( static::ID );
+		$credentials     = $this->get_credentials();
 		$should_read_pdf = $feature->is_feature_enabled();
 
 		if ( ! $should_read_pdf ) {
@@ -569,7 +566,7 @@ class ComputerVision extends Provider {
 			return new WP_Error( 'invalid_access_type', 'Invalid access type! Direct file system access is required.' );
 		}
 
-		$read = new Read( $settings, intval( $attachment_id ), $feature );
+		$read = new Read( $credentials, intval( $attachment_id ), $feature );
 
 		return $read->read_document();
 	}
@@ -654,7 +651,7 @@ class ComputerVision extends Provider {
 	 * @return bool|object|WP_Error
 	 */
 	protected function scan_image( string $image_url, ?\Classifai\Features\Feature $feature = null ) {
-		$settings = $feature->get_settings( static::ID );
+		$credentials = $this->get_credentials();
 
 		// Check if valid authentication is in place.
 		if ( ! $feature->is_feature_enabled() ) {
@@ -675,7 +672,7 @@ class ComputerVision extends Provider {
 			$endpoint_url,
 			[
 				'headers' => [
-					'Ocp-Apim-Subscription-Key' => $settings['api_key'],
+					'Ocp-Apim-Subscription-Key' => $credentials['api_key'] ?? '',
 					'Content-Type'              => 'application/json',
 				],
 				/**
@@ -726,7 +723,7 @@ class ComputerVision extends Provider {
 	 * @return string
 	 */
 	protected function prep_api_url( ?\Classifai\Features\Feature $feature = null ): string {
-		$settings     = $feature->get_settings( static::ID );
+		$credentials  = $this->get_credentials( $feature->get_settings() );
 		$api_features = [];
 
 		if ( $feature instanceof DescriptiveTextGenerator && $feature->is_feature_enabled() && ! empty( $feature->get_alt_text_settings() ) ) {
@@ -741,7 +738,7 @@ class ComputerVision extends Provider {
 			$api_features[] = 'read';
 		}
 
-		$endpoint = add_query_arg( 'features', implode( ',', $api_features ), trailingslashit( $settings['endpoint_url'] ) . $this->analyze_url );
+		$endpoint = add_query_arg( 'features', implode( ',', $api_features ), trailingslashit( $credentials['endpoint_url'] ?? '' ) . $this->analyze_url );
 
 		return $endpoint;
 	}
@@ -749,17 +746,17 @@ class ComputerVision extends Provider {
 	/**
 	 * Authenticates our credentials.
 	 *
-	 * @param string $url     Endpoint URL.
-	 * @param string $api_key Api Key.
+	 * @param array $settings Settings being saved.
 	 * @return bool|WP_Error
 	 */
-	protected function authenticate_credentials( string $url, string $api_key ) {
-		$rtn     = false;
-		$request = safe_wp_remote_post(
-			add_query_arg( 'features', 'caption', trailingslashit( $url ) . $this->analyze_url ),
+	protected function authenticate_credentials( array $settings = [] ) {
+		$credentials = $this->get_credentials( $settings );
+		$rtn         = false;
+		$request     = safe_wp_remote_post(
+			add_query_arg( 'features', 'caption', trailingslashit( $credentials['endpoint_url'] ?? '' ) . $this->analyze_url ),
 			[
 				'headers' => [
-					'Ocp-Apim-Subscription-Key' => $api_key,
+					'Ocp-Apim-Subscription-Key' => $credentials['api_key'] ?? '',
 					'Content-Type'              => 'application/json',
 				],
 				'body'    => '{"url":"https://classifaiplugin.com/wp-content/themes/fse-classifai-theme/assets/img/header.png"}',
@@ -774,6 +771,8 @@ class ComputerVision extends Provider {
 			} else {
 				$rtn = true;
 			}
+		} else {
+			$rtn = $request;
 		}
 
 		return $rtn;

--- a/includes/Classifai/Providers/Azure/Embeddings.php
+++ b/includes/Classifai/Providers/Azure/Embeddings.php
@@ -12,6 +12,7 @@ use Classifai\Features\Classification;
 use Classifai\Features\Feature;
 use Classifai\EmbeddingsScheduler;
 use WP_Error;
+
 use function Classifai\safe_wp_remote_post;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -251,9 +252,9 @@ class Embeddings extends OpenAI {
 	 * @return string
 	 */
 	protected function prep_api_url( ?Feature $feature = null ): string {
-		$settings   = $feature->get_settings( static::ID );
-		$endpoint   = $settings['endpoint_url'] ?? '';
-		$deployment = $settings['deployment'] ?? '';
+		$credentials = $this->get_credentials( $feature->get_settings() ?? [] );
+		$endpoint    = $credentials['endpoint_url'] ?? '';
+		$deployment  = $credentials['deployment'] ?? '';
 
 		if ( ! $endpoint ) {
 			return '';
@@ -270,24 +271,23 @@ class Embeddings extends OpenAI {
 	/**
 	 * Authenticates our credentials.
 	 *
-	 * @param string $url Endpoint URL.
-	 * @param string $api_key Api Key.
-	 * @param string $deployment Deployment name.
+	 * @param array $settings Settings being saved
 	 * @return bool|WP_Error
 	 */
-	protected function authenticate_credentials( string $url, string $api_key, string $deployment ) {
-		$rtn = false;
+	protected function authenticate_credentials( array $settings = [] ) {
+		$credentials = $this->get_credentials( $settings );
+		$rtn         = false;
 
 		// This does basically the same thing that prep_api_url does but when running authentication,
 		// we don't have settings saved yet, which prep_api_url needs.
-		$endpoint = trailingslashit( $url ) . str_replace( '{deployment-id}', $deployment, $this->embeddings_url );
+		$endpoint = trailingslashit( $credentials['endpoint_url'] ?? '' ) . str_replace( '{deployment-id}', $credentials['deployment'] ?? '', $this->embeddings_url );
 		$endpoint = add_query_arg( 'api-version', $this->api_version, $endpoint );
 
 		$request = safe_wp_remote_post(
 			$endpoint,
 			[
 				'headers' => [
-					'api-key'      => $api_key,
+					'api-key'      => $credentials['api_key'] ?? '',
 					'Content-Type' => 'application/json',
 				],
 				'body'    => wp_json_encode(
@@ -307,11 +307,12 @@ class Embeddings extends OpenAI {
 			} else {
 				$rtn = true;
 			}
+		} else {
+			$rtn = $request;
 		}
 
 		return $rtn;
 	}
-
 
 	/**
 	 * Get the threshold for the similarity calculation.
@@ -970,12 +971,14 @@ class Embeddings extends OpenAI {
 			$feature = new Classification();
 		}
 
-		$settings = $feature->get_settings();
-
 		// Ensure the feature is enabled.
 		if ( ! $feature->is_feature_enabled() ) {
 			return new WP_Error( 'not_enabled', esc_html__( 'Classification is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
+
+		// Ensure we have a valid Feature instance.
+		$backup_feature_instance = $this->feature_instance;
+		$this->feature_instance  = $feature;
 
 		/**
 		 * Filter the request body before sending to OpenAI.
@@ -1002,7 +1005,7 @@ class Embeddings extends OpenAI {
 			$this->prep_api_url( $feature ),
 			[
 				'headers' => [
-					'api-key'      => $settings[ static::ID ]['api_key'],
+					'api-key'      => $this->get_credential( 'api_key' ) ?? '',
 					'Content-Type' => 'application/json',
 				],
 				'body'    => wp_json_encode( $body ),
@@ -1012,6 +1015,9 @@ class Embeddings extends OpenAI {
 		$response = $this->get_result( $response );
 
 		set_transient( 'classifai_azure_openai_embeddings_latest_response', $response, DAY_IN_SECONDS * 30 );
+
+		// Restore the existing Feature instance.
+		$this->feature_instance = $backup_feature_instance;
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -1049,12 +1055,14 @@ class Embeddings extends OpenAI {
 			$feature = new Classification();
 		}
 
-		$settings = $feature->get_settings();
-
 		// Ensure the feature is enabled.
 		if ( ! $feature->is_feature_enabled() ) {
 			return new WP_Error( 'not_enabled', esc_html__( 'Classification is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
+
+		// Ensure we have a valid Feature instance.
+		$backup_feature_instance = $this->feature_instance;
+		$this->feature_instance  = $feature;
 
 		/**
 		 * Filter the request body before sending to OpenAI.
@@ -1081,7 +1089,7 @@ class Embeddings extends OpenAI {
 			$this->prep_api_url( $feature ),
 			[
 				'headers' => [
-					'api-key'      => $settings[ static::ID ]['api_key'],
+					'api-key'      => $this->get_credential( 'api_key' ) ?? '',
 					'Content-Type' => 'application/json',
 				],
 				'body'    => wp_json_encode( $body ),
@@ -1089,6 +1097,9 @@ class Embeddings extends OpenAI {
 			]
 		);
 		$response = $this->get_result( $response );
+
+		// Restore the existing Feature instance.
+		$this->feature_instance = $backup_feature_instance;
 
 		if ( is_wp_error( $response ) ) {
 			return $response;

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -284,7 +284,7 @@ class OpenAI extends Provider {
 	/**
 	 * Authenticates our credentials.
 	 *
-	 * array $settings Settings being saved.
+	 * @param array $settings Settings being saved.
 	 * @return bool|WP_Error
 	 */
 	protected function authenticate_credentials( array $settings = [] ) {

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -218,11 +218,7 @@ class OpenAI extends Provider {
 			$is_deployment_same = $new_settings[ static::ID ]['deployment'] === $settings[ static::ID ]['deployment'];
 
 			if ( ! ( $is_authenticated && $is_endpoint_same && $is_api_key_same && $is_deployment_same ) ) {
-				$auth_check = $this->authenticate_credentials(
-					$new_settings[ static::ID ]['endpoint_url'],
-					$new_settings[ static::ID ]['api_key'],
-					$new_settings[ static::ID ]['deployment']
-				);
+				$auth_check = $this->authenticate_credentials( $new_settings );
 
 				if ( is_wp_error( $auth_check ) ) {
 					$new_settings[ static::ID ]['authenticated'] = false;
@@ -262,9 +258,9 @@ class OpenAI extends Provider {
 	 * @return string
 	 */
 	protected function prep_api_url( ?\Classifai\Features\Feature $feature = null ): string {
-		$settings   = $feature->get_settings( static::ID );
-		$endpoint   = $settings['endpoint_url'] ?? '';
-		$deployment = $settings['deployment'] ?? '';
+		$credentials = $this->get_credentials( $feature->get_settings() ?? [] );
+		$endpoint    = $credentials['endpoint_url'] ?? '';
+		$deployment  = $credentials['deployment'] ?? '';
 
 		if ( ! $endpoint ) {
 			return '';
@@ -288,24 +284,23 @@ class OpenAI extends Provider {
 	/**
 	 * Authenticates our credentials.
 	 *
-	 * @param string $url Endpoint URL.
-	 * @param string $api_key Api Key.
-	 * @param string $deployment Deployment name.
+	 * array $settings Settings being saved.
 	 * @return bool|WP_Error
 	 */
-	protected function authenticate_credentials( string $url, string $api_key, string $deployment ) {
-		$rtn = false;
+	protected function authenticate_credentials( array $settings = [] ) {
+		$credentials = $this->get_credentials( $settings );
+		$rtn         = false;
 
 		// This does basically the same thing that prep_api_url does but when running authentication,
 		// we don't have settings saved yet, which prep_api_url needs.
-		$endpoint = trailingslashit( $url ) . str_replace( '{deployment-id}', $deployment, $this->chat_completion_url );
+		$endpoint = trailingslashit( $credentials['endpoint_url'] ?? '' ) . str_replace( '{deployment-id}', $credentials['deployment'] ?? '', $this->chat_completion_url );
 		$endpoint = add_query_arg( 'api-version', $this->completion_api_version, $endpoint );
 
 		$request = safe_wp_remote_post(
 			$endpoint,
 			[
 				'headers' => [
-					'api-key'      => $api_key,
+					'api-key'      => $credentials['api_key'] ?? '',
 					'Content-Type' => 'application/json',
 				],
 				'body'    => wp_json_encode(
@@ -325,6 +320,8 @@ class OpenAI extends Provider {
 			} else {
 				$rtn = true;
 			}
+		} else {
+			$rtn = $request;
 		}
 
 		return $rtn;
@@ -459,7 +456,7 @@ class OpenAI extends Provider {
 			$this->prep_api_url( $feature ),
 			[
 				'headers' => [
-					'api-key'      => $settings[ static::ID ]['api_key'],
+					'api-key'      => $this->get_credential( 'api_key' ) ?? '',
 					'Content-Type' => 'application/json',
 				],
 				'body'    => wp_json_encode( $body ),
@@ -566,7 +563,7 @@ class OpenAI extends Provider {
 			$this->prep_api_url( $feature ),
 			[
 				'headers' => [
-					'api-key'      => $settings[ static::ID ]['api_key'],
+					'api-key'      => $this->get_credential( 'api_key' ) ?? '',
 					'Content-Type' => 'application/json',
 				],
 				'body'    => wp_json_encode( $body ),
@@ -673,7 +670,7 @@ class OpenAI extends Provider {
 			$this->prep_api_url( $feature ),
 			[
 				'headers' => [
-					'api-key'      => $settings[ static::ID ]['api_key'],
+					'api-key'      => $this->get_credential( 'api_key' ) ?? '',
 					'Content-Type' => 'application/json',
 				],
 				'body'    => wp_json_encode( $body ),
@@ -834,7 +831,7 @@ class OpenAI extends Provider {
 			$this->prep_api_url( $feature ),
 			[
 				'headers' => [
-					'api-key'      => $settings[ static::ID ]['api_key'],
+					'api-key'      => $this->get_credential( 'api_key' ) ?? '',
 					'Content-Type' => 'application/json',
 				],
 				'body'    => wp_json_encode( $body ),
@@ -987,7 +984,7 @@ class OpenAI extends Provider {
 			$this->prep_api_url( $feature ),
 			[
 				'headers' => [
-					'api-key'      => $settings[ static::ID ]['api_key'],
+					'api-key'      => $this->get_credential( 'api_key' ) ?? '',
 					'Content-Type' => 'application/json',
 				],
 				'body'    => wp_json_encode( $body ),

--- a/includes/Classifai/Providers/Azure/Read.php
+++ b/includes/Classifai/Providers/Azure/Read.php
@@ -9,6 +9,7 @@
 namespace Classifai\Providers\Azure;
 
 use WP_Error;
+
 use function Classifai\computer_vision_max_filesize;
 use function Classifai\safe_wp_remote_post;
 use function Classifai\safe_wp_remote_get;
@@ -70,7 +71,7 @@ class Read {
 	 * @return string
 	 */
 	public function get_api_url( string $path = '' ): string {
-		return sprintf( '%s%s%s', trailingslashit( $this->settings['endpoint_url'] ), static::API_PATH, $path );
+		return sprintf( '%s%s%s', trailingslashit( $this->settings['endpoint_url'] ?? '' ), static::API_PATH, $path );
 	}
 
 	/**
@@ -173,7 +174,7 @@ class Read {
 				),
 				'headers' => [
 					'Content-Type'              => 'application/json',
-					'Ocp-Apim-Subscription-Key' => $this->settings['api_key'],
+					'Ocp-Apim-Subscription-Key' => $this->settings['api_key'] ?? '',
 				],
 			]
 		);
@@ -225,7 +226,7 @@ class Read {
 			$operation_url,
 			[
 				'headers' => [
-					'Ocp-Apim-Subscription-Key' => $this->settings['api_key'],
+					'Ocp-Apim-Subscription-Key' => $this->settings['api_key'] ?? '',
 				],
 			]
 		);

--- a/includes/Classifai/Providers/Azure/SmartCropping.php
+++ b/includes/Classifai/Providers/Azure/SmartCropping.php
@@ -217,7 +217,7 @@ class SmartCropping {
 	 * @return string
 	 */
 	public function get_api_url(): string {
-		return sprintf( '%s%s', trailingslashit( $this->settings['endpoint_url'] ), static::API_PATH );
+		return sprintf( '%s%s', trailingslashit( $this->settings['endpoint_url'] ?? '' ), static::API_PATH );
 	}
 
 	/**
@@ -248,7 +248,7 @@ class SmartCropping {
 				),
 				'headers' => [
 					'Content-Type'              => 'application/json',
-					'Ocp-Apim-Subscription-Key' => $this->settings['api_key'],
+					'Ocp-Apim-Subscription-Key' => $this->settings['api_key'] ?? '',
 				],
 			]
 		);

--- a/includes/Classifai/Providers/Azure/Speech.php
+++ b/includes/Classifai/Providers/Azure/Speech.php
@@ -149,7 +149,9 @@ class Speech extends Provider {
 			if ( $is_credentials_changed ) {
 				$new_settings[ static::ID ]['endpoint_url'] = $new_url;
 				$new_settings[ static::ID ]['api_key']      = $new_key;
-				$new_settings[ static::ID ]['voices']       = $this->connect_to_service(
+
+				// Connect to the service and get voices.
+				$new_settings[ static::ID ]['voices'] = $this->connect_to_service(
 					array(
 						'endpoint_url' => $new_url,
 						'api_key'      => $new_key,
@@ -188,39 +190,36 @@ class Speech extends Provider {
 	 */
 	public function connect_to_service( array $args = array() ): array {
 		$settings = $this->feature_instance->get_settings( static::ID );
-
-		$default = array(
+		$default  = array(
 			'endpoint_url' => isset( $settings[ static::ID ]['url'] ) ? $settings[ static::ID ]['url'] : '',
 			'api_key'      => isset( $settings[ static::ID ]['api_key'] ) ? $settings[ static::ID ]['api_key'] : '',
 		);
 
-		$default = wp_parse_args( $args, $default );
+		$default     = wp_parse_args( $args, $default );
+		$credentials = $this->get_credentials( [ static::ID => $default ] );
 
 		// Return if credentials don't exist.
-		if ( empty( $default['endpoint_url'] ) || empty( $default['api_key'] ) ) {
+		if ( empty( $credentials['endpoint_url'] ) || empty( $credentials['api_key'] ) ) {
 			return array();
 		}
 
 		// Create request arguments.
 		$request_params = array(
 			'headers' => array(
-				'Ocp-Apim-Subscription-Key' => $default['api_key'],
+				'Ocp-Apim-Subscription-Key' => $credentials['api_key'] ?? '',
 				'Content-Type'              => 'application/json',
 			),
+			'timeout' => 20, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			'use_vip' => true,
 		);
 
 		// Create request URL.
 		$request_url = sprintf(
 			'%1$scognitiveservices/voices/list',
-			$default['endpoint_url']
+			$credentials['endpoint_url'] ?? ''
 		);
 
-		$request_params['timeout'] = $request_params['timeout'] ?? 20;
-		$response                  = safe_wp_remote_get(
-			$request_url,
-			$request_params
-		);
+		$response = safe_wp_remote_get( $request_url, $request_params );
 
 		if ( is_wp_error( $response ) ) {
 			add_settings_error(
@@ -364,19 +363,21 @@ class Speech extends Provider {
 			$post_content
 		);
 
+		$credentials = $this->get_credentials();
+
 		// Request parameters.
 		$request_params = array(
 			'method'  => 'POST',
 			'body'    => $request_body,
 			'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			'headers' => array(
-				'Ocp-Apim-Subscription-Key' => $settings[ static::ID ]['api_key'],
+				'Ocp-Apim-Subscription-Key' => $credentials['api_key'] ?? '',
 				'Content-Type'              => 'application/ssml+xml',
 				'X-Microsoft-OutputFormat'  => 'audio-16khz-128kbitrate-mono-mp3',
 			),
 		);
 
-		$remote_url = sprintf( '%s%s', $settings[ static::ID ]['endpoint_url'], self::API_PATH );
+		$remote_url = sprintf( '%s%s', trailingslashit( $credentials['endpoint_url'] ?? '' ), self::API_PATH );
 		$response   = safe_wp_remote_post( $remote_url, $request_params );
 
 		if ( is_wp_error( $response ) ) {

--- a/includes/Classifai/Providers/CredentialResolver.php
+++ b/includes/Classifai/Providers/CredentialResolver.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Credential resolution for Providers.
+ *
+ * Determines the effective credentials for a Provider by pulling from the
+ * Feature-level config. Used at runtime when Providers need
+ * api_key, endpoint_url, etc.
+ *
+ * @since x.x.x
+ */
+
+namespace Classifai\Providers;
+
+use Classifai\Providers\ProviderProfiles;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * CredentialResolver class.
+ */
+class CredentialResolver {
+
+	/**
+	 * Resolve credentials for a Provider.
+	 *
+	 * TODO: This will be updated in the future to support getting
+	 * credentials from the global Provider scope.
+	 *
+	 * @param string $provider_id Capability-specific Provider ID (e.g. openai_chatgpt).
+	 * @param array  $feature_provider_settings The Provider specific Feature settings.
+	 * @return array Effective credentials for the Provider.
+	 */
+	public static function resolve( string $provider_id, array $feature_provider_settings = [] ): array {
+		$profile_id = ProviderProfiles::get_profile_for_provider( $provider_id );
+		if ( null === $profile_id ) {
+			return $feature_provider_settings;
+		}
+
+		// Get the credential fields the profile supports.
+		$credential_fields = ProviderProfiles::get_credential_fields( $profile_id );
+
+		// Ensure the Feature-level Provider settings only has credential fields.
+		return array_intersect_key( $feature_provider_settings, array_flip( $credential_fields ) );
+	}
+}

--- a/includes/Classifai/Providers/ElevenLabs/ElevenLabs.php
+++ b/includes/Classifai/Providers/ElevenLabs/ElevenLabs.php
@@ -103,7 +103,7 @@ trait ElevenLabs {
 		}
 
 		if ( ! isset( $options['headers']['xi-api-key'] ) ) {
-			$options['headers']['xi-api-key'] = $api_key;
+			$options['headers']['xi-api-key'] = $this->get_credential( 'api_key', [ static::ID => [ 'api_key' => $api_key ] ] ) ?? '';
 		}
 
 		if ( ! isset( $options['headers']['Content-Type'] ) ) {

--- a/includes/Classifai/Providers/ElevenLabs/TextToSpeech.php
+++ b/includes/Classifai/Providers/ElevenLabs/TextToSpeech.php
@@ -156,8 +156,7 @@ class TextToSpeech extends Provider {
 		}
 
 		$feature              = new FeatureTextToSpeech();
-		$settings             = $feature->get_settings();
-		$settings             = $settings[ static::ID ];
+		$settings             = $feature->get_settings( static::ID );
 		$post_content         = $feature->normalize_post_content( $post_id );
 		$content_hash         = get_post_meta( $post_id, FeatureTextToSpeech::AUDIO_HASH_KEY, true );
 		$saved_attachment_id  = (int) get_post_meta( $post_id, $feature::AUDIO_ID_KEY, true );

--- a/includes/Classifai/Providers/GoogleAI/APIRequest.php
+++ b/includes/Classifai/Providers/GoogleAI/APIRequest.php
@@ -2,7 +2,6 @@
 
 namespace Classifai\Providers\GoogleAI;
 
-use Classifai\Features\Feature;
 use Classifai\Providers\Provider;
 use WP_Error;
 
@@ -24,14 +23,21 @@ use function Classifai\safe_wp_remote_post;
 class APIRequest {
 
 	/**
-	 * The Provider instance.
+	 * The Google AI API key.
 	 *
-	 * @var Provider
+	 * @var string
 	 */
-	public Provider $provider;
+	public $api_key;
 
 	/**
-	 * The Feature ID.
+	 * The Provider instance.
+	 *
+	 * @var Provider|null
+	 */
+	public ?Provider $provider = null;
+
+	/**
+	 * The Feature name.
 	 *
 	 * @var string
 	 */
@@ -47,13 +53,15 @@ class APIRequest {
 	/**
 	 * Google AI APIRequest constructor.
 	 *
-	 * @param Provider     $provider Provider instance.
-	 * @param Feature|null $feature Feature instance.
-	 * @param array        $settings Feature settings. Optional, useful when settings aren't saved yet.
+	 * @param string        $api_key Google AI API key.
+	 * @param string        $feature Feature name.
+	 * @param Provider|null $provider Provider instance.
+	 * @param array         $settings Feature settings. Optional, useful when settings aren't saved yet.
 	 */
-	public function __construct( Provider $provider, ?Feature $feature, array $settings = [] ) {
+	public function __construct( string $api_key = '', string $feature = '', ?Provider $provider = null, array $settings = [] ) {
+		$this->api_key  = $api_key;
+		$this->feature  = $feature;
 		$this->provider = $provider;
-		$this->feature  = $feature ? $feature::ID : '';
 		$this->settings = $settings;
 	}
 
@@ -247,6 +255,10 @@ class APIRequest {
 	 * @return string
 	 */
 	public function get_api_key() {
-		return $this->provider->get_credential( 'api_key', $this->settings ) ?? '';
+		if ( $this->provider ) {
+			return $this->provider->get_credential( 'api_key', $this->settings ) ?? '';
+		}
+
+		return $this->api_key ?? '';
 	}
 }

--- a/includes/Classifai/Providers/GoogleAI/APIRequest.php
+++ b/includes/Classifai/Providers/GoogleAI/APIRequest.php
@@ -2,7 +2,10 @@
 
 namespace Classifai\Providers\GoogleAI;
 
+use Classifai\Features\Feature;
+use Classifai\Providers\Provider;
 use WP_Error;
+
 use function Classifai\safe_wp_remote_get;
 use function Classifai\safe_wp_remote_post;
 
@@ -21,28 +24,37 @@ use function Classifai\safe_wp_remote_post;
 class APIRequest {
 
 	/**
-	 * The Google AI API key.
+	 * The Provider instance.
 	 *
-	 * @var string
+	 * @var Provider
 	 */
-	public $api_key;
+	public Provider $provider;
 
 	/**
-	 * The feature name.
+	 * The Feature instance.
 	 *
-	 * @var string
+	 * @var Feature
 	 */
 	public $feature;
 
 	/**
+	 * The Feature settings.
+	 *
+	 * @var array
+	 */
+	public $settings;
+
+	/**
 	 * Google AI APIRequest constructor.
 	 *
-	 * @param string $api_key Google AI API key.
-	 * @param string $feature Feature name.
+	 * @param Provider     $provider Provider instance.
+	 * @param Feature|null $feature Feature instance.
+	 * @param array        $settings Feature settings. Optional, useful when settings aren't saved yet.
 	 */
-	public function __construct( string $api_key = '', string $feature = '' ) {
-		$this->api_key = $api_key;
-		$this->feature = $feature;
+	public function __construct( Provider $provider, ?Feature $feature, array $settings = [] ) {
+		$this->provider = $provider;
+		$this->feature  = $feature ? $feature::ID : '';
+		$this->settings = $settings;
 	}
 
 	/**
@@ -235,6 +247,6 @@ class APIRequest {
 	 * @return string
 	 */
 	public function get_api_key() {
-		return $this->api_key;
+		return $this->provider->get_credential( 'api_key', $this->settings ) ?? '';
 	}
 }

--- a/includes/Classifai/Providers/GoogleAI/APIRequest.php
+++ b/includes/Classifai/Providers/GoogleAI/APIRequest.php
@@ -31,9 +31,9 @@ class APIRequest {
 	public Provider $provider;
 
 	/**
-	 * The Feature instance.
+	 * The Feature ID.
 	 *
-	 * @var Feature
+	 * @var string
 	 */
 	public $feature;
 

--- a/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
+++ b/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
@@ -212,7 +212,7 @@ class GeminiAPI extends Provider {
 
 		$excerpt_length = absint( $settings['length'] ?? 55 );
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
@@ -333,7 +333,7 @@ class GeminiAPI extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Title generation is disabled or Google AI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
@@ -449,7 +449,7 @@ class GeminiAPI extends Provider {
 			]
 		);
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		if ( 'shrink' === $args['resize_type'] ) {
 			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );

--- a/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
+++ b/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
@@ -137,12 +137,13 @@ class GeminiAPI extends Provider {
 	public function sanitize_settings( array $new_settings ): array {
 		$settings         = $this->feature_instance->get_settings();
 		$api_key_settings = $this->sanitize_api_key_settings( $new_settings, $settings );
+		$models           = $this->get_models( $new_settings );
 		$model            = ! empty( $new_settings[ static::ID ]['model'] ) ? sanitize_text_field( $new_settings[ static::ID ]['model'] ) : $this->default_model;
 
 		$new_settings[ static::ID ]['api_key']       = $api_key_settings[ static::ID ]['api_key'];
 		$new_settings[ static::ID ]['authenticated'] = $api_key_settings[ static::ID ]['authenticated'];
 		$new_settings[ static::ID ]['model']         = $model;
-		$new_settings[ static::ID ]['models']        = $api_key_settings[ static::ID ]['models'];
+		$new_settings[ static::ID ]['models']        = is_wp_error( $models ) ? [] : $models;
 
 		return $new_settings;
 	}
@@ -211,7 +212,7 @@ class GeminiAPI extends Provider {
 
 		$excerpt_length = absint( $settings['length'] ?? 55 );
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
@@ -332,7 +333,7 @@ class GeminiAPI extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Title generation is disabled or Google AI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
@@ -448,7 +449,7 @@ class GeminiAPI extends Provider {
 			]
 		);
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		if ( 'shrink' === $args['resize_type'] ) {
 			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );

--- a/includes/Classifai/Providers/GoogleAI/GoogleAI.php
+++ b/includes/Classifai/Providers/GoogleAI/GoogleAI.php
@@ -42,7 +42,6 @@ trait GoogleAI {
 			);
 		} else {
 			$new_settings[ static::ID ]['authenticated'] = true;
-			$new_settings[ static::ID ]['models']        = $models;
 		}
 
 		$new_settings[ static::ID ]['api_key'] = sanitize_text_field( $new_settings[ static::ID ]['api_key'] ?? $settings[ static::ID ]['api_key'] );

--- a/includes/Classifai/Providers/GoogleAI/GoogleAI.php
+++ b/includes/Classifai/Providers/GoogleAI/GoogleAI.php
@@ -57,7 +57,7 @@ trait GoogleAI {
 	 */
 	public function authenticate_credentials( array $settings = [] ) {
 		// Make request to ensure credentials work.
-		$request  = new APIRequest( $this, $this->feature_instance, $settings );
+		$request  = new APIRequest( '', $this->feature_instance::ID, $this, $settings );
 		$response = $request->get( $this->model_url, [ 'use_vip' => true ] );
 
 		return ! is_wp_error( $response ) ? true : $response;
@@ -71,7 +71,7 @@ trait GoogleAI {
 	 */
 	protected function get_models( array $settings = [] ) {
 		// Make request to ensure credentials work.
-		$request  = new APIRequest( $this, $this->feature_instance, $settings );
+		$request  = new APIRequest( '', $this->feature_instance::ID, $this, $settings );
 		$response = $request->get( $this->model_url, [ 'use_vip' => true ] );
 
 		if ( is_wp_error( $response ) ) {

--- a/includes/Classifai/Providers/GoogleAI/GoogleAI.php
+++ b/includes/Classifai/Providers/GoogleAI/GoogleAI.php
@@ -25,13 +25,13 @@ trait GoogleAI {
 	 * @return array
 	 */
 	public function sanitize_api_key_settings( array $new_settings = [], array $settings = [] ): array {
-		$models = $this->get_models( $new_settings[ static::ID ]['api_key'] ?? '' );
+		$authenticated = $this->authenticate_credentials( $new_settings );
 
 		$new_settings[ static::ID ]['authenticated'] = $settings[ static::ID ]['authenticated'];
 
-		if ( is_wp_error( $models ) ) {
+		if ( is_wp_error( $authenticated ) ) {
 			$new_settings[ static::ID ]['authenticated'] = false;
-			$error_message                               = $models->get_error_message();
+			$error_message                               = $authenticated->get_error_message();
 
 			// Add an error message.
 			add_settings_error(
@@ -51,20 +51,28 @@ trait GoogleAI {
 	}
 
 	/**
-	 * Get the available models.
-	 * This function also authenticates the credentials.
+	 * Authenticate our credentials.
 	 *
-	 * @param string $api_key Api Key.
+	 * @param array $settings Settings being saved.
+	 * @return bool|WP_Error
+	 */
+	public function authenticate_credentials( array $settings = [] ) {
+		// Make request to ensure credentials work.
+		$request  = new APIRequest( $this, $this->feature_instance, $settings );
+		$response = $request->get( $this->model_url, [ 'use_vip' => true ] );
+
+		return ! is_wp_error( $response ) ? true : $response;
+	}
+
+	/**
+	 * Get the available models.
+	 *
+	 * @param array $settings Settings being saved.
 	 * @return array|WP_Error
 	 */
-	protected function get_models( string $api_key = '' ) {
-		// Check that we have credentials before hitting the API.
-		if ( empty( $api_key ) ) {
-			return new WP_Error( 'auth', esc_html__( 'Please enter your Google AI (Gemini) key.', 'classifai' ) );
-		}
-
+	protected function get_models( array $settings = [] ) {
 		// Make request to ensure credentials work.
-		$request  = new APIRequest( $api_key );
+		$request  = new APIRequest( $this, $this->feature_instance, $settings );
 		$response = $request->get( $this->model_url, [ 'use_vip' => true ] );
 
 		if ( is_wp_error( $response ) ) {

--- a/includes/Classifai/Providers/GoogleAI/Images.php
+++ b/includes/Classifai/Providers/GoogleAI/Images.php
@@ -284,7 +284,7 @@ class Images extends Provider {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( 'Your image prompt is too long. Please ensure it doesn\'t exceed %d characters.', 'classifai' ), $max_prompt_chars ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		/**
 		 * Filter the request body before sending to Google AI.

--- a/includes/Classifai/Providers/GoogleAI/Images.php
+++ b/includes/Classifai/Providers/GoogleAI/Images.php
@@ -284,7 +284,7 @@ class Images extends Provider {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( 'Your image prompt is too long. Please ensure it doesn\'t exceed %d characters.', 'classifai' ), $max_prompt_chars ) );
 		}
 
-		$request = new APIRequest( $settings['api_key'] ?? '', 'generate-image' );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		/**
 		 * Filter the request body before sending to Google AI.

--- a/includes/Classifai/Providers/Localhost/Ollama.php
+++ b/includes/Classifai/Providers/Localhost/Ollama.php
@@ -144,7 +144,7 @@ class Ollama extends Provider {
 		}
 
 		// Make our request.
-		$request  = new APIRequest( 'test' );
+		$request  = new APIRequest( $this, $this->feature_instance, [ static::ID => $default ] );
 		$response = $request->get(
 			$this->get_api_model_url( $default['endpoint_url'] ),
 			[
@@ -267,7 +267,7 @@ class Ollama extends Provider {
 		);
 
 		// Make our API request.
-		$request  = new APIRequest( 'test' );
+		$request  = new APIRequest( $this, $this->feature_instance );
 		$response = $request->post(
 			$this->get_api_chat_url( $settings[ static::ID ]['endpoint_url'] ?? '' ),
 			[
@@ -377,7 +377,7 @@ class Ollama extends Provider {
 		);
 
 		// Make our API requests.
-		$request = new APIRequest( 'test', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		$responses = [];
 		for ( $i = 0; $i < $args['num']; $i++ ) {
@@ -493,7 +493,7 @@ class Ollama extends Provider {
 		);
 
 		// Make our API requests.
-		$request = new APIRequest( 'test', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		$responses = [];
 		for ( $i = 0; $i < $args['num']; $i++ ) {
@@ -635,7 +635,7 @@ class Ollama extends Provider {
 		);
 
 		// Make our API request.
-		$request  = new APIRequest( 'test' );
+		$request  = new APIRequest( $this, $this->feature_instance );
 		$response = $request->post(
 			$this->get_api_chat_url( $settings[ static::ID ]['endpoint_url'] ?? '' ),
 			[
@@ -778,7 +778,7 @@ class Ollama extends Provider {
 		);
 
 		// Make our API request.
-		$request  = new APIRequest( 'test' );
+		$request  = new APIRequest( $this, $this->feature_instance );
 		$response = $request->post(
 			$this->get_api_chat_url( $settings[ static::ID ]['endpoint_url'] ?? '' ),
 			[

--- a/includes/Classifai/Providers/Localhost/Ollama.php
+++ b/includes/Classifai/Providers/Localhost/Ollama.php
@@ -144,7 +144,7 @@ class Ollama extends Provider {
 		}
 
 		// Make our request.
-		$request  = new APIRequest( $this, $this->feature_instance, [ static::ID => $default ] );
+		$request  = new APIRequest( '', $this->feature_instance::ID, $this, [ static::ID => $default ] );
 		$response = $request->get(
 			$this->get_api_model_url( $default['endpoint_url'] ),
 			[
@@ -267,7 +267,7 @@ class Ollama extends Provider {
 		);
 
 		// Make our API request.
-		$request  = new APIRequest( $this, $this->feature_instance );
+		$request  = new APIRequest( '', $this->feature_instance::ID, $this );
 		$response = $request->post(
 			$this->get_api_chat_url( $settings[ static::ID ]['endpoint_url'] ?? '' ),
 			[
@@ -377,7 +377,7 @@ class Ollama extends Provider {
 		);
 
 		// Make our API requests.
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		$responses = [];
 		for ( $i = 0; $i < $args['num']; $i++ ) {
@@ -493,7 +493,7 @@ class Ollama extends Provider {
 		);
 
 		// Make our API requests.
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		$responses = [];
 		for ( $i = 0; $i < $args['num']; $i++ ) {
@@ -635,7 +635,7 @@ class Ollama extends Provider {
 		);
 
 		// Make our API request.
-		$request  = new APIRequest( $this, $this->feature_instance );
+		$request  = new APIRequest( '', $this->feature_instance::ID, $this );
 		$response = $request->post(
 			$this->get_api_chat_url( $settings[ static::ID ]['endpoint_url'] ?? '' ),
 			[
@@ -778,7 +778,7 @@ class Ollama extends Provider {
 		);
 
 		// Make our API request.
-		$request  = new APIRequest( $this, $this->feature_instance );
+		$request  = new APIRequest( '', $this->feature_instance::ID, $this );
 		$response = $request->post(
 			$this->get_api_chat_url( $settings[ static::ID ]['endpoint_url'] ?? '' ),
 			[

--- a/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
+++ b/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
@@ -1045,6 +1045,10 @@ class OllamaEmbeddings extends Ollama {
 			$feature = new Classification();
 		}
 
+		// Ensure we have a valid Feature instance.
+		$backup_feature_instance = $this->feature_instance;
+		$this->feature_instance  = $feature;
+
 		$settings = $feature->get_settings();
 
 		// Ensure the feature is enabled.
@@ -1052,7 +1056,7 @@ class OllamaEmbeddings extends Ollama {
 			return new WP_Error( 'not_enabled', esc_html__( 'Classification is disabled or Ollama connection failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( 'test', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		/**
 		 * Filter the request body before sending to Ollama.
@@ -1082,6 +1086,9 @@ class OllamaEmbeddings extends Ollama {
 				'body' => wp_json_encode( $body ),
 			]
 		);
+
+		// Restore the existing Feature instance.
+		$this->feature_instance = $backup_feature_instance;
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -1119,6 +1126,10 @@ class OllamaEmbeddings extends Ollama {
 			$feature = new Classification();
 		}
 
+		// Ensure we have a valid Feature instance.
+		$backup_feature_instance = $this->feature_instance;
+		$this->feature_instance  = $feature;
+
 		$settings = $feature->get_settings();
 
 		// Ensure the feature is enabled.
@@ -1126,7 +1137,7 @@ class OllamaEmbeddings extends Ollama {
 			return new WP_Error( 'not_enabled', esc_html__( 'Classification is disabled or Ollama connection failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( 'test', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		/**
 		 * Filter the request body before sending to Ollama.
@@ -1156,6 +1167,9 @@ class OllamaEmbeddings extends Ollama {
 				'body' => wp_json_encode( $body ),
 			]
 		);
+
+		// Restore the existing Feature instance.
+		$this->feature_instance = $backup_feature_instance;
 
 		if ( is_wp_error( $response ) ) {
 			return $response;

--- a/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
+++ b/includes/Classifai/Providers/Localhost/OllamaEmbeddings.php
@@ -1056,7 +1056,7 @@ class OllamaEmbeddings extends Ollama {
 			return new WP_Error( 'not_enabled', esc_html__( 'Classification is disabled or Ollama connection failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		/**
 		 * Filter the request body before sending to Ollama.
@@ -1137,7 +1137,7 @@ class OllamaEmbeddings extends Ollama {
 			return new WP_Error( 'not_enabled', esc_html__( 'Classification is disabled or Ollama connection failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		/**
 		 * Filter the request body before sending to Ollama.

--- a/includes/Classifai/Providers/Localhost/OllamaMultimodal.php
+++ b/includes/Classifai/Providers/Localhost/OllamaMultimodal.php
@@ -96,7 +96,7 @@ class OllamaMultimodal extends Ollama {
 	 */
 	public function request( string $url, array $body ) {
 		// Make our API request.
-		$request  = new APIRequest( 'test' );
+		$request  = new APIRequest( $this, $this->feature_instance );
 		$response = $request->post(
 			$url,
 			[

--- a/includes/Classifai/Providers/Localhost/OllamaMultimodal.php
+++ b/includes/Classifai/Providers/Localhost/OllamaMultimodal.php
@@ -96,7 +96,7 @@ class OllamaMultimodal extends Ollama {
 	 */
 	public function request( string $url, array $body ) {
 		// Make our API request.
-		$request  = new APIRequest( $this, $this->feature_instance );
+		$request  = new APIRequest( '', $this->feature_instance::ID, $this );
 		$response = $request->post(
 			$url,
 			[

--- a/includes/Classifai/Providers/Localhost/StableDiffusion.php
+++ b/includes/Classifai/Providers/Localhost/StableDiffusion.php
@@ -224,7 +224,7 @@ class StableDiffusion extends Provider {
 		}
 
 		// Make our request.
-		$request  = new APIRequest( 'test' );
+		$request  = new APIRequest( $this, $this->feature_instance, [ static::ID => $default ] );
 		$response = $request->get(
 			$this->get_api_model_url( $default['endpoint_url'] ),
 			[
@@ -304,7 +304,7 @@ class StableDiffusion extends Provider {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( 'Your image prompt is too long. Please ensure it doesn\'t exceed %d characters.', 'classifai' ), $this->max_prompt_chars ) );
 		}
 
-		$request = new APIRequest( 'test', 'generate-image' );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		$dimensions = $this->get_dimensions_from_size( $args['size'] );
 		$body       = [

--- a/includes/Classifai/Providers/Localhost/StableDiffusion.php
+++ b/includes/Classifai/Providers/Localhost/StableDiffusion.php
@@ -224,7 +224,7 @@ class StableDiffusion extends Provider {
 		}
 
 		// Make our request.
-		$request  = new APIRequest( $this, $this->feature_instance, [ static::ID => $default ] );
+		$request  = new APIRequest( '', $this->feature_instance::ID, $this, [ static::ID => $default ] );
 		$response = $request->get(
 			$this->get_api_model_url( $default['endpoint_url'] ),
 			[
@@ -304,7 +304,7 @@ class StableDiffusion extends Provider {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( 'Your image prompt is too long. Please ensure it doesn\'t exceed %d characters.', 'classifai' ), $this->max_prompt_chars ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		$dimensions = $this->get_dimensions_from_size( $args['size'] );
 		$body       = [

--- a/includes/Classifai/Providers/OpenAI/APIRequest.php
+++ b/includes/Classifai/Providers/OpenAI/APIRequest.php
@@ -2,7 +2,10 @@
 
 namespace Classifai\Providers\OpenAI;
 
+use Classifai\Providers\Provider;
+use Classifai\Features\Feature;
 use WP_Error;
+
 use function Classifai\safe_wp_remote_post;
 use function Classifai\safe_wp_remote_get;
 
@@ -21,28 +24,37 @@ use function Classifai\safe_wp_remote_get;
 class APIRequest {
 
 	/**
-	 * The OpenAI API key.
+	 * The Provider instance.
 	 *
-	 * @var string
+	 * @var Provider
 	 */
-	public $api_key;
+	public Provider $provider;
 
 	/**
-	 * The feature name.
+	 * The Feature ID.
 	 *
 	 * @var string
 	 */
 	public $feature;
 
 	/**
+	 * The Feature settings.
+	 *
+	 * @var array
+	 */
+	public $settings;
+
+	/**
 	 * OpenAI APIRequest constructor.
 	 *
-	 * @param string $api_key OpenAI API key.
-	 * @param string $feature Feature name.
+	 * @param Provider     $provider Provider instance.
+	 * @param Feature|null $feature Feature instance.
+	 * @param array        $settings Feature settings. Optional, useful when settings aren't saved yet.
 	 */
-	public function __construct( string $api_key = '', string $feature = '' ) {
-		$this->api_key = $api_key;
-		$this->feature = $feature;
+	public function __construct( Provider $provider, ?Feature $feature, array $settings = [] ) {
+		$this->provider = $provider;
+		$this->feature  = $feature ? $feature::ID : '';
+		$this->settings = $settings;
 	}
 
 	/**
@@ -342,6 +354,6 @@ class APIRequest {
 	 * @return string
 	 */
 	public function get_api_key() {
-		return $this->api_key;
+		return $this->provider->get_credential( 'api_key', $this->settings ) ?? '';
 	}
 }

--- a/includes/Classifai/Providers/OpenAI/APIRequest.php
+++ b/includes/Classifai/Providers/OpenAI/APIRequest.php
@@ -32,9 +32,9 @@ class APIRequest {
 	/**
 	 * The Provider instance.
 	 *
-	 * @var Provider
+	 * @var Provider|null
 	 */
-	public Provider $provider;
+	public ?Provider $provider = null;
 
 	/**
 	 * The Feature name.

--- a/includes/Classifai/Providers/OpenAI/APIRequest.php
+++ b/includes/Classifai/Providers/OpenAI/APIRequest.php
@@ -3,7 +3,6 @@
 namespace Classifai\Providers\OpenAI;
 
 use Classifai\Providers\Provider;
-use Classifai\Features\Feature;
 use WP_Error;
 
 use function Classifai\safe_wp_remote_post;
@@ -24,6 +23,13 @@ use function Classifai\safe_wp_remote_get;
 class APIRequest {
 
 	/**
+	 * The OpenAI API key.
+	 *
+	 * @var string
+	 */
+	public $api_key;
+
+	/**
 	 * The Provider instance.
 	 *
 	 * @var Provider
@@ -31,7 +37,7 @@ class APIRequest {
 	public Provider $provider;
 
 	/**
-	 * The Feature ID.
+	 * The Feature name.
 	 *
 	 * @var string
 	 */
@@ -47,13 +53,15 @@ class APIRequest {
 	/**
 	 * OpenAI APIRequest constructor.
 	 *
-	 * @param Provider     $provider Provider instance.
-	 * @param Feature|null $feature Feature instance.
-	 * @param array        $settings Feature settings. Optional, useful when settings aren't saved yet.
+	 * @param string        $api_key OpenAI API key.
+	 * @param string        $feature Feature name.
+	 * @param Provider|null $provider Provider instance.
+	 * @param array         $settings Feature settings. Optional, useful when settings aren't saved yet.
 	 */
-	public function __construct( Provider $provider, ?Feature $feature, array $settings = [] ) {
+	public function __construct( string $api_key = '', string $feature = '', ?Provider $provider = null, array $settings = [] ) {
+		$this->api_key  = $api_key;
+		$this->feature  = $feature;
 		$this->provider = $provider;
-		$this->feature  = $feature ? $feature::ID : '';
 		$this->settings = $settings;
 	}
 
@@ -354,6 +362,10 @@ class APIRequest {
 	 * @return string
 	 */
 	public function get_api_key() {
-		return $this->provider->get_credential( 'api_key', $this->settings ) ?? '';
+		if ( $this->provider ) {
+			return $this->provider->get_credential( 'api_key', $this->settings ) ?? '';
+		}
+
+		return $this->api_key ?? '';
 	}
 }

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -279,7 +279,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Descriptive text generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		/**
 		 * Filter the prompt we will send to ChatGPT.
@@ -380,7 +380,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Image Text Extraction is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		/**
 		 * Filter the prompt we will send to ChatGPT.
@@ -491,7 +491,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Image tag generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		/**
 		 * Filter the prompt we will send to ChatGPT.
@@ -607,7 +607,7 @@ class ChatGPT extends Provider {
 
 		$excerpt_length = absint( $settings['length'] ?? 55 );
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
@@ -716,7 +716,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Title generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
@@ -821,7 +821,7 @@ class ChatGPT extends Provider {
 			]
 		);
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		if ( 'shrink' === $args['resize_type'] ) {
 			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );
@@ -962,7 +962,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Generate results" button.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->prompt );
 
@@ -1103,7 +1103,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Content generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		/**
 		 * Filter the prompt we will send to ChatGPT.

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -279,7 +279,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Descriptive text generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		/**
 		 * Filter the prompt we will send to ChatGPT.
@@ -380,7 +380,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Image Text Extraction is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		/**
 		 * Filter the prompt we will send to ChatGPT.
@@ -491,7 +491,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Image tag generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		/**
 		 * Filter the prompt we will send to ChatGPT.
@@ -607,7 +607,7 @@ class ChatGPT extends Provider {
 
 		$excerpt_length = absint( $settings['length'] ?? 55 );
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
@@ -716,7 +716,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Title generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
@@ -821,7 +821,7 @@ class ChatGPT extends Provider {
 			]
 		);
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		if ( 'shrink' === $args['resize_type'] ) {
 			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );
@@ -962,7 +962,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Generate results" button.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->prompt );
 
@@ -1103,7 +1103,7 @@ class ChatGPT extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Content generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		/**
 		 * Filter the prompt we will send to ChatGPT.

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -1469,7 +1469,7 @@ class Embeddings extends Provider {
 		$backup_feature_instance = $this->feature_instance;
 		$this->feature_instance  = $feature;
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		/**
 		 * Filter the request body before sending to OpenAI.
@@ -1550,7 +1550,7 @@ class Embeddings extends Provider {
 		$backup_feature_instance = $this->feature_instance;
 		$this->feature_instance  = $feature;
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		/**
 		 * Filter the request body before sending to OpenAI.

--- a/includes/Classifai/Providers/OpenAI/Embeddings.php
+++ b/includes/Classifai/Providers/OpenAI/Embeddings.php
@@ -1459,14 +1459,17 @@ class Embeddings extends Provider {
 		if ( ! $feature ) {
 			$feature = new Classification();
 		}
-		$settings = $feature->get_settings();
 
 		// Ensure the feature is enabled.
 		if ( ! $feature->is_feature_enabled() ) {
 			return new WP_Error( 'not_enabled', esc_html__( 'Embedding generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		// Ensure we have a valid Feature instance.
+		$backup_feature_instance = $this->feature_instance;
+		$this->feature_instance  = $feature;
+
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		/**
 		 * Filter the request body before sending to OpenAI.
@@ -1498,6 +1501,9 @@ class Embeddings extends Provider {
 		);
 
 		set_transient( 'classifai_openai_embeddings_latest_response', $response, DAY_IN_SECONDS * 30 );
+
+		// Restore the existing Feature instance.
+		$this->feature_instance = $backup_feature_instance;
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -1535,14 +1541,16 @@ class Embeddings extends Provider {
 			$feature = new Classification();
 		}
 
-		$settings = $feature->get_settings();
-
 		// Ensure the feature is enabled.
 		if ( ! $feature->is_feature_enabled() ) {
 			return new WP_Error( 'not_enabled', esc_html__( 'Embedding generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		// Ensure we have a valid Feature instance.
+		$backup_feature_instance = $this->feature_instance;
+		$this->feature_instance  = $feature;
+
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		/**
 		 * Filter the request body before sending to OpenAI.
@@ -1572,6 +1580,9 @@ class Embeddings extends Provider {
 				'body' => wp_json_encode( $body ),
 			]
 		);
+
+		// Restore the existing Feature instance.
+		$this->feature_instance = $backup_feature_instance;
 
 		if ( is_wp_error( $response ) ) {
 			return $response;

--- a/includes/Classifai/Providers/OpenAI/Images.php
+++ b/includes/Classifai/Providers/OpenAI/Images.php
@@ -351,7 +351,7 @@ class Images extends Provider {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( 'Your image prompt is too long. Please ensure it doesn\'t exceed %d characters.', 'classifai' ), $max_prompt_chars ) );
 		}
 
-		$request = new APIRequest( $settings['api_key'] ?? '', 'generate-image' );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		$model = $this->get_model();
 		$body  = [

--- a/includes/Classifai/Providers/OpenAI/Images.php
+++ b/includes/Classifai/Providers/OpenAI/Images.php
@@ -351,7 +351,7 @@ class Images extends Provider {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( 'Your image prompt is too long. Please ensure it doesn\'t exceed %d characters.', 'classifai' ), $max_prompt_chars ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		$model = $this->get_model();
 		$body  = [

--- a/includes/Classifai/Providers/OpenAI/Moderation.php
+++ b/includes/Classifai/Providers/OpenAI/Moderation.php
@@ -201,7 +201,7 @@ class Moderation extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Moderation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 		$comment = get_comment( $comment_id );
 
 		/**

--- a/includes/Classifai/Providers/OpenAI/Moderation.php
+++ b/includes/Classifai/Providers/OpenAI/Moderation.php
@@ -191,8 +191,7 @@ class Moderation extends Provider {
 			return new WP_Error( 'permission_denied', esc_html__( 'You do not have permission to moderate comments.', 'classifai' ) );
 		}
 
-		$feature  = new ModerationFeature();
-		$settings = $feature->get_settings();
+		$feature = new ModerationFeature();
 
 		// Ensure the feature is enabled and the user has access.
 		if (
@@ -202,7 +201,7 @@ class Moderation extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Moderation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 		$comment = get_comment( $comment_id );
 
 		/**

--- a/includes/Classifai/Providers/OpenAI/OpenAI.php
+++ b/includes/Classifai/Providers/OpenAI/OpenAI.php
@@ -66,7 +66,7 @@ trait OpenAI {
 	 */
 	protected function authenticate_credentials( array $settings = [] ) {
 		// Make request to ensure credentials work.
-		$request  = new APIRequest( $this, $this->feature_instance, $settings );
+		$request  = new APIRequest( '', $this->feature_instance::ID, $this, $settings );
 		$response = $request->get( $this->model_url, [ 'use_vip' => true ] );
 
 		return ! is_wp_error( $response ) ? true : $response;

--- a/includes/Classifai/Providers/OpenAI/OpenAI.php
+++ b/includes/Classifai/Providers/OpenAI/OpenAI.php
@@ -27,7 +27,7 @@ trait OpenAI {
 	 * @return array
 	 */
 	public function sanitize_api_key_settings( array $new_settings = [], array $settings = [] ): array {
-		$authenticated = $this->authenticate_credentials( $new_settings[ static::ID ]['api_key'] ?? '' );
+		$authenticated = $this->authenticate_credentials( $new_settings );
 
 		$new_settings[ static::ID ]['authenticated'] = $settings[ static::ID ]['authenticated'];
 
@@ -61,17 +61,12 @@ trait OpenAI {
 	/**
 	 * Authenticate our credentials.
 	 *
-	 * @param string $api_key Api Key.
+	 * @param array $settings Settings being saved.
 	 * @return bool|WP_Error
 	 */
-	protected function authenticate_credentials( string $api_key = '' ) {
-		// Check that we have credentials before hitting the API.
-		if ( empty( $api_key ) ) {
-			return new WP_Error( 'auth', esc_html__( 'Please enter your OpenAI API key.', 'classifai' ) );
-		}
-
+	protected function authenticate_credentials( array $settings = [] ) {
 		// Make request to ensure credentials work.
-		$request  = new APIRequest( $api_key );
+		$request  = new APIRequest( $this, $this->feature_instance, $settings );
 		$response = $request->get( $this->model_url, [ 'use_vip' => true ] );
 
 		return ! is_wp_error( $response ) ? true : $response;

--- a/includes/Classifai/Providers/OpenAI/SpeechToText.php
+++ b/includes/Classifai/Providers/OpenAI/SpeechToText.php
@@ -215,14 +215,13 @@ class SpeechToText extends Provider {
 	 * @return WP_Error|bool
 	 */
 	public function transcribe_audio( string $file_path = '', array $args = [] ) {
-		$feature  = new AudioTranscriptsGeneration();
-		$settings = $feature->get_settings( static::ID );
+		$feature = new AudioTranscriptsGeneration();
 
 		if ( ! $feature->is_feature_enabled() ) {
 			return new WP_Error( 'not_enabled', esc_html__( 'Audio Transcripts Generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		/**
 		 * Filter the request body before sending to OpenAI.

--- a/includes/Classifai/Providers/OpenAI/SpeechToText.php
+++ b/includes/Classifai/Providers/OpenAI/SpeechToText.php
@@ -221,7 +221,7 @@ class SpeechToText extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Audio Transcripts Generation is disabled or OpenAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		/**
 		 * Filter the request body before sending to OpenAI.

--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -364,7 +364,7 @@ class TextToSpeech extends Provider {
 		$post_content        = $feature->normalize_post_content( $post_id );
 		$content_hash        = get_post_meta( $post_id, FeatureTextToSpeech::AUDIO_HASH_KEY, true );
 		$saved_attachment_id = (int) get_post_meta( $post_id, $feature::AUDIO_ID_KEY, true );
-		$request             = new APIRequest( $this, $this->feature_instance );
+		$request             = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		if ( mb_strlen( $post_content ) > 4096 ) {
 			return new WP_Error(

--- a/includes/Classifai/Providers/OpenAI/TextToSpeech.php
+++ b/includes/Classifai/Providers/OpenAI/TextToSpeech.php
@@ -364,7 +364,7 @@ class TextToSpeech extends Provider {
 		$post_content        = $feature->normalize_post_content( $post_id );
 		$content_hash        = get_post_meta( $post_id, FeatureTextToSpeech::AUDIO_HASH_KEY, true );
 		$saved_attachment_id = (int) get_post_meta( $post_id, $feature::AUDIO_ID_KEY, true );
-		$request             = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request             = new APIRequest( $this, $this->feature_instance );
 
 		if ( mb_strlen( $post_content ) > 4096 ) {
 			return new WP_Error(

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -189,7 +189,7 @@ abstract class Provider {
 		) {
 			$feature_provider_settings = $settings[ $provider_id ];
 		} else {
-			$feature_provider_settings = $this->feature_instance->get_settings( $provider_id ) ?? [];
+			$feature_provider_settings = $this->feature_instance ? $this->feature_instance->get_settings( $provider_id ) : [];
 		}
 
 		// Get our credentials.

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -223,9 +223,9 @@ abstract class Provider {
 		 * @since x.x.x
 		 * @hook classifai_provider_credentials_{$provider_id}
 		 *
-		 * @param array $credentials The credentials for the Provider.
-		 * @param string|null $feature_id The ID of the Feature, or null if not set.
-		 * @param array $feature_provider_settings The Provider specific Feature settings.
+		 * @param array       $credentials               The credentials for the Provider.
+		 * @param string|null $feature_id                The ID of the Feature, or null if not set.
+		 * @param array       $feature_provider_settings The Provider specific Feature settings.
 		 * @return array The filtered credentials.
 		 */
 		$credentials = apply_filters(
@@ -241,10 +241,10 @@ abstract class Provider {
 		 * @since x.x.x
 		 * @hook classifai_provider_credentials
 		 *
-		 * @param array $credentials The credentials for the Provider.
-		 * @param string $provider_id The ID of the Provider.
-		 * @param string|null $feature_id The ID of the Feature, or null if not set.
-		 * @param array $feature_provider_settings The Provider specific Feature settings.
+		 * @param array       $credentials               The credentials for the Provider.
+		 * @param string      $provider_id               The ID of the Provider.
+		 * @param string|null $feature_id                The ID of the Feature, or null if not set.
+		 * @param array       $feature_provider_settings The Provider specific Feature settings.
 		 * @return array The filtered credentials.
 		 */
 		return apply_filters(

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -179,16 +179,61 @@ abstract class Provider {
 	 * @return array
 	 */
 	public function get_credentials( array $settings = [] ): array {
+		$provider_id = static::ID;
+
 		// Get our Provider-specific settings.
 		if (
 			! empty( $settings ) &&
-			array_key_exists( static::ID, $settings ) &&
-			! empty( $settings[ static::ID ] )
+			array_key_exists( $provider_id, $settings ) &&
+			! empty( $settings[ $provider_id ] )
 		) {
-			$feature_provider_settings = $settings[ static::ID ];
+			$feature_provider_settings = $settings[ $provider_id ];
 		} else {
-			$feature_provider_settings = $this->feature_instance->get_settings( static::ID ) ?? [];
+			$feature_provider_settings = $this->feature_instance->get_settings( $provider_id ) ?? [];
 		}
+
+		// Get our credentials.
+		$credentials = CredentialResolver::resolve( $provider_id, $feature_provider_settings );
+
+		/**
+		 * Filter the credentials for the Provider.
+		 *
+		 * Possible hook names include:
+		 *  - `classifai_provider_credentials_azure_openai`
+		 *  - `classifai_provider_credentials_openai_chatgpt`
+		 *  - `classifai_provider_credentials_openai_embeddings`
+		 *  - `classifai_provider_credentials_openai_moderation`
+		 *  - `classifai_provider_credentials_openai_dalle`
+		 *  - `classifai_provider_credentials_openai_whisper`
+		 *  - `classifai_provider_credentials_openai_text_to_speech`
+		 *  - `classifai_provider_credentials_googleai_gemini_api`
+		 *  - `classifai_provider_credentials_googleai_images`
+		 *  - `classifai_provider_credentials_ibm_watson_nlu`
+		 *  - `classifai_provider_credentials_aws_polly`
+		 *  - `classifai_provider_credentials_ms_computer_vision`
+		 *  - `classifai_provider_credentials_ms_azure_text_to_speech`
+		 *  - `classifai_provider_credentials_elevenlabs_speech_to_text`
+		 *  - `classifai_provider_credentials_elevenlabs_text_to_speech`
+		 *  - `classifai_provider_credentials_xai_grok`
+		 *  - `classifai_provider_credentials_stable_diffusion`
+		 *  - `classifai_provider_credentials_ollama`
+		 *  - `classifai_provider_credentials_chrome_ai`
+		 *  - `classifai_provider_credentials_togetherai_image`
+		 *
+		 * @since x.x.x
+		 * @hook classifai_provider_credentials_{$provider_id}
+		 *
+		 * @param array $credentials The credentials for the Provider.
+		 * @param string|null $feature_id The ID of the Feature, or null if not set.
+		 * @param array $feature_provider_settings The Provider specific Feature settings.
+		 * @return array The filtered credentials.
+		 */
+		$credentials = apply_filters(
+			"classifai_provider_credentials_{$provider_id}",
+			$credentials,
+			$this->feature_instance ? $this->feature_instance::ID : null,
+			$feature_provider_settings
+		);
 
 		/**
 		 * Filter the credentials for the Provider.
@@ -204,11 +249,8 @@ abstract class Provider {
 		 */
 		return apply_filters(
 			'classifai_provider_credentials',
-			CredentialResolver::resolve(
-				static::ID,
-				$feature_provider_settings
-			),
-			static::ID,
+			$credentials,
+			$provider_id,
 			$this->feature_instance ? $this->feature_instance::ID : null,
 			$feature_provider_settings
 		);

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -5,6 +5,8 @@
 
 namespace Classifai\Providers;
 
+use Classifai\Providers\CredentialResolver;
+
 abstract class Provider {
 
 	/**
@@ -166,5 +168,61 @@ abstract class Provider {
 				'class'         => 'classifai-provider-field hidden provider-scope-' . static::ID, // Important to add this.
 			]
 		);
+	}
+
+	/**
+	 * Get the credentials for the Provider.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $settings Feature settings. Optional, will default to using saved settings.
+	 * @return array
+	 */
+	public function get_credentials( array $settings = [] ): array {
+		// Get our Provider-specific settings.
+		if (
+			! empty( $settings ) &&
+			array_key_exists( static::ID, $settings ) &&
+			! empty( $settings[ static::ID ] )
+		) {
+			$feature_provider_settings = $settings[ static::ID ];
+		} else {
+			$feature_provider_settings = $this->feature_instance->get_settings( static::ID ) ?? [];
+		}
+
+		/**
+		 * Filter the credentials for the Provider.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_provider_credentials
+		 *
+		 * @param array $credentials The credentials for the Provider.
+		 * @param string $provider_id The ID of the Provider.
+		 * @param string|null $feature_id The ID of the Feature, or null if not set.
+		 * @param array $feature_provider_settings The Provider specific Feature settings.
+		 * @return array The filtered credentials.
+		 */
+		return apply_filters(
+			'classifai_provider_credentials',
+			CredentialResolver::resolve(
+				static::ID,
+				$feature_provider_settings
+			),
+			static::ID,
+			$this->feature_instance ? $this->feature_instance::ID : null,
+			$feature_provider_settings
+		);
+	}
+
+	/**
+	 * Get a credential field value for the Provider.
+	 *
+	 * @param string $credential_key The credential field name.
+	 * @param array  $settings       Feature settings. Optional, will default to using saved settings.
+	 * @return mixed The credential value, or null if not set.
+	 */
+	public function get_credential( string $credential_key, array $settings = [] ) {
+		$credentials = $this->get_credentials( $settings );
+		return $credentials[ $credential_key ] ?? null;
 	}
 }

--- a/includes/Classifai/Providers/ProviderProfiles.php
+++ b/includes/Classifai/Providers/ProviderProfiles.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Provider profile registry.
+ *
+ * Maps capability-specific Provider IDs (e.g. openai_chatgpt) to vendor-level
+ * profiles (e.g. openai). Grouped profiles share one credential set across
+ * multiple Providers; ungrouped profiles are 1:1 with a Provider.
+ *
+ * @since x.x.x
+ */
+
+namespace Classifai\Providers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * ProviderProfiles class.
+ */
+class ProviderProfiles {
+
+	/**
+	 * Profile definitions.
+	 *
+	 * Grouped profiles (OpenAI, Ollama, ElevenLabs, Google AI) share credentials.
+	 * Ungrouped (e.g. Azure, AWS) use distinct endpoint/key per capability.
+	 *
+	 * @var array
+	 */
+	private static $profiles = [
+		'openai'                  => [
+			'provider_ids'      => [
+				'openai_chatgpt',
+				'openai_embeddings',
+				'openai_moderation',
+				'openai_dalle',
+				'openai_whisper',
+				'openai_text_to_speech',
+			],
+			'credential_fields' => [ 'api_key', 'authenticated' ],
+			'label'             => 'OpenAI',
+		],
+		'googleai'                => [
+			'provider_ids'      => [ 'googleai_gemini_api', 'googleai_images' ],
+			'credential_fields' => [ 'api_key', 'authenticated' ],
+			'label'             => 'Google AI',
+		],
+		'azure_openai'            => [
+			'provider_ids'      => [ 'azure_openai' ],
+			'credential_fields' => [ 'endpoint_url', 'api_key', 'deployment', 'authenticated' ],
+			'label'             => 'Azure OpenAI',
+		],
+		'azure_openai_embeddings' => [
+			'provider_ids'      => [ 'azure_openai_embeddings' ],
+			'credential_fields' => [ 'endpoint_url', 'api_key', 'deployment', 'authenticated' ],
+			'label'             => 'Azure OpenAI Embeddings',
+		],
+		'ms_computer_vision'      => [
+			'provider_ids'      => [ 'ms_computer_vision' ],
+			'credential_fields' => [ 'endpoint_url', 'api_key', 'authenticated' ],
+			'label'             => 'Azure AI Vision',
+		],
+		'ms_azure_text_to_speech' => [
+			'provider_ids'      => [ 'ms_azure_text_to_speech' ],
+			'credential_fields' => [ 'endpoint_url', 'api_key', 'authenticated' ],
+			'label'             => 'Azure Text to Speech',
+		],
+		'ibm_watson_nlu'          => [
+			'provider_ids'      => [ 'ibm_watson_nlu' ],
+			'credential_fields' => [ 'endpoint_url', 'apikey', 'username', 'password', 'authenticated' ],
+			'label'             => 'IBM Watson NLU',
+		],
+		'xai_grok'                => [
+			'provider_ids'      => [ 'xai_grok' ],
+			'credential_fields' => [ 'api_key', 'authenticated' ],
+			'label'             => 'XAI Grok',
+		],
+		'aws_polly'               => [
+			'provider_ids'      => [ 'aws_polly' ],
+			'credential_fields' => [ 'access_key_id', 'secret_access_key', 'aws_region', 'authenticated' ],
+			'label'             => 'AWS Polly',
+		],
+		'elevenlabs'              => [
+			'provider_ids'      => [ 'elevenlabs_text_to_speech', 'elevenlabs_speech_to_text' ],
+			'credential_fields' => [ 'api_key', 'authenticated' ],
+			'label'             => 'ElevenLabs',
+		],
+		'togetherai_image'        => [
+			'provider_ids'      => [ 'togetherai_image' ],
+			'credential_fields' => [ 'api_key', 'authenticated' ],
+			'label'             => 'Together AI',
+		],
+		'stable_diffusion'        => [
+			'provider_ids'      => [ 'stable_diffusion' ],
+			'credential_fields' => [ 'endpoint_url', 'authenticated' ],
+			'label'             => 'Stable Diffusion',
+		],
+		'ollama'                  => [
+			'provider_ids'      => [ 'ollama', 'ollama_embeddings', 'ollama_multimodal' ],
+			'credential_fields' => [ 'endpoint_url', 'authenticated' ],
+			'label'             => 'Ollama',
+		],
+		'chrome_ai'               => [
+			'provider_ids'      => [ 'chrome_ai' ],
+			'credential_fields' => [],
+			'label'             => 'Chrome AI',
+		],
+	];
+
+	/**
+	 * Get all profile definitions.
+	 *
+	 * @return array Associative array of profile_id =>
+	 * [ 'provider_ids', 'credential_fields' ].
+	 */
+	public static function get_all_profiles(): array {
+		/**
+		 * Filter the Provider profiles registry.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_provider_profiles
+		 *
+		 * @param array $profiles Profile definitions.
+		 *
+		 * @return array Filtered profiles.
+		 */
+		return apply_filters( 'classifai_provider_profiles', self::$profiles );
+	}
+
+	/**
+	 * Get the profile ID for a capability-specific Provider ID.
+	 *
+	 * @param string $provider_id Provider ID (e.g. openai_chatgpt, azure_openai).
+	 * @return string|null Profile ID, or null if not found.
+	 */
+	public static function get_profile_for_provider( string $provider_id ): ?string {
+		$profiles = self::get_all_profiles();
+		foreach ( $profiles as $profile_id => $def ) {
+			if ( in_array( $provider_id, $def['provider_ids'], true ) ) {
+				return $profile_id;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get Provider IDs that belong to a profile.
+	 *
+	 * @param string $profile_id Profile ID.
+	 * @return array List of Provider IDs.
+	 */
+	public static function get_provider_ids_for_profile( string $profile_id ): array {
+		$profiles = self::get_all_profiles();
+		return $profiles[ $profile_id ]['provider_ids'] ?? [];
+	}
+
+	/**
+	 * Get credential field names for a profile (keys to store/merge).
+	 *
+	 * @param string $profile_id Profile ID.
+	 * @return array List of field names.
+	 */
+	public static function get_credential_fields( string $profile_id ): array {
+		$profiles = self::get_all_profiles();
+		return $profiles[ $profile_id ]['credential_fields'] ?? [];
+	}
+}

--- a/includes/Classifai/Providers/TogetherAI/Images.php
+++ b/includes/Classifai/Providers/TogetherAI/Images.php
@@ -207,7 +207,7 @@ class Images extends Provider {
 		 */
 		$prompt = apply_filters( 'classifai_togetherai_image_prompt', $prompt );
 
-		$request = new APIRequest( $settings['api_key'] ?? '', 'generate-image' );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		$dimensions = $this->get_dimensions_from_size( $args['size'] );
 		$body       = [

--- a/includes/Classifai/Providers/TogetherAI/Images.php
+++ b/includes/Classifai/Providers/TogetherAI/Images.php
@@ -207,7 +207,7 @@ class Images extends Provider {
 		 */
 		$prompt = apply_filters( 'classifai_togetherai_image_prompt', $prompt );
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		$dimensions = $this->get_dimensions_from_size( $args['size'] );
 		$body       = [

--- a/includes/Classifai/Providers/TogetherAI/TogetherAI.php
+++ b/includes/Classifai/Providers/TogetherAI/TogetherAI.php
@@ -92,7 +92,7 @@ trait TogetherAI {
 	 * @return array|WP_Error
 	 */
 	protected function authenticate_credentials( array $settings = [] ) {
-		$request  = new APIRequest( $this, $this->feature_instance, $settings );
+		$request  = new APIRequest( '', $this->feature_instance::ID, $this, $settings );
 		$response = $request->get( $this->get_api_url( $this->model_path ), [ 'use_vip' => true ] );
 
 		if ( is_wp_error( $response ) ) {

--- a/includes/Classifai/Providers/TogetherAI/TogetherAI.php
+++ b/includes/Classifai/Providers/TogetherAI/TogetherAI.php
@@ -53,7 +53,7 @@ trait TogetherAI {
 	 * @return array
 	 */
 	public function sanitize_api_key_settings( array $new_settings = [], array $settings = [] ): array {
-		$models = $this->get_models( $new_settings[ static::ID ]['api_key'] ?? '' );
+		$models = $this->authenticate_credentials( $new_settings );
 
 		$new_settings[ static::ID ]['authenticated'] = $settings[ static::ID ]['authenticated'];
 		$new_settings[ static::ID ]['models']        = $settings[ static::ID ]['models'];
@@ -86,18 +86,13 @@ trait TogetherAI {
 	}
 
 	/**
-	 * Get the available models.
+	 * Get the available models and authenticate credentials.
 	 *
-	 * @param string $api_key The API key.
+	 * @param array $settings Settings being saved.
 	 * @return array|WP_Error
 	 */
-	protected function get_models( string $api_key = '' ) {
-		// Check that we have credentials before hitting the API.
-		if ( empty( $api_key ) ) {
-			return new WP_Error( 'auth', esc_html__( 'Please enter your Together AI API key.', 'classifai' ) );
-		}
-
-		$request  = new APIRequest( $api_key );
+	protected function authenticate_credentials( array $settings = [] ) {
+		$request  = new APIRequest( $this, $this->feature_instance, $settings );
 		$response = $request->get( $this->get_api_url( $this->model_path ), [ 'use_vip' => true ] );
 
 		if ( is_wp_error( $response ) ) {

--- a/includes/Classifai/Providers/Watson/Helpers.php
+++ b/includes/Classifai/Providers/Watson/Helpers.php
@@ -21,11 +21,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return string
  */
 function get_api_url(): string {
-	$settings = ( new Classification() )->get_settings();
-	$creds    = ! empty( $settings[ NLU::ID ] ) ? $settings[ NLU::ID ] : [];
+	$feature      = new Classification();
+	$provider     = $feature->get_feature_provider_instance( NLU::ID );
+	$endpoint_url = $provider->get_credential( 'endpoint_url', $feature->get_settings() );
 
-	if ( ! empty( $creds['endpoint_url'] ) ) {
-		return $creds['endpoint_url'];
+	if ( ! empty( $endpoint_url ) ) {
+		return $endpoint_url;
 	} elseif ( defined( 'WATSON_URL' ) ) {
 		return WATSON_URL;
 	} else {
@@ -42,8 +43,9 @@ function get_api_url(): string {
  * @return string
  */
 function get_username(): string {
-	$settings = ( new Classification() )->get_settings( NLU::ID );
-	$username = ! empty( $settings['username'] ) ? $settings['username'] : '';
+	$feature  = new Classification();
+	$provider = $feature->get_feature_provider_instance( NLU::ID );
+	$username = $provider->get_credential( 'username', $feature->get_settings() );
 
 	if ( ! empty( $username ) ) {
 		return $username;
@@ -63,8 +65,9 @@ function get_username(): string {
  * @return string
  */
 function get_password(): string {
-	$settings = ( new Classification() )->get_settings( NLU::ID );
-	$password = ! empty( $settings['password'] ) ? $settings['password'] : '';
+	$feature  = new Classification();
+	$provider = $feature->get_feature_provider_instance( NLU::ID );
+	$password = $provider->get_credential( 'password', $feature->get_settings() );
 
 	if ( ! empty( $password ) ) {
 		return $password;

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -366,7 +366,7 @@ class NLU extends Provider {
 	 * @param array $settings The list of settings to be saved
 	 * @return bool|WP_Error
 	 */
-	protected function nlu_authentication_check( array $settings ) {
+	public function authenticate_credentials( array $settings ) {
 		// Check that we have credentials before hitting the API.
 		if ( empty( $settings[ static::ID ]['username'] )
 			|| empty( $settings[ static::ID ]['password'] )
@@ -375,10 +375,11 @@ class NLU extends Provider {
 			return new WP_Error( 'auth', esc_html__( 'Please enter your credentials.', 'classifai' ) );
 		}
 
+		$credentials       = $this->get_credentials( $settings );
 		$request           = new APIRequest();
-		$request->username = $settings[ static::ID ]['username'];
-		$request->password = $settings[ static::ID ]['password'];
-		$base_url          = trailingslashit( $settings[ static::ID ]['endpoint_url'] ) . 'v1/analyze';
+		$request->username = $credentials['username'] ?? '';
+		$request->password = $credentials['password'] ?? '';
+		$base_url          = trailingslashit( $credentials['endpoint_url'] ?? '' ) . 'v1/analyze';
 		$url               = esc_url( add_query_arg( [ 'version' => WATSON_NLU_VERSION ], $base_url ) );
 		$options           = [
 			'body'    => wp_json_encode(
@@ -415,7 +416,7 @@ class NLU extends Provider {
 	 */
 	public function sanitize_settings( array $new_settings ): array {
 		$settings      = $this->feature_instance->get_settings();
-		$authenticated = $this->nlu_authentication_check( $new_settings );
+		$authenticated = $this->authenticate_credentials( $new_settings );
 
 		if ( is_wp_error( $authenticated ) ) {
 			$new_settings[ static::ID ]['authenticated'] = false;

--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -366,7 +366,7 @@ class NLU extends Provider {
 	 * @param array $settings The list of settings to be saved
 	 * @return bool|WP_Error
 	 */
-	public function authenticate_credentials( array $settings ) {
+	protected function authenticate_credentials( array $settings ) {
 		// Check that we have credentials before hitting the API.
 		if ( empty( $settings[ static::ID ]['username'] )
 			|| empty( $settings[ static::ID ]['password'] )

--- a/includes/Classifai/Providers/XAI/APIRequest.php
+++ b/includes/Classifai/Providers/XAI/APIRequest.php
@@ -32,9 +32,9 @@ class APIRequest {
 	/**
 	 * The Provider instance.
 	 *
-	 * @var Provider
+	 * @var Provider|null
 	 */
-	public Provider $provider;
+	public ?Provider $provider = null;
 
 	/**
 	 * The Feature name.

--- a/includes/Classifai/Providers/XAI/APIRequest.php
+++ b/includes/Classifai/Providers/XAI/APIRequest.php
@@ -2,7 +2,10 @@
 
 namespace Classifai\Providers\XAI;
 
+use Classifai\Features\Feature;
+use Classifai\Providers\Provider;
 use WP_Error;
+
 use function Classifai\safe_wp_remote_get;
 use function Classifai\safe_wp_remote_post;
 
@@ -21,28 +24,37 @@ use function Classifai\safe_wp_remote_post;
 class APIRequest {
 
 	/**
-	 * The xAI API key.
+	 * The Provider instance.
 	 *
-	 * @var string
+	 * @var Provider
 	 */
-	public $api_key;
+	public Provider $provider;
 
 	/**
-	 * The feature name.
+	 * The Feature name.
 	 *
 	 * @var string
 	 */
 	public $feature;
 
 	/**
+	 * The Feature settings.
+	 *
+	 * @var array
+	 */
+	public $settings;
+
+	/**
 	 * xAI APIRequest constructor.
 	 *
-	 * @param string $api_key xAI API key.
-	 * @param string $feature Feature name.
+	 * @param Provider     $provider Provider instance.
+	 * @param Feature|null $feature Feature instance.
+	 * @param array        $settings Feature settings. Optional, useful when settings aren't saved yet.
 	 */
-	public function __construct( string $api_key = '', string $feature = '' ) {
-		$this->api_key = $api_key;
-		$this->feature = $feature;
+	public function __construct( Provider $provider, ?Feature $feature, array $settings = [] ) {
+		$this->provider = $provider;
+		$this->feature  = $feature ? $feature::ID : '';
+		$this->settings = $settings;
 	}
 
 	/**
@@ -236,6 +248,6 @@ class APIRequest {
 	 * @return string
 	 */
 	public function get_api_key() {
-		return $this->api_key;
+		return $this->provider->get_credential( 'api_key', $this->settings ) ?? '';
 	}
 }

--- a/includes/Classifai/Providers/XAI/APIRequest.php
+++ b/includes/Classifai/Providers/XAI/APIRequest.php
@@ -2,7 +2,6 @@
 
 namespace Classifai\Providers\XAI;
 
-use Classifai\Features\Feature;
 use Classifai\Providers\Provider;
 use WP_Error;
 
@@ -22,6 +21,13 @@ use function Classifai\safe_wp_remote_post;
  * $request->post( $xai_url, $options );
  */
 class APIRequest {
+
+	/**
+	 * The xAI API key.
+	 *
+	 * @var string
+	 */
+	public $api_key;
 
 	/**
 	 * The Provider instance.
@@ -47,13 +53,15 @@ class APIRequest {
 	/**
 	 * xAI APIRequest constructor.
 	 *
-	 * @param Provider     $provider Provider instance.
-	 * @param Feature|null $feature Feature instance.
-	 * @param array        $settings Feature settings. Optional, useful when settings aren't saved yet.
+	 * @param string        $api_key xAI API key.
+	 * @param string        $feature Feature name.
+	 * @param Provider|null $provider Provider instance.
+	 * @param array         $settings Feature settings. Optional, useful when settings aren't saved yet.
 	 */
-	public function __construct( Provider $provider, ?Feature $feature, array $settings = [] ) {
+	public function __construct( string $api_key = '', string $feature = '', ?Provider $provider = null, array $settings = [] ) {
+		$this->api_key  = $api_key;
+		$this->feature  = $feature;
 		$this->provider = $provider;
-		$this->feature  = $feature ? $feature::ID : '';
 		$this->settings = $settings;
 	}
 
@@ -248,6 +256,10 @@ class APIRequest {
 	 * @return string
 	 */
 	public function get_api_key() {
-		return $this->provider->get_credential( 'api_key', $this->settings ) ?? '';
+		if ( $this->provider ) {
+			return $this->provider->get_credential( 'api_key', $this->settings ) ?? '';
+		}
+
+		return $this->api_key ?? '';
 	}
 }

--- a/includes/Classifai/Providers/XAI/Grok.php
+++ b/includes/Classifai/Providers/XAI/Grok.php
@@ -198,7 +198,7 @@ class Grok extends Provider {
 	 * @return array
 	 */
 	public function sanitize_api_key_settings( array $new_settings = [], array $settings = [] ): array {
-		$models = $this->get_models( $new_settings[ static::ID ]['api_key'] ?? '' );
+		$models = $this->authenticate_credentials( $new_settings );
 
 		$new_settings[ static::ID ]['authenticated'] = $settings[ static::ID ]['authenticated'];
 		$new_settings[ static::ID ]['models']        = $settings[ static::ID ]['models'] ?? [];
@@ -249,19 +249,19 @@ class Grok extends Provider {
 	}
 
 	/**
-	 * Authenticate our credentials.
+	 * Authenticate our credentials and get the models.
 	 *
-	 * @param string $api_key Api Key.
+	 * @param array $settings Settings being saved.
 	 * @return array|WP_Error
 	 */
-	protected function get_models( string $api_key = '' ) {
+	public function authenticate_credentials( array $settings = [] ) {
 		// Check that we have credentials before hitting the API.
 		if ( empty( $api_key ) ) {
 			return new WP_Error( 'auth', esc_html__( 'Please enter your xAI API key.', 'classifai' ) );
 		}
 
 		// Make request to ensure credentials work.
-		$request  = new APIRequest( $api_key );
+		$request  = new APIRequest( $this, $this->feature_instance, $settings );
 		$response = $request->get( $this->models_url, [ 'use_vip' => true ] );
 
 		if ( is_wp_error( $response ) ) {
@@ -367,7 +367,7 @@ class Grok extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Descriptive text generation is disabled or xAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		/**
 		 * Filter the prompt we will send to xAI Grok.
@@ -473,7 +473,7 @@ class Grok extends Provider {
 
 		$excerpt_length = absint( $settings['length'] ?? 55 );
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
@@ -582,7 +582,7 @@ class Grok extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Title generation is disabled or xAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
@@ -687,7 +687,7 @@ class Grok extends Provider {
 			]
 		);
 
-		$request = new APIRequest( $settings[ static::ID ]['api_key'] ?? '', $feature->get_option_name() );
+		$request = new APIRequest( $this, $this->feature_instance );
 
 		if ( 'shrink' === $args['resize_type'] ) {
 			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );

--- a/includes/Classifai/Providers/XAI/Grok.php
+++ b/includes/Classifai/Providers/XAI/Grok.php
@@ -255,11 +255,6 @@ class Grok extends Provider {
 	 * @return array|WP_Error
 	 */
 	public function authenticate_credentials( array $settings = [] ) {
-		// Check that we have credentials before hitting the API.
-		if ( empty( $api_key ) ) {
-			return new WP_Error( 'auth', esc_html__( 'Please enter your xAI API key.', 'classifai' ) );
-		}
-
 		// Make request to ensure credentials work.
 		$request  = new APIRequest( $this, $this->feature_instance, $settings );
 		$response = $request->get( $this->models_url, [ 'use_vip' => true ] );

--- a/includes/Classifai/Providers/XAI/Grok.php
+++ b/includes/Classifai/Providers/XAI/Grok.php
@@ -254,9 +254,9 @@ class Grok extends Provider {
 	 * @param array $settings Settings being saved.
 	 * @return array|WP_Error
 	 */
-	public function authenticate_credentials( array $settings = [] ) {
+	protected function authenticate_credentials( array $settings = [] ) {
 		// Make request to ensure credentials work.
-		$request  = new APIRequest( $this, $this->feature_instance, $settings );
+		$request  = new APIRequest( '', $this->feature_instance::ID, $this, $settings );
 		$response = $request->get( $this->models_url, [ 'use_vip' => true ] );
 
 		if ( is_wp_error( $response ) ) {
@@ -362,7 +362,7 @@ class Grok extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Descriptive text generation is disabled or xAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		/**
 		 * Filter the prompt we will send to xAI Grok.
@@ -468,7 +468,7 @@ class Grok extends Provider {
 
 		$excerpt_length = absint( $settings['length'] ?? 55 );
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
@@ -577,7 +577,7 @@ class Grok extends Provider {
 			return new WP_Error( 'not_enabled', esc_html__( 'Title generation is disabled or xAI authentication failed. Please check your settings.', 'classifai' ) );
 		}
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
@@ -682,7 +682,7 @@ class Grok extends Provider {
 			]
 		);
 
-		$request = new APIRequest( $this, $this->feature_instance );
+		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		if ( 'shrink' === $args['resize_type'] ) {
 			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );

--- a/wp-hooks-docs/docs/03.advanced-docs/10.programmatic-credentials.md
+++ b/wp-hooks-docs/docs/03.advanced-docs/10.programmatic-credentials.md
@@ -10,11 +10,11 @@ ClassifAI supports programmatic credential management through a unified filter h
 
 ## Overview
 
-By default, ClassifAI stores API credentials in the WordPress database. The `classifai_provider_credentials` filter allows you to override these credentials at runtime, enabling integration with external secret management systems where credentials should be fetched dynamically rather than stored in the database.
+By default, ClassifAI stores API credentials in the WordPress database. The `classifai_provider_credentials` and `classifai_provider_credentials_{$provider_id}` filters allow you to override these credentials at runtime, enabling integration with external secret management systems where credentials should be fetched dynamically rather than stored in the database.
 
 ## The Filter Hook
 
-The primary hook for credential filtering is `classifai_provider_credentials`. This filter fires before every API request, allowing you to override credentials programmatically.
+The primary hooks for credential filtering are `classifai_provider_credentials` and `classifai_provider_credentials_{$provider_id}`. These filters fire before every API request, allowing you to override credentials programmatically.
 
 ### Filter Parameters
 
@@ -23,6 +23,13 @@ apply_filters(
     'classifai_provider_credentials',
     $credentials, // Array of credentials from database settings
     $provider_id, // Provider ID (e.g., 'azure_openai', 'openai_chatgpt')
+    $feature_id, // Feature ID making the request (e.g., 'feature_title_generation')
+    $feature_provider_settings // Feature-specific Provider settings
+);
+
+apply_filters(
+    'classifai_provider_credentials_{$provider_id}',
+    $credentials, // Array of credentials from database settings
     $feature_id, // Feature ID making the request (e.g., 'feature_title_generation')
     $feature_provider_settings // Feature-specific Provider settings
 );
@@ -126,6 +133,16 @@ add_filter( 'classifai_provider_credentials', function( $credentials, $provider_
 
     return $credentials;
 }, 10, 3 );
+```
+
+or
+
+```php
+add_filter( 'classifai_provider_credentials_openai_chatgpt', function( $credentials, $feature_id ) {
+    $credentials['api_key'] = get_option( 'custom_openai_key' );
+
+    return $credentials;
+}, 10, 2 );
 ```
 
 ## Important Considerations

--- a/wp-hooks-docs/docs/03.advanced-docs/10.programmatic-credentials.md
+++ b/wp-hooks-docs/docs/03.advanced-docs/10.programmatic-credentials.md
@@ -1,0 +1,165 @@
+---
+id: programmatic-credentials
+title: "Programmatic Credentials"
+sidebar_label: "Programmatic Credentials"
+---
+
+# Programmatic Credentials
+
+ClassifAI supports programmatic credential management through a unified filter hook, allowing you to integrate external secret management services like Azure Key Vault or AWS Secrets Manager, or manage credentials via environment variables.
+
+## Overview
+
+By default, ClassifAI stores API credentials in the WordPress database. The `classifai_provider_credentials` filter allows you to override these credentials at runtime, enabling integration with external secret management systems where credentials should be fetched dynamically rather than stored in the database.
+
+## The Filter Hook
+
+The primary hook for credential filtering is `classifai_provider_credentials`. This filter fires before every API request, allowing you to override credentials programmatically.
+
+### Filter Parameters
+
+```php
+apply_filters(
+    'classifai_provider_credentials',
+    $credentials, // Array of credentials from database settings
+    $provider_id, // Provider ID (e.g., 'azure_openai', 'openai_chatgpt')
+    $feature_id, // Feature ID making the request (e.g., 'feature_title_generation')
+    $feature_provider_settings // Feature-specific Provider settings
+);
+```
+
+### Return Value
+
+The filter should return an array of credentials matching the Provider's expected format. The array keys vary by Provider:
+
+- **Azure Providers**: `api_key`, `endpoint_url`, `deployment` (for OpenAI/Embeddings)
+- **OpenAI Providers**: `api_key`
+- **Google AI Providers**: `api_key`
+- **IBM Watson Providers**: `username`, `password`, `endpoint_url`
+- **AWS Polly Providers**: `access_key_id`, `secret_access_key`, `aws_region`
+- **ElevenLabs Providers**: `api_key`
+- **xAI Grok Providers**: `api_key`
+
+## Usage Examples
+
+### Azure Key Vault Integration
+
+This example shows how to fetch credentials from Azure Key Vault for Azure OpenAI Providers:
+
+```php
+add_filter( 'classifai_provider_credentials', function( $credentials, $provider_id, $feature_id ) {
+    // Only override for Azure Providers
+    if ( ! str_starts_with( $provider_id, 'azure_' ) ) {
+        return $credentials;
+    }
+
+    // Initialize Azure Key Vault client (requires Azure SDK)
+    $vault_client = new \Azure\KeyVault\SecretClient(
+        'https://your-vault.vault.azure.net',
+        new \Azure\Identity\DefaultAzureCredential()
+    );
+
+    // Fetch secrets from Key Vault
+    $api_key = $vault_client->getSecret( "classifai-{$provider_id}-api-key" )->getValue();
+    $endpoint = $vault_client->getSecret( "classifai-{$provider_id}-endpoint" )->getValue();
+
+    return array_merge( $credentials, [
+        'api_key'      => $api_key,
+        'endpoint_url' => $endpoint,
+        // Keep deployment from settings if not in vault
+        'deployment'   => $credentials['deployment'] ?? '',
+    ] );
+}, 10, 3 );
+```
+
+### Environment Variable Credentials
+
+Use environment variables for credentials instead of storing them in the database:
+
+```php
+add_filter( 'classifai_provider_credentials', function( $credentials, $provider_id, $feature_id ) {
+    // Convert provider_id to environment variable format
+    $env_key = strtoupper( str_replace( '-', '_', "CLASSIFAI_{$provider_id}_API_KEY" ) );
+
+    if ( defined( $env_key ) ) {
+        $credentials['api_key'] = constant( $env_key );
+    }
+
+    // Handle Azure Providers that need endpoint_url
+    if ( str_starts_with( $provider_id, 'azure_' ) ) {
+        $env_endpoint = strtoupper( str_replace( '-', '_', "CLASSIFAI_{$provider_id}_ENDPOINT" ) );
+        if ( defined( $env_endpoint ) ) {
+            $credentials['endpoint_url'] = constant( $env_endpoint );
+        }
+    }
+
+    return $credentials;
+}, 10, 3 );
+```
+
+### Feature-Specific Credentials
+
+Use different API keys for different Features:
+
+```php
+add_filter( 'classifai_provider_credentials', function( $credentials, $provider_id, $feature_id ) {
+    // Use premium API key for content generation
+    if ( 'feature_content_generation' === $feature_id ) {
+        $credentials['api_key'] = get_option( 'classifai_premium_api_key' );
+    }
+
+    // Use standard API key for other features
+    return $credentials;
+}, 10, 3 );
+```
+
+### Provider-Specific Override
+
+Override credentials for a specific Provider:
+
+```php
+add_filter( 'classifai_provider_credentials', function( $credentials, $provider_id, $feature_id ) {
+    // Only override for OpenAI ChatGPT
+    if ( 'openai_chatgpt' === $provider_id ) {
+        $credentials['api_key'] = get_option( 'custom_openai_key' );
+    }
+
+    return $credentials;
+}, 10, 3 );
+```
+
+## Important Considerations
+
+### Caching
+
+When using external secret management services, implement caching to avoid excessive API calls:
+
+```php
+add_filter( 'classifai_provider_credentials', function( $credentials, $provider_id, $feature_id ) {
+    $cache_key = "classifai_creds_{$provider_id}_{$feature_id}";
+    $cached = get_transient( $cache_key );
+
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    // Fetch from external service
+    $vault_credentials = fetch_from_key_vault( $provider_id );
+
+    // Merge with the original credentials
+    $credentials = array_merge( $credentials, $vault_credentials );
+
+    // Cache for 5 minutes
+    set_transient( $cache_key, $credentials, 5 * MINUTE_IN_SECONDS );
+
+    return $credentials;
+}, 10, 3 );
+```
+
+### Settings Page Authentication
+
+The authentication check on the settings page also uses filtered credentials. This means your integration will be tested when users save settings, ensuring credentials are valid.
+
+### Security
+
+Filtered credentials are never stored back to the database. They are only used for the current API request and discarded afterward.

--- a/wp-hooks-docs/docs/03.advanced-docs/index.md
+++ b/wp-hooks-docs/docs/03.advanced-docs/index.md
@@ -25,5 +25,6 @@ Welcome to the ClassifAI Advanced Documentation. This section provides in-depth 
 
 - [Feature Provider Support](./07.feature-provider-support.md) - Overview of supported AI providers for each feature
 - [Data Flow](./08.data-flow.md) - Detailed explanation of ClassifAI's data architecture and processing flow
+- [Programmatic Credentials](./10.programmatic-credentials.md) - Guide to setting up programmatic credential management
 
 Each section provides detailed technical information to help you make the most of ClassifAI's capabilities. Whether you're extending the plugin, customizing its behavior, or integrating it with other systems, you'll find comprehensive guidance here.


### PR DESCRIPTION
### Description of the Change

This PR takes just the Provider credential filtering out of #1038 in order to make both of those PRs easier to review and test and hopefully get this piece merged in sooner.

The work here was heavily inspired by the work done in #1020 (and supersedes that PR) and was originally done in #1038 to ensure any changes we make around credentials management also work when we move Providers to be global.

Here's a high-level overview of changes here:

- Introduce a new CredentialResolver class that will pull just credentials out of our settings
- Add new methods on the Provider class that get all credentials for that Provider or a specific credential field. These all pass through new filters (`classifai_provider_credentials_{$provider_id}` and `classifai_provider_credentials`) making it easy for other to hook in and change those credentials
- More standardization on how API requests are made, making it easier to ensure all credentials pass through our new filter and setting us up for the future where we will integrate the new WP AI Client for these requests

Closes #1019 

### How to test the Change

Practically all Feature/Provider combinations are touched by this update though in general, this is all fairly minor changes. Testing to ensure Features still work as expected (that API requests work) is what is needed here.

### Changelog Entry

> Added - New methods on the Provider class that allow you to get all credentials or a specific credential, pulling the credentials from the larger Feature settings
> Added - New filters, `classifai_provider_credentials_{$provider_id}` and `classifai_provider_credentials`, that allows developers the ability to override AI credentials prior to those being used
> Changed - For filters that run when API requests are made, the Feature name, not the Feature option name is now passed as an argument. If you have code that relies on that argument, updates will be needed

### Credits

Props @fabiankaegy, @dkotter 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
