### PR TITLE
Fix a potential fatal error when building user roles

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.8'}
+          - {name: 'WP minimum', version: 'https://wordpress.org/wordpress-6.8.zip'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/includes/Classifai/Features/Feature.php
+++ b/includes/Classifai/Features/Feature.php
@@ -99,8 +99,16 @@ abstract class Feature {
 		}
 
 		$default_settings = $this->get_default_settings();
-		$this->roles      = get_editable_roles() ?? [];
-		$this->roles      = array_combine( array_keys( $this->roles ), array_column( $this->roles, 'name' ) );
+		$editable_roles   = get_editable_roles() ?? [];
+		$this->roles      = [];
+
+		foreach ( $editable_roles as $role_key => $role ) {
+			if ( empty( $role['name'] ) ) {
+				continue;
+			}
+
+			$this->roles[ $role_key ] = $role['name'];
+		}
 
 		// Remove subscriber from the list of roles.
 		unset( $this->roles['subscriber'] );

--- a/includes/Classifai/Features/ImageGeneration.php
+++ b/includes/Classifai/Features/ImageGeneration.php
@@ -441,14 +441,16 @@ class ImageGeneration extends Feature {
 		$default_settings = $this->get_default_settings();
 
 		// Get all roles that have the upload_files cap.
-		$roles = get_editable_roles() ?? [];
-		$roles = array_filter(
-			$roles,
-			function ( $role ) {
-				return isset( $role['capabilities'], $role['capabilities']['upload_files'] ) && $role['capabilities']['upload_files'];
+		$editable_roles = get_editable_roles() ?? [];
+		$roles          = [];
+
+		foreach ( $editable_roles as $role_key => $role ) {
+			if ( empty( $role['name'] ) || empty( $role['capabilities']['upload_files'] ) ) {
+				continue;
 			}
-		);
-		$roles = array_combine( array_keys( $roles ), array_column( $roles, 'name' ) );
+
+			$roles[ $role_key ] = $role['name'];
+		}
 
 		/**
 		 * Filter the allowed WordPress roles for image generation.

--- a/tests/bin/set-core-version.js
+++ b/tests/bin/set-core-version.js
@@ -22,7 +22,7 @@ if ( args[ 0 ] === 'latest' ) {
 config.core = args[ 0 ];
 
 // eslint-disable-next-line no-useless-escape
-if ( ! config.core.match( /^WordPress\/WordPress\#/ ) ) {
+if ( ! config.core.match( /^(https?:\/\/|WordPress\/WordPress\#)/ ) ) {
 	config.core = `WordPress/WordPress#${ config.core }`;
 }
 


### PR DESCRIPTION
### Description of the Change

We had a fatal error reported:

> PHP Fatal error: Uncaught ValueError: array_combine(): Argument number 1 ($keys) and argument number 2 ($values) must have the same number of elements

This pointed to our code that builds the list of roles that each Feature uses to determine which roles have access to the Feature. In looking at that code, if a role somehow doesn't have the `name` attribute set, you end up with two arrays of differing lengths and thus running `array_combine` will throw an error.

In a standard WordPress install I couldn't reproduce this but it seems like a good place to harden our code a bit. This updates both our general `setup_roles` method and the `setup_roles` method we run in the Image Generation Feature.

### How to test the Change

1. Checkout this PR
2. Enable a Feature like Title Generation
3. Go to the settings for that Feature and toggle open the `User Permissions` panel
4. Ensure you see all expected roles in the `Allowed roles` list
5. Go to the settings for Image Generation and check there as well
6. Ensure if you disallow a user role, like Administrator, that users with that role can't use the Feature

### Changelog Entry

> Fixed - Better handling of user roles to avoid a potential fatal error

### Credits

Props @dkotter, @gthayer 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
