### PR TITLE
adds TTS generation status polling in Classic Editor

### DIFF
--- a/includes/Classifai/Features/TextToSpeech.php
+++ b/includes/Classifai/Features/TextToSpeech.php
@@ -105,6 +105,7 @@ class TextToSpeech extends Feature {
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_box' ] );
 		add_action( 'admin_notices', [ $this, 'show_error_if' ] );
 		add_action( 'save_post', [ $this, 'save_post_metadata' ], 5 );
+		add_action( 'wp_ajax_classifai_get_tts_status', [ $this, 'ajax_get_audio_generation_status' ] );
 	}
 
 	/**
@@ -419,6 +420,36 @@ class TextToSpeech extends Feature {
 	public function render_meta_box( \WP_Post $post ) {
 		wp_nonce_field( 'classifai_text_to_speech_meta_action', 'classifai_text_to_speech_meta' );
 
+		$is_as_scheduled_job =
+			function_exists( 'as_has_scheduled_action' ) &&
+			\as_has_scheduled_action(
+				'classifai_schedule_text_to_speech_job',
+				[
+					'post_id'         => (int) $post->ID,
+					'calling_user_id' => get_current_user_id(),
+				],
+				'classifai'
+			);
+
+		if ( $is_as_scheduled_job ) :
+			?>
+			<p class="classifai-tts-status" data-post-id="<?php echo esc_attr( (string) $post->ID ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'classifai_tts_status' ) ); ?>">
+				<?php esc_html_e( 'Audio generation is in progress…', 'classifai' ); ?>
+			</p>
+			<?php
+		else :
+			$this->render_audio_generation_ui( $post );
+		endif;
+	}
+
+	/**
+	 * Render the post-generation UI for the TTS meta box. Used both on initial
+	 * render and via AJAX after a queued job completes so the meta box
+	 * matches a fresh page load.
+	 *
+	 * @param \WP_Post $post WP_Post object.
+	 */
+	public function render_audio_generation_ui( \WP_Post $post ) {
 		$source_url = false;
 		$audio_id   = get_post_meta( $post->ID, self::AUDIO_ID_KEY, true );
 
@@ -445,24 +476,7 @@ class TextToSpeech extends Feature {
 		if ( $post_type ) {
 			$post_type_label = $post_type->labels->singular_name;
 		}
-
-		$is_as_scheduled_job =
-			function_exists( 'as_has_scheduled_action' ) &&
-			\as_has_scheduled_action(
-				'classifai_schedule_text_to_speech_job',
-				[
-					'post_id'         => (int) $post->ID,
-					'calling_user_id' => get_current_user_id(),
-				],
-				'classifai'
-			);
-
-		if ( $is_as_scheduled_job ) : ?>
-		<p>
-			<?php esc_html_e( 'Audio generation is in progress…', 'classifai' ); ?>
-		</p>
-		<?php else : ?>
-
+		?>
 		<p>
 			<label for="classifai_synthesize_speech">
 				<input type="checkbox" value="1" id="classifai_synthesize_speech" name="classifai_synthesize_speech" <?php checked( $process_content ); ?> />
@@ -488,8 +502,6 @@ class TextToSpeech extends Feature {
 			</span>
 		</p>
 
-		<?php endif; ?>
-
 		<?php
 		if ( $source_url ) {
 			$cache_busting_url = add_query_arg(
@@ -499,13 +511,64 @@ class TextToSpeech extends Feature {
 				$source_url
 			);
 			?>
-
 			<p>
 				<audio id="classifai-audio-preview" controls controlslist="nodownload" src="<?php echo esc_url( $cache_busting_url ); ?>"></audio>
 			</p>
-
 			<?php
 		}
+	}
+
+	/**
+	 * AJAX handler for the Classic Editor meta box's polling. Returns the
+	 * current audio generation status for the given post id.
+	 */
+	public function ajax_get_audio_generation_status() {
+		check_ajax_referer( 'classifai_tts_status', 'nonce' );
+
+		$post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+
+		if ( ! $post_id || ! current_user_can( 'edit_post', $post_id ) ) {
+			wp_send_json_error( [ 'message' => __( 'Invalid post.', 'classifai' ) ], 403 );
+		}
+
+		$in_progress =
+			function_exists( 'as_has_scheduled_action' ) &&
+			\as_has_scheduled_action(
+				'classifai_schedule_text_to_speech_job',
+				[
+					'post_id'         => $post_id,
+					'calling_user_id' => get_current_user_id(),
+				],
+				'classifai'
+			);
+
+		$error_message = '';
+		$raw_error     = get_post_meta( $post_id, '_classifai_text_to_speech_error', true );
+
+		if ( ! empty( $raw_error ) ) {
+			$decoded = (array) json_decode( (string) $raw_error );
+			if ( ! empty( $decoded['message'] ) ) {
+				$error_message = (string) $decoded['message'];
+			}
+		}
+
+		$html = '';
+		if ( ! $in_progress && ! $error_message ) {
+			$post = get_post( $post_id );
+			if ( $post ) {
+				ob_start();
+				$this->render_audio_generation_ui( $post );
+				$html = (string) ob_get_clean();
+			}
+		}
+
+		wp_send_json_success(
+			[
+				'inProgress' => (bool) $in_progress,
+				'error'      => $error_message,
+				'html'       => $html,
+			]
+		);
 	}
 
 	/**

--- a/includes/Classifai/Features/TextToSpeech.php
+++ b/includes/Classifai/Features/TextToSpeech.php
@@ -106,6 +106,40 @@ class TextToSpeech extends Feature {
 		add_action( 'admin_notices', [ $this, 'show_error_if' ] );
 		add_action( 'save_post', [ $this, 'save_post_metadata' ], 5 );
 		add_action( 'wp_ajax_classifai_get_tts_status', [ $this, 'ajax_get_audio_generation_status' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+	}
+
+	/**
+	 * Enqueue the Classic Editor polling script. Loaded in Classic Editor only when the feature is enabled.
+	 *
+	 * @param string $hook_suffix The current admin page.
+	 */
+	public function enqueue_admin_assets( string $hook_suffix ) {
+		if ( 'post.php' !== $hook_suffix && 'post-new.php' !== $hook_suffix ) {
+			return;
+		}
+
+		if ( ! $this->is_feature_enabled() ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+
+		if ( ! $screen || $screen->is_block_editor() ) {
+			return;
+		}
+
+		if ( ! in_array( $screen->post_type, $this->get_supported_post_types(), true ) ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'classifai-plugin-classic-text-to-speech',
+			CLASSIFAI_PLUGIN_URL . 'dist/classifai-plugin-classic-text-to-speech.js',
+			get_asset_info( 'classifai-plugin-classic-text-to-speech', 'dependencies' ),
+			get_asset_info( 'classifai-plugin-classic-text-to-speech', 'version' ),
+			true
+		);
 	}
 
 	/**
@@ -525,7 +559,7 @@ class TextToSpeech extends Feature {
 	public function ajax_get_audio_generation_status() {
 		check_ajax_referer( 'classifai_tts_status', 'nonce' );
 
-		$post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+		$post_id = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
 
 		if ( ! $post_id || ! current_user_can( 'edit_post', $post_id ) ) {
 			wp_send_json_error( [ 'message' => __( 'Invalid post.', 'classifai' ) ], 403 );

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -461,7 +461,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			return;
 		}
 
-		const POLL_INTERVAL_MS = 5000;
+		const POLL_INTERVAL_MS = 10000;
 
 		const renderComplete = ( { error, html } ) => {
 			if ( error ) {

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -445,60 +445,6 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	} );
 } )( jQuery );
 
-// Poll admin-ajax to update the Classic Editor TTS meta box once audio generation completes.
-( function ( $ ) {
-	$( function () {
-		const $status = $( '.classifai-tts-status' );
-
-		if ( ! $status.length ) {
-			return;
-		}
-
-		const postId = parseInt( $status.data( 'post-id' ), 10 );
-		const nonce = $status.data( 'nonce' );
-
-		if ( ! postId || ! nonce ) {
-			return;
-		}
-
-		const POLL_INTERVAL_MS = 10000;
-
-		const renderComplete = ( { error, html } ) => {
-			if ( error ) {
-				$status.text( error );
-				return;
-			}
-
-			if ( html ) {
-				$status.replaceWith( html );
-			}
-		};
-
-		const timer = setInterval( () => {
-			$.ajax( {
-				url: ajaxurl, // eslint-disable-line no-undef
-				type: 'POST',
-				data: {
-					action: 'classifai_get_tts_status',
-					nonce,
-					post_id: postId,
-				},
-			} ).done( ( response ) => {
-				if ( ! response || ! response.success || ! response.data ) {
-					return;
-				}
-
-				if ( response.data.inProgress ) {
-					return;
-				}
-
-				clearInterval( timer );
-				renderComplete( response.data );
-			} );
-		}, POLL_INTERVAL_MS );
-	} );
-} )( jQuery );
-
 // Update the Term Cleanup status.
 ( function ( $ ) {
 	const statusWrapper = $( '.classifai-term-cleanup-process-status' );

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -445,6 +445,60 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	} );
 } )( jQuery );
 
+// Poll admin-ajax to update the Classic Editor TTS meta box once audio generation completes.
+( function ( $ ) {
+	$( function () {
+		const $status = $( '.classifai-tts-status' );
+
+		if ( ! $status.length ) {
+			return;
+		}
+
+		const postId = parseInt( $status.data( 'post-id' ), 10 );
+		const nonce = $status.data( 'nonce' );
+
+		if ( ! postId || ! nonce ) {
+			return;
+		}
+
+		const POLL_INTERVAL_MS = 5000;
+
+		const renderComplete = ( { error, html } ) => {
+			if ( error ) {
+				$status.text( error );
+				return;
+			}
+
+			if ( html ) {
+				$status.replaceWith( html );
+			}
+		};
+
+		const timer = setInterval( () => {
+			$.ajax( {
+				url: ajaxurl, // eslint-disable-line no-undef
+				type: 'POST',
+				data: {
+					action: 'classifai_get_tts_status',
+					nonce,
+					post_id: postId,
+				},
+			} ).done( ( response ) => {
+				if ( ! response || ! response.success || ! response.data ) {
+					return;
+				}
+
+				if ( response.data.inProgress ) {
+					return;
+				}
+
+				clearInterval( timer );
+				renderComplete( response.data );
+			} );
+		}, POLL_INTERVAL_MS );
+	} );
+} )( jQuery );
+
 // Update the Term Cleanup status.
 ( function ( $ ) {
 	const statusWrapper = $( '.classifai-term-cleanup-process-status' );

--- a/src/js/features/text-to-speech/classic/index.js
+++ b/src/js/features/text-to-speech/classic/index.js
@@ -1,0 +1,69 @@
+// Poll admin-ajax to update the Classic Editor TTS meta box once audio generation completes.
+const init = () => {
+	const status = document.querySelector( '.classifai-tts-status' );
+
+	if ( ! status ) {
+		return;
+	}
+
+	const postId = parseInt( status.dataset.postId, 10 );
+	const nonce = status.dataset.nonce;
+
+	if ( ! postId || ! nonce ) {
+		return;
+	}
+
+	const POLL_INTERVAL_MS = 10000;
+
+	const renderComplete = ( { error, html } ) => {
+		if ( error ) {
+			status.textContent = error;
+			return;
+		}
+
+		if ( html ) {
+			status.outerHTML = html;
+		}
+	};
+
+	const timer = setInterval( async () => {
+		try {
+			const body = new URLSearchParams( {
+				action: 'classifai_get_tts_status',
+				nonce,
+				post_id: postId,
+			} );
+
+			const response = await fetch( window.ajaxurl, {
+				method: 'POST',
+				credentials: 'same-origin',
+				body,
+			} );
+
+			if ( ! response.ok ) {
+				return;
+			}
+
+			const json = await response.json();
+
+			if ( ! json || ! json.success || ! json.data ) {
+				return;
+			}
+
+			if ( json.data.inProgress ) {
+				return;
+			}
+
+			clearInterval( timer );
+			renderComplete( json.data );
+		} catch ( e ) {
+			// Swallow transient fetch errors and try again next tick.
+		}
+	}, POLL_INTERVAL_MS );
+};
+
+if ( document.readyState !== 'loading' ) {
+	init();
+} else {
+	document.addEventListener( 'DOMContentLoaded', init );
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ module.exports = {
 		'classifai-plugin-classification-pre-publish': './src/js/features/classification/pre-publish-panel.js',
 		'classifai-plugin-fill': './src/js/features/slot-fill/index.js',
 		'classifai-plugin-text-to-speech': './src/js/features/text-to-speech/index.js',
+		'classifai-plugin-classic-text-to-speech': './src/js/features/text-to-speech/classic/index.js',
 		'classifai-plugin-text-to-speech-frontend': './src/js/features/text-to-speech/frontend/index.js',
 		'classifai-plugin-content-resizing': './src/js/features/content-resizing/index.js',
 		'classifai-plugin-title-generation': './src/js/features/title-generation/index.js',


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

3.8.0 introduced Action Scheduler support for audio generation. The Classic Editor meta box renders the "in-progress" state when the audio generation is triggered so the "Audio generation is in progress…" message persists indefinitely with no client-side mechanism to detect completion.

This PR adds a 10-second polling. When the scheduled action completes, the in-progress text is replaced with the post-completion UI (checkboxes + audio player), without requiring a page reload.

Post-fix video (speed up 3x)

https://github.com/user-attachments/assets/03b62c90-4d46-4712-aafa-9326bd292726


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1072

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Enable Text to Speech with a configured provider; switch to Classic Editor.
2. Edit a post with content, tick **Enable audio generation**, click Update.
3. Confirm "Audio generation is in progress…" appears, and DevTools → Network shows `admin-ajax.php` POSTs every 10s with`action=classifai_get_tts_status`.                                                                                                                    
4. As soon as the TTS generation completes, the meta box swaps to the post-completion UI (two checkboxes + audio player) without a reload.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

 > Fixed - Classic Editor TTS meta box no longer hangs at "Audio generation is in progress…"; it now polls and swaps to the completed state without requiring a page reload.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, ...

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
