### PR TITLE
Fix all Gutenberg deprecation notices

### DIFF
--- a/src/js/components/user-selector.js
+++ b/src/js/components/user-selector.js
@@ -126,6 +126,7 @@ export const UserSelector = ( { value, onChange } ) => {
 				__experimentalInvalid: __( 'Invalid user', 'classifai' ),
 			} }
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 		/>
 	);
 };

--- a/src/js/features/classification/classification-toggle.js
+++ b/src/js/features/classification/classification-toggle.js
@@ -29,6 +29,7 @@ export const ClassificationToggle = () => {
 			onChange={ ( value ) => {
 				editPost( { classifai_process_content: value ? 'yes' : 'no' } );
 			} }
+			__nextHasNoMarginBottom
 		/>
 	);
 };

--- a/src/js/features/classification/taxonomy-controls.js
+++ b/src/js/features/classification/taxonomy-controls.js
@@ -278,6 +278,7 @@ const TaxonomyControls = ( { onChange, query } ) => {
 								value={ getExistingTaxQueryValue( slug ) }
 								suggestions={ terms.names }
 								onChange={ onTermsChange( slug ) }
+								__next40pxDefaultSize
 							/>
 							{ ! hasAI && (
 								<>

--- a/src/js/features/text-to-speech/index.js
+++ b/src/js/features/text-to-speech/index.js
@@ -172,6 +172,7 @@ const TextToSpeechPlugin = () => {
 				} }
 				disabled={ isProcessingAudio }
 				isBusy={ isProcessingAudio }
+				__nextHasNoMarginBottom
 			/>
 			{ sourceUrl && (
 				<>
@@ -189,6 +190,7 @@ const TextToSpeechPlugin = () => {
 						} }
 						disabled={ isProcessingAudio }
 						isBusy={ isProcessingAudio }
+						__nextHasNoMarginBottom
 					/>
 					<BaseControl
 						id="classifai-audio-preview-controls"

--- a/src/js/settings/components/feature-additional-settings/excerpt-generation.js
+++ b/src/js/settings/components/feature-additional-settings/excerpt-generation.js
@@ -92,6 +92,7 @@ export const ExcerptGenerationSettings = () => {
 					onChange={ ( value ) =>
 						setFeatureSettings( { length: value } )
 					}
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/feature-additional-settings/image-tag-generator.js
+++ b/src/js/settings/components/feature-additional-settings/image-tag-generator.js
@@ -50,6 +50,7 @@ export const ImageTagGeneratorSettings = () => {
 					}
 					options={ options }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow

--- a/src/js/settings/components/feature-additional-settings/nlu-feature.js
+++ b/src/js/settings/components/feature-additional-settings/nlu-feature.js
@@ -148,6 +148,7 @@ export const NLUFeatureSettings = () => {
 							min="0"
 							max="100"
 							step="0.01"
+							__next40pxDefaultSize
 						/>
 
 						{ 'ibm_watson_nlu' === featureSettings.provider && (
@@ -175,6 +176,7 @@ export const NLUFeatureSettings = () => {
 									} );
 								} }
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 							/>
 						) }
 					</SettingsRow>

--- a/src/js/settings/components/feature-additional-settings/prompt-repeater.js
+++ b/src/js/settings/components/feature-additional-settings/prompt-repeater.js
@@ -110,6 +110,7 @@ export const PromptRepeater = ( props ) => {
 									'classifai'
 								) }
 								className="classifai-prompt-title"
+								__next40pxDefaultSize
 							/>
 							<TextareaControl
 								value={ prompt.prompt }

--- a/src/js/settings/components/feature-additional-settings/smart-404.js
+++ b/src/js/settings/components/feature-additional-settings/smart-404.js
@@ -47,6 +47,7 @@ export const Smart404Settings = () => {
 							num: value,
 						} );
 					} }
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -65,6 +66,7 @@ export const Smart404Settings = () => {
 							num_search: value,
 						} );
 					} }
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -85,6 +87,7 @@ export const Smart404Settings = () => {
 							threshold: value,
 						} );
 					} }
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -154,6 +157,7 @@ export const Smart404Settings = () => {
 						},
 					] }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/feature-additional-settings/term-cleanup.js
+++ b/src/js/settings/components/feature-additional-settings/term-cleanup.js
@@ -156,6 +156,7 @@ export const TermCleanupSettings = () => {
 								min="0"
 								max="100"
 								step="0.01"
+								__next40pxDefaultSize
 							/>
 						</SettingsRow>
 					);

--- a/src/js/settings/components/model-selector/index.js
+++ b/src/js/settings/components/model-selector/index.js
@@ -67,6 +67,7 @@ export const ModelSelector = ( {
 				options={ models }
 				disabled={ models.length <= 1 }
 				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 			/>
 		</SettingsRow>
 	);

--- a/src/js/settings/components/provider-settings/amazon-polly.js
+++ b/src/js/settings/components/provider-settings/amazon-polly.js
@@ -45,6 +45,7 @@ export const AmazonPollySettings = ( { isConfigured = false } ) => {
 							onChange={ ( value ) =>
 								onChange( { access_key_id: value } )
 							}
+							__next40pxDefaultSize
 						/>
 					</SettingsRow>
 					<SettingsRow
@@ -61,6 +62,7 @@ export const AmazonPollySettings = ( { isConfigured = false } ) => {
 							onChange={ ( value ) =>
 								onChange( { secret_access_key: value } )
 							}
+							__next40pxDefaultSize
 						/>
 					</SettingsRow>
 					<SettingsRow
@@ -82,6 +84,7 @@ export const AmazonPollySettings = ( { isConfigured = false } ) => {
 							onChange={ ( value ) =>
 								onChange( { aws_region: value } )
 							}
+							__next40pxDefaultSize
 						/>
 					</SettingsRow>
 				</>
@@ -136,6 +139,7 @@ export const AmazonPollySettings = ( { isConfigured = false } ) => {
 						},
 					] }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow label={ __( 'Voice', 'classifai' ) }>
@@ -156,6 +160,7 @@ export const AmazonPollySettings = ( { isConfigured = false } ) => {
 							};
 						} ) }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/azure-ai-vision.js
+++ b/src/js/settings/components/provider-settings/azure-ai-vision.js
@@ -60,6 +60,7 @@ export const AzureAIVisionSettings = ( { isConfigured = false } ) => {
 							onChange={ ( value ) =>
 								onChange( { endpoint_url: value } )
 							}
+							__next40pxDefaultSize
 						/>
 					</SettingsRow>
 					<SettingsRow label={ __( 'API Key', 'classifai' ) }>
@@ -70,6 +71,7 @@ export const AzureAIVisionSettings = ( { isConfigured = false } ) => {
 							onChange={ ( value ) =>
 								onChange( { api_key: value } )
 							}
+							__next40pxDefaultSize
 						/>
 					</SettingsRow>
 				</>
@@ -97,6 +99,7 @@ export const AzureAIVisionSettings = ( { isConfigured = false } ) => {
 								descriptive_confidence_threshold: value,
 							} )
 						}
+						__next40pxDefaultSize
 					/>
 				</SettingsRow>
 			) }
@@ -122,6 +125,7 @@ export const AzureAIVisionSettings = ( { isConfigured = false } ) => {
 								tag_confidence_threshold: value,
 							} )
 						}
+						__next40pxDefaultSize
 					/>
 				</SettingsRow>
 			) }

--- a/src/js/settings/components/provider-settings/azure-openai.js
+++ b/src/js/settings/components/provider-settings/azure-openai.js
@@ -63,6 +63,7 @@ export const AzureOpenAISettings = ( {
 							onChange={ ( value ) =>
 								onChange( { endpoint_url: value } )
 							}
+							__next40pxDefaultSize
 						/>
 					</SettingsRow>
 					<SettingsRow label={ __( 'API Key', 'classifai' ) }>
@@ -73,6 +74,7 @@ export const AzureOpenAISettings = ( {
 							onChange={ ( value ) =>
 								onChange( { api_key: value } )
 							}
+							__next40pxDefaultSize
 						/>
 					</SettingsRow>
 					<SettingsRow
@@ -89,6 +91,7 @@ export const AzureOpenAISettings = ( {
 							onChange={ ( value ) =>
 								onChange( { deployment: value } )
 							}
+							__next40pxDefaultSize
 						/>
 					</SettingsRow>
 				</>
@@ -113,6 +116,7 @@ export const AzureOpenAISettings = ( {
 						onChange={ ( value ) =>
 							onChange( { number_of_suggestions: value } )
 						}
+						__next40pxDefaultSize
 					/>
 				</SettingsRow>
 			) }

--- a/src/js/settings/components/provider-settings/azure-text-to-speech.js
+++ b/src/js/settings/components/provider-settings/azure-text-to-speech.js
@@ -67,6 +67,7 @@ export const AzureTextToSpeechSettings = ( { isConfigured = false } ) => {
 							onChange={ ( value ) =>
 								onChange( { endpoint_url: value } )
 							}
+							__next40pxDefaultSize
 						/>
 					</SettingsRow>
 					<SettingsRow label={ __( 'API Key', 'classifai' ) }>
@@ -77,6 +78,7 @@ export const AzureTextToSpeechSettings = ( { isConfigured = false } ) => {
 							onChange={ ( value ) =>
 								onChange( { api_key: value } )
 							}
+							__next40pxDefaultSize
 						/>
 					</SettingsRow>
 				</>
@@ -94,6 +96,7 @@ export const AzureTextToSpeechSettings = ( { isConfigured = false } ) => {
 							} )
 						) }
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 				</SettingsRow>
 			) }

--- a/src/js/settings/components/provider-settings/elevenlabs/base.js
+++ b/src/js/settings/components/provider-settings/elevenlabs/base.js
@@ -41,6 +41,7 @@ export const ElevenLabsSettings = ( { providerSettings, onChange } ) => {
 					type="password"
 					value={ providerSettings.api_key || '' }
 					onChange={ ( value ) => onChange( { api_key: value } ) }
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/elevenlabs/text-to-speech.js
+++ b/src/js/settings/components/provider-settings/elevenlabs/text-to-speech.js
@@ -81,6 +81,7 @@ export const ElevenLabsTextToSpeechSettings = ( { isConfigured = false } ) => {
 					} ) ) }
 					disabled={ ! providerSettings.voices?.length }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/googleai-gemini.js
+++ b/src/js/settings/components/provider-settings/googleai-gemini.js
@@ -89,6 +89,7 @@ export const GoogleAIGeminiSettings = ( { isConfigured = false } ) => {
 					options={ models }
 					disabled={ models.length <= 1 }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/googleai-images.js
+++ b/src/js/settings/components/provider-settings/googleai-images.js
@@ -55,6 +55,7 @@ export const GoogleAIImagesSettings = ( { isConfigured = false } ) => {
 						value: i + 1,
 					} ) ) }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -93,6 +94,7 @@ export const GoogleAIImagesSettings = ( { isConfigured = false } ) => {
 						},
 					] }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -108,6 +110,7 @@ export const GoogleAIImagesSettings = ( { isConfigured = false } ) => {
 						onChange( { per_image_settings: value } )
 					}
 					checked={ providerSettings.per_image_settings || false }
+					__nextHasNoMarginBottom
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/googleai.js
+++ b/src/js/settings/components/provider-settings/googleai.js
@@ -41,6 +41,7 @@ export const GoogleAISettings = ( { providerSettings, onChange } ) => {
 					type="password"
 					value={ providerSettings.api_key || '' }
 					onChange={ ( value ) => onChange( { api_key: value } ) }
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/ibm-watson-nlu.js
+++ b/src/js/settings/components/provider-settings/ibm-watson-nlu.js
@@ -68,6 +68,7 @@ export const IBMWatsonNLUSettings = ( { isConfigured = false } ) => {
 					onChange={ ( value ) =>
 						onChange( { endpoint_url: value } )
 					}
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			{ ! useAPIkey && (
@@ -79,6 +80,7 @@ export const IBMWatsonNLUSettings = ( { isConfigured = false } ) => {
 						onChange={ ( value ) =>
 							onChange( { username: value } )
 						}
+						__next40pxDefaultSize
 					/>
 				</SettingsRow>
 			) }
@@ -101,6 +103,7 @@ export const IBMWatsonNLUSettings = ( { isConfigured = false } ) => {
 						}
 						onChange( data );
 					} }
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow>

--- a/src/js/settings/components/provider-settings/index.js
+++ b/src/js/settings/components/provider-settings/index.js
@@ -214,6 +214,7 @@ export const ProviderSettings = () => {
 							value={ provider }
 							options={ providers }
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 					</SettingsRow>
 				) }

--- a/src/js/settings/components/provider-settings/openai-chatgpt.js
+++ b/src/js/settings/components/provider-settings/openai-chatgpt.js
@@ -80,6 +80,7 @@ export const OpenAIChatGPTSettings = ( { isConfigured = false } ) => {
 						type="password"
 						value={ providerSettings.api_key || '' }
 						onChange={ ( value ) => onChange( { api_key: value } ) }
+						__next40pxDefaultSize
 					/>
 				</SettingsRow>
 			) }
@@ -103,6 +104,7 @@ export const OpenAIChatGPTSettings = ( { isConfigured = false } ) => {
 						onChange={ ( value ) =>
 							onChange( { number_of_suggestions: value } )
 						}
+						__next40pxDefaultSize
 					/>
 				</SettingsRow>
 			) }

--- a/src/js/settings/components/provider-settings/openai-embeddings.js
+++ b/src/js/settings/components/provider-settings/openai-embeddings.js
@@ -56,6 +56,7 @@ export const OpenAIEmbeddingsSettings = ( { isConfigured = false } ) => {
 						min="1"
 						max="100"
 						step="0.01"
+						__next40pxDefaultSize
 					/>
 				</SettingsRow>
 			) }

--- a/src/js/settings/components/provider-settings/openai-images.js
+++ b/src/js/settings/components/provider-settings/openai-images.js
@@ -55,6 +55,7 @@ export const OpenAIImagesSettings = ( { isConfigured = false } ) => {
 						value: i + 1,
 					} ) ) }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -87,6 +88,7 @@ export const OpenAIImagesSettings = ( { isConfigured = false } ) => {
 						},
 					] }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -115,6 +117,7 @@ export const OpenAIImagesSettings = ( { isConfigured = false } ) => {
 						},
 					] }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -130,6 +133,7 @@ export const OpenAIImagesSettings = ( { isConfigured = false } ) => {
 						onChange( { per_image_settings: value } )
 					}
 					checked={ providerSettings.per_image_settings || false }
+					__nextHasNoMarginBottom
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/openai.js
+++ b/src/js/settings/components/provider-settings/openai.js
@@ -40,6 +40,7 @@ export const OpenAISettings = ( { providerSettings, onChange } ) => {
 					type="password"
 					value={ providerSettings.api_key || '' }
 					onChange={ ( value ) => onChange( { api_key: value } ) }
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/stable-diffusion.js
+++ b/src/js/settings/components/provider-settings/stable-diffusion.js
@@ -80,6 +80,7 @@ export const StableDiffusionSettings = ( { isConfigured = false } ) => {
 						onChange={ ( value ) =>
 							onChange( { endpoint_url: value } )
 						}
+						__next40pxDefaultSize
 					/>
 				</SettingsRow>
 			) }
@@ -97,6 +98,7 @@ export const StableDiffusionSettings = ( { isConfigured = false } ) => {
 					options={ models }
 					disabled={ ! isConfigured }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -117,6 +119,7 @@ export const StableDiffusionSettings = ( { isConfigured = false } ) => {
 						value: i + 1,
 					} ) ) }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -145,6 +148,7 @@ export const StableDiffusionSettings = ( { isConfigured = false } ) => {
 						},
 					] }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -160,6 +164,7 @@ export const StableDiffusionSettings = ( { isConfigured = false } ) => {
 						onChange( { per_image_settings: value } )
 					}
 					checked={ providerSettings.per_image_settings || false }
+					__nextHasNoMarginBottom
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/together-ai-images.js
+++ b/src/js/settings/components/provider-settings/together-ai-images.js
@@ -70,6 +70,7 @@ export const TogetherAIImagesSettings = ( { isConfigured = false } ) => {
 					options={ models }
 					disabled={ models.length <= 1 }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -90,6 +91,7 @@ export const TogetherAIImagesSettings = ( { isConfigured = false } ) => {
 						value: i + 1,
 					} ) ) }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -118,6 +120,7 @@ export const TogetherAIImagesSettings = ( { isConfigured = false } ) => {
 						},
 					] }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			<SettingsRow
@@ -133,6 +136,7 @@ export const TogetherAIImagesSettings = ( { isConfigured = false } ) => {
 						onChange( { per_image_settings: value } )
 					}
 					checked={ providerSettings.per_image_settings || false }
+					__nextHasNoMarginBottom
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/together-ai.js
+++ b/src/js/settings/components/provider-settings/together-ai.js
@@ -41,6 +41,7 @@ export const TogetherAISettings = ( { providerSettings, onChange } ) => {
 					type="password"
 					value={ providerSettings.api_key || '' }
 					onChange={ ( value ) => onChange( { api_key: value } ) }
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 		</>

--- a/src/js/settings/components/provider-settings/xai-grok.js
+++ b/src/js/settings/components/provider-settings/xai-grok.js
@@ -123,6 +123,7 @@ export const XAIGrokSettings = ( { isConfigured = false } ) => {
 						type="password"
 						value={ providerSettings.api_key || '' }
 						onChange={ ( value ) => onChange( { api_key: value } ) }
+						__next40pxDefaultSize
 					/>
 				</SettingsRow>
 			) }
@@ -137,6 +138,7 @@ export const XAIGrokSettings = ( { isConfigured = false } ) => {
 					options={ models }
 					disabled={ models.length <= 1 }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</SettingsRow>
 			{ [
@@ -159,6 +161,7 @@ export const XAIGrokSettings = ( { isConfigured = false } ) => {
 						onChange={ ( value ) =>
 							onChange( { number_of_suggestions: value } )
 						}
+						__next40pxDefaultSize
 					/>
 				</SettingsRow>
 			) }


### PR DESCRIPTION
### Description of the Change

We use quite a few Gutenberg components within our settings screen and there's quite a few deprecation notices being shown due to changes coming with sizing and spacing. This PR fixes all those deprecation warnings by opting in to the new changes, allowing us to catch and fix any issues early (and keep the console clean).

Note most of these changes had been made originally in #1038 but there's no real need they need to be there and would be nice to reduce the size of that PR and get these fixes out quicker.

### How to test the Change

1. Open your browser console
2. Click around the settings screen, into each Feature and Provider combination
3. Ensure all fields show as expected and no console statements are logged

### Changelog Entry

> Fixed - Opt-in to new changes coming to Gutenberg react components, like larger font-sizing and removal of margins, to avoid deprecation notices being logged to the browser console

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
