### PR TITLE
Bump WordPress minimum from 6.8 to 6.9

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.8'}
+          - {name: 'WP minimum', version: 'https://wordpress.org/wordpress-6.9.zip'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Session.vim
 .vscode
 .cursor
 .claude
+CLAUDE.md
 
 # Mac OSX
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Tap into leading cloud-based services like [OpenAI](https://openai.com/), [Micro
 ## Requirements
 
 * PHP 7.4+
-* [WordPress](http://wordpress.org) 6.8+
+* [WordPress](http://wordpress.org) 6.9+
 * Each individual Feature may have its own requirements, please refer to the [ClassifAI documentation site](https://10up.github.io/classifai/get-started/#requirements) for detailed requirements.
 
 ## Pricing

--- a/classifai.php
+++ b/classifai.php
@@ -5,7 +5,7 @@
  * Update URI:        https://classifaiplugin.com
  * Description:       Enhance your WordPress content with Artificial Intelligence and Machine Learning services.
  * Version:           3.9.0-dev
- * Requires at least: 6.8
+ * Requires at least: 6.9
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com

--- a/phpcs-compat.xml.dist
+++ b/phpcs-compat.xml.dist
@@ -13,6 +13,6 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<config name="minimum_supported_wp_version" value="6.8"/>
+	<config name="minimum_supported_wp_version" value="6.9"/>
 	<config name="testVersion" value="7.4-"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,7 @@
 
 	<exclude-pattern>*/tests/*</exclude-pattern>
 
-	<config name="minimum_supported_wp_version" value="6.8"/>
+	<config name="minimum_supported_wp_version" value="6.9"/>
 	<config name="testVersion" value="7.4-"/>
 
 	<!-- Exclude the PHPCompatibilityWP ruleset -->

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,4 +21,4 @@ parameters:
 		- '#Constant CLASSIFAI_.+ not found#'
 		- '#Constant WATSON_.+ not found#'
 	WPCompat:
-		requiresAtLeast: '6.8'
+		requiresAtLeast: '6.9'

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === ClassifAI ===
 Contributors:      10up, jeffpaul, dkotter
 Tags:              AI, Artificial Intelligence, ML, Machine Learning, Microsoft Azure, IBM Watson, OpenAI, ChatGPT, Content Tagging, Classification, Smart Cropping, Alt Text
-Requires at least: 6.8
+Requires at least: 6.9
 Tested up to:      7.0
 Requires PHP:      7.4
 Stable tag:        3.8.0
@@ -41,7 +41,7 @@ Tap into leading cloud-based services like [OpenAI](https://openai.com/), [Micro
 == Requirements ==
 
 * PHP 7.4+
-* [WordPress](http://wordpress.org) 6.8+
+* [WordPress](http://wordpress.org) 6.9+
 * Each individual Feature may have its own requirements, please refer to the [ClassifAI documentation site](https://10up.github.io/classifai/get-started/#requirements) for detailed requirements.
 
 == Frequently Asked Questions ==

--- a/tests/bin/set-core-version.js
+++ b/tests/bin/set-core-version.js
@@ -22,7 +22,7 @@ if ( args[ 0 ] === 'latest' ) {
 config.core = args[ 0 ];
 
 // eslint-disable-next-line no-useless-escape
-if ( ! config.core.match( /^WordPress\/WordPress\#/ ) ) {
+if ( ! config.core.match( /^(https?:\/\/|WordPress\/WordPress\#)/ ) ) {
 	config.core = `WordPress/WordPress#${ config.core }`;
 }
 

--- a/wp-hooks-docs/docs/01.get-started/index.md
+++ b/wp-hooks-docs/docs/01.get-started/index.md
@@ -13,7 +13,7 @@ Tap into leading cloud-based services like [OpenAI](https://openai.com/), [Micro
 ## Requirements
 
 * PHP 7.4+
-* [WordPress](http://wordpress.org) 6.8+
+* [WordPress](http://wordpress.org) 6.9+
 * To utilize the NLU Language Processing functionality, you will need an active [IBM Watson](https://cloud.ibm.com/registration) account.
 * To utilize the ChatGPT, Embeddings, Text to Speech or Speech to Text Language Processing functionality or Image Generation functionality, you will need an active [OpenAI](https://platform.openai.com/signup) account.
 * To utilize the Azure AI Vision Image Processing functionality or Text to Speech Language Processing functionality, you will need an active [Microsoft Azure](https://signup.azure.com/signup) account.


### PR DESCRIPTION
### Description of the Change

Bumps our minimum WordPress version from 6.8 to 6.9

### How to test the Change

Ensure tests pass on this PR

### Changelog Entry

> Changed - Bump WordPress minimum from 6.8 to 6.9

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
