### PR TITLE
Obfuscate credentials before rendering to the front-end

### DIFF
--- a/includes/Classifai/Admin/Settings.php
+++ b/includes/Classifai/Admin/Settings.php
@@ -479,7 +479,9 @@ class Settings {
 		$settings        = $service_manager->get_settings();
 
 		// Obfuscate the license key before returning.
-		$settings['license_key'] = CredentialObfuscator::obfuscate( $settings['license_key'] );
+		if ( isset( $settings['license_key'] ) ) {
+			$settings['license_key'] = CredentialObfuscator::obfuscate( $settings['license_key'] );
+		}
 
 		return rest_ensure_response( $settings );
 	}

--- a/includes/Classifai/Admin/Settings.php
+++ b/includes/Classifai/Admin/Settings.php
@@ -7,6 +7,7 @@ use Classifai\Features\RecommendedContent;
 use Classifai\Services\ServicesManager;
 use Classifai\Taxonomy\TaxonomyFactory;
 use Classifai\Helpers\CredentialReuse;
+use Classifai\Providers\CredentialObfuscator;
 
 use function Classifai\get_asset_info;
 use function Classifai\get_plugin;
@@ -226,14 +227,18 @@ class Settings {
 	/**
 	 * Get the settings.
 	 *
-	 * @return array The settings.
+	 * Obfuscates sensitive credentials before returning to prevent
+	 * exposure of API keys in the frontend.
+	 *
+	 * @return array The settings with credentials obfuscated.
 	 */
 	public function get_settings(): array {
 		$features = $this->get_features( true );
 		$settings = [];
 
 		foreach ( $features as $feature ) {
-			$settings[ $feature::ID ] = $feature->get_settings();
+			$feature_settings         = $feature->get_settings();
+			$settings[ $feature::ID ] = CredentialObfuscator::obfuscate_feature_settings( $feature_settings );
 		}
 
 		return $settings;

--- a/includes/Classifai/Admin/Settings.php
+++ b/includes/Classifai/Admin/Settings.php
@@ -477,6 +477,10 @@ class Settings {
 	public function get_registration_settings_callback(): \WP_REST_Response {
 		$service_manager = new ServicesManager();
 		$settings        = $service_manager->get_settings();
+
+		// Obfuscate the license key before returning.
+		$settings['license_key'] = CredentialObfuscator::obfuscate( $settings['license_key'] );
+
 		return rest_ensure_response( $settings );
 	}
 
@@ -492,12 +496,19 @@ class Settings {
 			require_once ABSPATH . 'wp-admin/includes/template.php';
 		}
 
-		$service_manager = new ServicesManager();
-		$settings        = $service_manager->get_settings();
-		$new_settings    = $service_manager->sanitize_settings( $request->get_json_params() );
+		$service_manager  = new ServicesManager();
+		$current_settings = $service_manager->get_settings();
+		$new_settings     = $request->get_json_params();
+
+		// If the license key is obfuscated, use the current value.
+		if ( isset( $new_settings['license_key'] ) && CredentialObfuscator::is_obfuscated( $new_settings['license_key'] ) ) {
+			$new_settings['license_key'] = $current_settings['license_key'] ?? '';
+		}
+
+		$new_settings = $service_manager->sanitize_settings( $new_settings );
 
 		// Update the settings with the new values.
-		$new_settings = array_merge( $settings, $new_settings );
+		$new_settings = array_merge( $current_settings, $new_settings );
 		update_option( 'classifai_settings', $new_settings );
 
 		$setting_errors = get_settings_errors();

--- a/includes/Classifai/Features/Feature.php
+++ b/includes/Classifai/Features/Feature.php
@@ -4,6 +4,7 @@ namespace Classifai\Features;
 
 use WP_REST_Request;
 use WP_Error;
+use Classifai\Providers\CredentialObfuscator;
 
 use function Classifai\find_provider_class;
 use function Classifai\should_use_legacy_settings_panel;
@@ -300,6 +301,13 @@ abstract class Feature {
 
 		// Sanitize the feature specific settings.
 		$new_settings = $this->sanitize_default_feature_settings( $new_settings );
+
+		// Preserve obfuscated credentials for all Providers.
+		// This ensures switching Providers doesn't save obfuscated values for inactive Providers.
+		$new_settings = CredentialObfuscator::merge_all_provider_credentials(
+			$new_settings,
+			$current_settings
+		);
 
 		// Sanitize the provider specific settings.
 		$provider_instance = $this->get_feature_provider_instance( $new_settings['provider'] );

--- a/includes/Classifai/Providers/CredentialObfuscator.php
+++ b/includes/Classifai/Providers/CredentialObfuscator.php
@@ -56,7 +56,9 @@ class CredentialObfuscator {
 		$length = strlen( $value );
 
 		// If the value is too short, just return asterisks.
-		if ( $length <= self::VISIBLE_PREFIX_LENGTH ) {
+		if ( $length <= self::VISIBLE_PREFIX_LENGTH && $length <= self::MIN_ASTERISKS_TO_DETECT ) {
+			return str_repeat( '*', self::MIN_ASTERISKS_TO_DETECT );
+		} elseif ( $length <= self::VISIBLE_PREFIX_LENGTH ) {
 			return str_repeat( '*', $length );
 		}
 

--- a/includes/Classifai/Providers/CredentialObfuscator.php
+++ b/includes/Classifai/Providers/CredentialObfuscator.php
@@ -77,6 +77,11 @@ class CredentialObfuscator {
 		$prefix    = substr( $value, 0, self::VISIBLE_PREFIX_LENGTH );
 		$asterisks = str_repeat( '*', $length - self::VISIBLE_PREFIX_LENGTH );
 
+		// If we don't have enough asterisks, add more.
+		if ( strlen( $asterisks ) < self::MIN_ASTERISKS_TO_DETECT ) {
+			$asterisks = str_repeat( '*', self::MIN_ASTERISKS_TO_DETECT );
+		}
+
 		return $prefix . $asterisks;
 	}
 

--- a/includes/Classifai/Providers/CredentialObfuscator.php
+++ b/includes/Classifai/Providers/CredentialObfuscator.php
@@ -38,20 +38,6 @@ class CredentialObfuscator {
 	const MIN_ASTERISKS_TO_DETECT = 3;
 
 	/**
-	 * Fields that should NOT be obfuscated (non-sensitive).
-	 *
-	 * @var array
-	 */
-	private static $non_sensitive_fields = [
-		'authenticated',
-		'endpoint_url',
-		'aws_region',
-		'deployment',
-		'username',
-		'access_key_id',
-	];
-
-	/**
 	 * Obfuscate a credential value.
 	 *
 	 * Returns first N characters followed by asterisks.
@@ -112,10 +98,12 @@ class CredentialObfuscator {
 	 * @since x.x.x
 	 *
 	 * @param string $field The field name to check.
+	 * @param string $profile_id The profile ID.
 	 * @return bool True if the field should be obfuscated.
 	 */
-	public static function should_obfuscate_field( string $field ): bool {
-		return ! in_array( $field, self::$non_sensitive_fields, true );
+	public static function should_obfuscate_field( string $field, string $profile_id ): bool {
+		$sensitive_fields = ProviderProfiles::get_sensitive_fields( $profile_id );
+		return in_array( $field, $sensitive_fields, true );
 	}
 
 	/**
@@ -142,7 +130,7 @@ class CredentialObfuscator {
 			if (
 				isset( $settings[ $field ] ) &&
 				is_string( $settings[ $field ] ) &&
-				self::should_obfuscate_field( $field )
+				self::should_obfuscate_field( $field, $profile_id )
 			) {
 				$settings[ $field ] = self::obfuscate( $settings[ $field ] );
 			}
@@ -205,7 +193,7 @@ class CredentialObfuscator {
 
 		foreach ( $credential_fields as $field ) {
 			// Skip non-sensitive fields.
-			if ( ! self::should_obfuscate_field( $field ) ) {
+			if ( ! self::should_obfuscate_field( $field, $profile_id ) ) {
 				continue;
 			}
 

--- a/includes/Classifai/Providers/CredentialObfuscator.php
+++ b/includes/Classifai/Providers/CredentialObfuscator.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Helper class for credential obfuscation functionality.
+ *
+ * @package Classifai
+ */
+
+namespace Classifai\Providers;
+
+use Classifai\Providers\ProviderProfiles;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * CredentialObfuscator class.
+ *
+ * Handles obfuscation of sensitive credentials when displayed in the admin UI
+ * and preserves original values when obfuscated values are submitted.
+ *
+ * @since x.x.x
+ */
+class CredentialObfuscator {
+
+	/**
+	 * Number of characters to show at the beginning of obfuscated values.
+	 *
+	 * @var int
+	 */
+	const VISIBLE_PREFIX_LENGTH = 8;
+
+	/**
+	 * Minimum number of consecutive asterisks to detect an obfuscated value.
+	 *
+	 * @var int
+	 */
+	const MIN_ASTERISKS_TO_DETECT = 3;
+
+	/**
+	 * Fields that should NOT be obfuscated (non-sensitive).
+	 *
+	 * @var array
+	 */
+	private static $non_sensitive_fields = [
+		'authenticated',
+		'endpoint_url',
+		'aws_region',
+		'deployment',
+		'username',
+		'access_key_id',
+	];
+
+	/**
+	 * Obfuscate a credential value.
+	 *
+	 * Returns first N characters followed by asterisks.
+	 * Example: "sk-abc123xyz789" becomes "sk-abc************"
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $value The credential value to obfuscate.
+	 * @return string The obfuscated value, or original if too short.
+	 */
+	public static function obfuscate( string $value ): string {
+		if ( empty( $value ) ) {
+			return $value;
+		}
+
+		$length = strlen( $value );
+
+		// If the value is too short, just return asterisks.
+		if ( $length <= self::VISIBLE_PREFIX_LENGTH ) {
+			return str_repeat( '*', $length );
+		}
+
+		$prefix    = substr( $value, 0, self::VISIBLE_PREFIX_LENGTH );
+		$asterisks = str_repeat( '*', $length - self::VISIBLE_PREFIX_LENGTH );
+
+		return $prefix . $asterisks;
+	}
+
+	/**
+	 * Check if a value appears to be obfuscated.
+	 *
+	 * Detects values containing 3 or more consecutive asterisks.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $value The value to check.
+	 * @return bool True if the value appears to be obfuscated.
+	 */
+	public static function is_obfuscated( string $value ): bool {
+		if ( empty( $value ) ) {
+			return false;
+		}
+
+		$pattern = '/\*{' . self::MIN_ASTERISKS_TO_DETECT . ',}/';
+		return (bool) preg_match( $pattern, $value );
+	}
+
+	/**
+	 * Check if a field should be obfuscated.
+	 *
+	 * Returns false for non-sensitive fields like authenticated, endpoint_url, etc.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $field The field name to check.
+	 * @return bool True if the field should be obfuscated.
+	 */
+	public static function should_obfuscate_field( string $field ): bool {
+		return ! in_array( $field, self::$non_sensitive_fields, true );
+	}
+
+	/**
+	 * Obfuscate credential fields for a specific Provider.
+	 *
+	 * Uses ProviderProfiles to determine which fields are credentials.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $provider_id The Provider ID (e.g., 'openai_chatgpt').
+	 * @param array  $settings    The Provider settings array.
+	 * @return array The settings with credentials obfuscated.
+	 */
+	public static function obfuscate_provider_settings( string $provider_id, array $settings ): array {
+		$profile_id = ProviderProfiles::get_profile_for_provider( $provider_id );
+
+		if ( ! $profile_id ) {
+			return $settings;
+		}
+
+		$credential_fields = ProviderProfiles::get_credential_fields( $profile_id );
+
+		foreach ( $credential_fields as $field ) {
+			if (
+				isset( $settings[ $field ] ) &&
+				is_string( $settings[ $field ] ) &&
+				self::should_obfuscate_field( $field )
+			) {
+				$settings[ $field ] = self::obfuscate( $settings[ $field ] );
+			}
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Obfuscate all Provider credentials in Feature settings.
+	 *
+	 * Iterates through all Provider settings in the Feature and obfuscates
+	 * their credential fields.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $settings The complete Feature settings array.
+	 * @return array The settings with all Provider credentials obfuscated.
+	 */
+	public static function obfuscate_feature_settings( array $settings ): array {
+		$profiles = ProviderProfiles::get_all_profiles();
+
+		// Get all Provider IDs from profiles.
+		$all_provider_ids = [];
+		foreach ( $profiles as $profile ) {
+			$all_provider_ids = array_merge( $all_provider_ids, $profile['provider_ids'] );
+		}
+
+		// Obfuscate credentials for each Provider that has settings.
+		foreach ( $settings as $key => $value ) {
+			if ( is_array( $value ) && in_array( $key, $all_provider_ids, true ) ) {
+				$settings[ $key ] = self::obfuscate_provider_settings( $key, $value );
+			}
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Merge new credentials with existing credentials, preserving originals when obfuscated.
+	 *
+	 * If a new value is obfuscated, use the existing value instead.
+	 * This prevents obfuscated placeholder values from being saved to the database.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array  $new_settings      The new settings being saved.
+	 * @param array  $existing_settings The current saved settings.
+	 * @param string $provider_id       The Provider ID.
+	 * @return array The merged settings.
+	 */
+	public static function merge_credentials( array $new_settings, array $existing_settings, string $provider_id ): array {
+		$profile_id = ProviderProfiles::get_profile_for_provider( $provider_id );
+
+		if ( ! $profile_id ) {
+			return $new_settings;
+		}
+
+		$credential_fields = ProviderProfiles::get_credential_fields( $profile_id );
+
+		foreach ( $credential_fields as $field ) {
+			// Skip non-sensitive fields.
+			if ( ! self::should_obfuscate_field( $field ) ) {
+				continue;
+			}
+
+			// If the new value is obfuscated, preserve the existing value.
+			if (
+				isset( $new_settings[ $field ] ) &&
+				is_string( $new_settings[ $field ] ) &&
+				self::is_obfuscated( $new_settings[ $field ] ) &&
+				isset( $existing_settings[ $field ] )
+			) {
+				$new_settings[ $field ] = $existing_settings[ $field ];
+			}
+		}
+
+		return $new_settings;
+	}
+
+	/**
+	 * Merge credentials for all Providers in Feature settings.
+	 *
+	 * Iterates through all Provider settings and preserves existing credentials
+	 * when obfuscated values are submitted. This ensures switching Providers
+	 * doesn't save obfuscated values for inactive Providers.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $new_settings      The new Feature settings being saved.
+	 * @param array $existing_settings The current saved Feature settings.
+	 * @return array The settings with all Provider credentials properly merged.
+	 */
+	public static function merge_all_provider_credentials( array $new_settings, array $existing_settings ): array {
+		$profiles = ProviderProfiles::get_all_profiles();
+
+		// Get all Provider IDs from profiles.
+		$all_provider_ids = [];
+		foreach ( $profiles as $profile ) {
+			$all_provider_ids = array_merge( $all_provider_ids, $profile['provider_ids'] );
+		}
+
+		// Merge credentials for each Provider that has settings.
+		foreach ( $new_settings as $key => $value ) {
+			if ( is_array( $value ) && in_array( $key, $all_provider_ids, true ) ) {
+				$new_settings[ $key ] = self::merge_credentials(
+					$value,
+					$existing_settings[ $key ] ?? [],
+					$key
+				);
+			}
+		}
+
+		return $new_settings;
+	}
+}

--- a/includes/Classifai/Providers/ProviderProfiles.php
+++ b/includes/Classifai/Providers/ProviderProfiles.php
@@ -39,71 +39,85 @@ class ProviderProfiles {
 				'openai_text_to_speech',
 			],
 			'credential_fields' => [ 'api_key', 'authenticated' ],
+			'sensitive_fields'  => [ 'api_key' ],
 			'label'             => 'OpenAI',
 		],
 		'googleai'                => [
 			'provider_ids'      => [ 'googleai_gemini_api', 'googleai_images' ],
 			'credential_fields' => [ 'api_key', 'authenticated' ],
+			'sensitive_fields'  => [ 'api_key' ],
 			'label'             => 'Google AI',
 		],
 		'azure_openai'            => [
 			'provider_ids'      => [ 'azure_openai' ],
 			'credential_fields' => [ 'endpoint_url', 'api_key', 'deployment', 'authenticated' ],
+			'sensitive_fields'  => [ 'api_key' ],
 			'label'             => 'Azure OpenAI',
 		],
 		'azure_openai_embeddings' => [
 			'provider_ids'      => [ 'azure_openai_embeddings' ],
 			'credential_fields' => [ 'endpoint_url', 'api_key', 'deployment', 'authenticated' ],
+			'sensitive_fields'  => [ 'api_key' ],
 			'label'             => 'Azure OpenAI Embeddings',
 		],
 		'ms_computer_vision'      => [
 			'provider_ids'      => [ 'ms_computer_vision' ],
 			'credential_fields' => [ 'endpoint_url', 'api_key', 'authenticated' ],
+			'sensitive_fields'  => [ 'api_key' ],
 			'label'             => 'Azure AI Vision',
 		],
 		'ms_azure_text_to_speech' => [
 			'provider_ids'      => [ 'ms_azure_text_to_speech' ],
 			'credential_fields' => [ 'endpoint_url', 'api_key', 'authenticated' ],
+			'sensitive_fields'  => [ 'api_key' ],
 			'label'             => 'Azure Text to Speech',
 		],
 		'ibm_watson_nlu'          => [
 			'provider_ids'      => [ 'ibm_watson_nlu' ],
 			'credential_fields' => [ 'endpoint_url', 'apikey', 'username', 'password', 'authenticated' ],
+			'sensitive_fields'  => [ 'apikey', 'password' ],
 			'label'             => 'IBM Watson NLU',
 		],
 		'xai_grok'                => [
 			'provider_ids'      => [ 'xai_grok' ],
 			'credential_fields' => [ 'api_key', 'authenticated' ],
+			'sensitive_fields'  => [ 'api_key' ],
 			'label'             => 'XAI Grok',
 		],
 		'aws_polly'               => [
 			'provider_ids'      => [ 'aws_polly' ],
 			'credential_fields' => [ 'access_key_id', 'secret_access_key', 'aws_region', 'authenticated' ],
+			'sensitive_fields'  => [ 'secret_access_key' ],
 			'label'             => 'AWS Polly',
 		],
 		'elevenlabs'              => [
 			'provider_ids'      => [ 'elevenlabs_text_to_speech', 'elevenlabs_speech_to_text' ],
 			'credential_fields' => [ 'api_key', 'authenticated' ],
+			'sensitive_fields'  => [ 'api_key' ],
 			'label'             => 'ElevenLabs',
 		],
 		'togetherai_image'        => [
 			'provider_ids'      => [ 'togetherai_image' ],
 			'credential_fields' => [ 'api_key', 'authenticated' ],
+			'sensitive_fields'  => [ 'api_key' ],
 			'label'             => 'Together AI',
 		],
 		'stable_diffusion'        => [
 			'provider_ids'      => [ 'stable_diffusion' ],
 			'credential_fields' => [ 'endpoint_url', 'authenticated' ],
+			'sensitive_fields'  => [],
 			'label'             => 'Stable Diffusion',
 		],
 		'ollama'                  => [
 			'provider_ids'      => [ 'ollama', 'ollama_embeddings', 'ollama_multimodal' ],
 			'credential_fields' => [ 'endpoint_url', 'authenticated' ],
+			'sensitive_fields'  => [],
 			'label'             => 'Ollama',
 		],
 		'chrome_ai'               => [
 			'provider_ids'      => [ 'chrome_ai' ],
 			'credential_fields' => [],
+			'sensitive_fields'  => [],
 			'label'             => 'Chrome AI',
 		],
 	];
@@ -165,5 +179,16 @@ class ProviderProfiles {
 	public static function get_credential_fields( string $profile_id ): array {
 		$profiles = self::get_all_profiles();
 		return $profiles[ $profile_id ]['credential_fields'] ?? [];
+	}
+
+	/**
+	 * Get sensitive field names for a profile.
+	 *
+	 * @param string $profile_id Profile ID.
+	 * @return array List of field names.
+	 */
+	public static function get_sensitive_fields( string $profile_id ): array {
+		$profiles = self::get_all_profiles();
+		return $profiles[ $profile_id ]['sensitive_fields'] ?? [];
 	}
 }


### PR DESCRIPTION
### Description of the Change

At the moment, we grab all settings when rendering our settings page. This includes any Provider credentials that have previously been saved. This allows us to populate those credential fields with saved values so if any additional saves happen, we don't lose those credentials.

The issue here is that means these credentials are rendered in plain text, both in the API response that gets our settings and in the text inputs themselves. This isn't a huge deal as only administrators have access to these setting pages but it still isn't ideal.

This PR fixes that by adding in an `CredentialObfuscator` class that will take all the settings we have saved and will then obfuscate just the private credential fields (like API keys). This only happens when we get our settings to display, not when we get the settings to use in API requests. We then check that we don't have obfuscated credentials when saving and if we do, we ignore those credentials (so we don't save obfuscated credentials).

### How to test the Change

1. Add credentials for one or more Providers and save those
2. Refresh the page and then inspect the source, ensuring the value of the text input is obfuscated
3. Can also refresh the page and inspect the network requests to ensure the response from our settings endpoint returns obfuscated credentials
4. Ensure that if you re-save a previously configured Provider that the obfuscated credentials aren't saved to the database and the Provider continues to work

### Changelog Entry

> Security - Add a `CredentialObfuscator` class that will obfuscate any private credentials before rendering those.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
