### PR TITLE
(Hardening) Add a cap check before previewing classification of a post.

### DIFF
--- a/includes/Classifai/Providers/Watson/NLU.php
+++ b/includes/Classifai/Providers/Watson/NLU.php
@@ -250,7 +250,10 @@ class NLU extends Provider {
 			wp_send_json_error( esc_html__( 'Failed nonce check.', 'classifai' ) );
 		}
 
-		$post_id    = filter_input( INPUT_POST, 'post_id', FILTER_SANITIZE_NUMBER_INT );
+		$post_id = filter_input( INPUT_POST, 'post_id', FILTER_SANITIZE_NUMBER_INT );
+		if ( ! current_user_can( 'read_post', $post_id ) ) {
+			wp_send_json_error( esc_html__( 'You do not have permission to preview this post.', 'classifai' ) );
+		}
 		$classifier = new Classifier();
 		$normalizer = new \Classifai\Normalizer();
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This adds a read_post capability check to the Watson NLU classification preview ajax endpoint.

It's a very, very minor hardening issue as users can only access the nonce if they have the `manage_options` capability required to access the classifai settings page.

It protects against the case in which a developer has used the `map_meta_cap` filter to modify the permissions of users able to read posts. Without that use case it does nothing. 


### How to test the Change

1. Create and publish a post with dummy content
2. Enable Watson NLU Classification feature
3. Save the settings
4. Open your browser tools network tab. Your browser will need to have a feature where you can right click on a request and "copy as curl" (Firefox has this).
5. In the preview post option search for the post created by title
6. The preview should show as expected.
7. Copy the admin-ajax request used for the preview as curl
8. Run the curl code in your terminal
9. Ensure the preview data is shown in the terminal 
10. Add this code as an mu-plugin to prevent anyone from reading any posts
   ```php
   add_filter( 'map_meta_cap', function( $caps, $cap, $user_id, $args ) {
   	if ( 'read_post' === $cap ) {
   		$caps[] = 'do_not_allow';
   	}
   	return $caps;
   }, 10, 4 );
   ```
11. Re-run the curl command
12. Ensure the response contains the error "You do not have permission to preview this post"
13. Delete the mu-plugin code added above to avoid confusion later

### Changelog Entry
> Security - Hardening: add read post check for Watson NLU classification previewer

### Credits
Props @peterwilsoncc 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
