### PR TITLE
CSS updates to highlight terms in the previewer that are below the configured threshold 

### DIFF
--- a/src/js/settings/components/feature-additional-settings/classification-previewers/ibm-watson-nlu.js
+++ b/src/js/settings/components/feature-additional-settings/classification-previewers/ibm-watson-nlu.js
@@ -104,6 +104,21 @@ export function IBMWatsonNLUResults( { postId } ) {
 		keywords: responseData.keywords,
 	};
 
+	const hasAnyTags = Object.keys( renderData ).some(
+		( taxSlug ) => renderData[ taxSlug ].length > 0
+	);
+
+	const allBelowThreshold =
+		hasAnyTags &&
+		Object.keys( renderData ).every( ( taxSlug ) =>
+			renderData[ taxSlug ].every( ( tag ) => {
+				const threshold =
+					settings[ `${ taxMap[ taxSlug ] }_threshold` ];
+				const score = normalizeScore( tag.score || tag.relevance );
+				return score < threshold;
+			} )
+		);
+
 	const card = Object.keys( renderData ).map( ( taxSlug ) => {
 		const tags = renderData[ taxSlug ].map( ( tag, _index ) => {
 			const threshold = settings[ `${ taxMap[ taxSlug ] }_threshold` ];
@@ -169,16 +184,29 @@ export function IBMWatsonNLUResults( { postId } ) {
 
 	return card.length ? (
 		<>
-			<Notice
-				status="success"
-				isDismissible={ false }
-				className="classifai__classification-previewer-result-notice"
-			>
-				{ __(
-					'Results for each category are sorted in descending order, starting with the term that has the highest score, indicating the best match based on the embedding data.',
-					'classifai'
-				) }
-			</Notice>
+			{ allBelowThreshold ? (
+				<Notice
+					status="warning"
+					isDismissible={ false }
+					className="classifai__classification-previewer-result-notice"
+				>
+					{ __(
+						'None of the terms are above the configured threshold.',
+						'classifai'
+					) }
+				</Notice>
+			) : (
+				<Notice
+					status="success"
+					isDismissible={ false }
+					className="classifai__classification-previewer-result-notice"
+				>
+					{ __(
+						'Results for each category are sorted in descending order, starting with the term that has the highest score, indicating the best match based on the embedding data.',
+						'classifai'
+					) }
+				</Notice>
+			) }
 			{ card }
 		</>
 	) : null;

--- a/src/js/settings/components/feature-additional-settings/classification-previewers/ibm-watson-nlu.js
+++ b/src/js/settings/components/feature-additional-settings/classification-previewers/ibm-watson-nlu.js
@@ -112,7 +112,7 @@ export function IBMWatsonNLUResults( { postId } ) {
 			const scoreClass =
 				score >= threshold
 					? 'classifai__classification-previewer-result-tag--exceeds-threshold'
-					: '';
+					: 'classifai__classification-previewer-result-tag--below-threshold';
 
 			return (
 				<div

--- a/src/js/settings/components/feature-additional-settings/classification-previewers/ibm-watson-nlu.js
+++ b/src/js/settings/components/feature-additional-settings/classification-previewers/ibm-watson-nlu.js
@@ -184,7 +184,17 @@ export function IBMWatsonNLUResults( { postId } ) {
 
 	return card.length ? (
 		<>
-			{ allBelowThreshold ? (
+			<Notice
+				status="success"
+				isDismissible={ false }
+				className="classifai__classification-previewer-result-notice"
+			>
+				{ __(
+					'Results for each category are sorted in descending order, starting with the term that has the highest score, indicating the best match based on the embedding data.',
+					'classifai'
+				) }
+			</Notice>
+			{ allBelowThreshold && (
 				<Notice
 					status="warning"
 					isDismissible={ false }
@@ -192,17 +202,6 @@ export function IBMWatsonNLUResults( { postId } ) {
 				>
 					{ __(
 						'None of the terms are above the configured threshold.',
-						'classifai'
-					) }
-				</Notice>
-			) : (
-				<Notice
-					status="success"
-					isDismissible={ false }
-					className="classifai__classification-previewer-result-notice"
-				>
-					{ __(
-						'Results for each category are sorted in descending order, starting with the term that has the highest score, indicating the best match based on the embedding data.',
 						'classifai'
 					) }
 				</Notice>

--- a/src/js/settings/components/feature-additional-settings/classification-previewers/openai-embedding.js
+++ b/src/js/settings/components/feature-additional-settings/classification-previewers/openai-embedding.js
@@ -93,7 +93,7 @@ export function AzureOpenAIEmbeddingsResults( { postId } ) {
 			const scoreClass =
 				score >= threshold
 					? 'classifai__classification-previewer-result-tag--exceeds-threshold'
-					: '';
+					: 'classifai__classification-previewer-result-tag--below-threshold';
 
 			return (
 				<div

--- a/src/js/settings/components/feature-additional-settings/classification-previewers/openai-embedding.js
+++ b/src/js/settings/components/feature-additional-settings/classification-previewers/openai-embedding.js
@@ -85,6 +85,20 @@ export function AzureOpenAIEmbeddingsResults( { postId } ) {
 		} )();
 	}, [ postId ] );
 
+	const hasAnyTags = Object.keys( responseData ).some(
+		( taxSlug ) => responseData[ taxSlug ]?.data?.length > 0
+	);
+
+	const allBelowThreshold =
+		hasAnyTags &&
+		Object.keys( responseData ).every( ( taxSlug ) =>
+			( responseData[ taxSlug ]?.data || [] ).every( ( tag ) => {
+				const threshold = settings[ `${ taxSlug }_threshold` ];
+				const score = normalizeScore( tag.score );
+				return score < threshold;
+			} )
+		);
+
 	const card = Object.keys( responseData ).map( ( taxSlug ) => {
 		const tags = responseData[ taxSlug ]?.data.map( ( tag, _index ) => {
 			const threshold = settings[ `${ taxSlug }_threshold` ];
@@ -150,16 +164,29 @@ export function AzureOpenAIEmbeddingsResults( { postId } ) {
 
 	return card.length ? (
 		<>
-			<Notice
-				status="success"
-				isDismissible={ false }
-				className="classifai__classification-previewer-result-notice"
-			>
-				{ __(
-					'Results for each taxonomy are sorted in descending order, starting with the term that has the highest score, indicating the best match based on the embedding data.',
-					'classifai'
-				) }
-			</Notice>
+			{ allBelowThreshold ? (
+				<Notice
+					status="warning"
+					isDismissible={ false }
+					className="classifai__classification-previewer-result-notice"
+				>
+					{ __(
+						'None of the terms are above the configured threshold.',
+						'classifai'
+					) }
+				</Notice>
+			) : (
+				<Notice
+					status="success"
+					isDismissible={ false }
+					className="classifai__classification-previewer-result-notice"
+				>
+					{ __(
+						'Results for each taxonomy are sorted in descending order, starting with the term that has the highest score, indicating the best match based on the embedding data.',
+						'classifai'
+					) }
+				</Notice>
+			) }
 			{ card }
 		</>
 	) : null;

--- a/src/js/settings/components/feature-additional-settings/classification-previewers/openai-embedding.js
+++ b/src/js/settings/components/feature-additional-settings/classification-previewers/openai-embedding.js
@@ -164,7 +164,17 @@ export function AzureOpenAIEmbeddingsResults( { postId } ) {
 
 	return card.length ? (
 		<>
-			{ allBelowThreshold ? (
+			<Notice
+				status="success"
+				isDismissible={ false }
+				className="classifai__classification-previewer-result-notice"
+			>
+				{ __(
+					'Results for each taxonomy are sorted in descending order, starting with the term that has the highest score, indicating the best match based on the embedding data.',
+					'classifai'
+				) }
+			</Notice>
+			{ allBelowThreshold && (
 				<Notice
 					status="warning"
 					isDismissible={ false }
@@ -172,17 +182,6 @@ export function AzureOpenAIEmbeddingsResults( { postId } ) {
 				>
 					{ __(
 						'None of the terms are above the configured threshold.',
-						'classifai'
-					) }
-				</Notice>
-			) : (
-				<Notice
-					status="success"
-					isDismissible={ false }
-					className="classifai__classification-previewer-result-notice"
-				>
-					{ __(
-						'Results for each taxonomy are sorted in descending order, starting with the term that has the highest score, indicating the best match based on the embedding data.',
 						'classifai'
 					) }
 				</Notice>

--- a/src/scss/settings.scss
+++ b/src/scss/settings.scss
@@ -623,6 +623,21 @@
 	}
 }
 
+.classifai__classification-previewer-result-tag--below-threshold {
+	border-color: #e74c3c;
+	font-weight: bold;
+
+	.classifai__classification-previewer-result-tag-score {
+		color: #f1f1f1;
+		background-color: #e74c3c;
+		border-right: 1px solid #e74c3c;
+	}
+
+	.classifai__classification-previewer-result-tag-label {
+		color: #e74c3c;
+	}
+}
+
 .components-button.classifai__classification-previewer-close-button.is-link {
 	position: relative;
 	margin: 0 auto;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/classifai/issues/1056

### How to test the Change
1. Have the plugin configured with Classification enabled, and set Category to 20% and Tag set to 45%. These tests were done with the `OpenAI Embeddings Provider`.
2. Publish a new post on the site titled "Gettysburg Address" with the contents of the [Gettysburg Address](https://en.wikipedia.org/wiki/Gettysburg_Address#Text)
3. Create a new Category term "History"
4. Create new Tags for "Civil War" and "Gettysburg"
5. In Classification settings > Previewer, search for the Gettysburg Address post.
6. Inspect the terms and verify they have valid CSS classed based on their score and the configured thresholds, either the existing `classifai__classification-previewer-result-tag--exceeds-threshold` class, or the `classifai__classification-previewer-result-tag--below-threshold` added as part of this PR.

Sample Screenshot:
<img width="498" height="310" alt="image" src="https://github.com/user-attachments/assets/32c8e14a-32e3-4a08-b0cd-dbc5f22ca864" />


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Added new `classifai__classification-previewer-result-tag--below-threshold` class and CSS colors to terms in the previewer for terms that don't meet the configured threshold

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, ...

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2F10up%2Fclassifai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1058-85fff9823c7981dc8adac71d82995c86e2c98788.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->