### PR TITLE
Update AI models to their latest

### DIFF
--- a/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
+++ b/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
@@ -37,7 +37,7 @@ class GeminiAPI extends Provider {
 	 *
 	 * @var string
 	 */
-	protected $default_model = 'models/gemini-2.5-flash-preview-05-20';
+	protected $default_model = 'models/gemini-3.5-flash';
 
 	/**
 	 * GeminiAPI constructor.

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -41,21 +41,21 @@ class ChatGPT extends Provider {
 	 *
 	 * @var string
 	 */
-	protected $chatgpt_model = 'gpt-4o-mini';
+	protected $chatgpt_model = 'gpt-5.4-mini';
 
 	/**
 	 * OpenAI Vision model
 	 *
 	 * @var string
 	 */
-	protected $vision_model = 'gpt-4.1-mini';
+	protected $vision_model = 'gpt-5.4-mini';
 
 	/**
 	 * Maximum number of tokens our model supports
 	 *
 	 * @var int
 	 */
-	protected $max_tokens = 128000;
+	protected $max_tokens = 400000;
 
 	/**
 	 * Image types to process.

--- a/includes/Classifai/Providers/OpenAI/Images.php
+++ b/includes/Classifai/Providers/OpenAI/Images.php
@@ -32,7 +32,7 @@ class Images extends Provider {
 	 *
 	 * @var string
 	 */
-	protected $model = 'gpt-image-1';
+	protected $model = 'gpt-image-2';
 
 	/**
 	 * Maximum number of characters a prompt can have.
@@ -364,8 +364,8 @@ class Images extends Provider {
 			'style'           => sanitize_text_field( $args['style'] ),
 		];
 
-		if ( 'gpt-image-1' === $model ) {
-			// The gpt-image-1 model doesn't support response_format or style.
+		if ( 'gpt-image-1' === $model || 'gpt-image-2' === $model ) {
+			// The gpt-image models don't support response_format or style.
 			unset( $body['response_format'] );
 			unset( $body['style'] );
 		} elseif ( 'dall-e-3' === $model ) {

--- a/includes/Classifai/Providers/XAI/Grok.php
+++ b/includes/Classifai/Providers/XAI/Grok.php
@@ -47,21 +47,21 @@ class Grok extends Provider {
 	 *
 	 * @var string
 	 */
-	protected $default_model = 'grok-2-1212';
+	protected $default_model = 'grok-4.3';
 
 	/**
 	 * xAI Grok default vision model
 	 *
 	 * @var string
 	 */
-	protected $default_vision_model = 'grok-2-vision-1212';
+	protected $default_vision_model = 'grok-4.3';
 
 	/**
 	 * Maximum number of tokens our model supports
 	 *
 	 * @var int
 	 */
-	protected $max_tokens = 131072;
+	protected $max_tokens = 1000000;
 
 	/**
 	 * xAI Grok constructor.


### PR DESCRIPTION
### Description of the Change

We are out of date on a handful of the default models we set so this PR updates all of those to their latest.

The one it doesn't update is the Google image generation model. While it would be great to set this to Nano Banana 2, the request format for that is different so it's not as simple as just changing the model. Since we're looking to migrate to the new AI Client and Connectors in WP 7.0, seems not worth the effort to make that change as we'll be able to take advantage of that once that migration is done.

### How to test the Change

Verify any Features that rely on these changed models still work:

- Text generation with Google
- Text generation with OpenAI
- Vision generation with OpenAI
- Image generation with OpenAI
- Text generation with xAI
- Vision generation with xAI

### Changelog Entry

> Changed - Update from `gemini-2.5-flash` to `gemini-3.5-flash` as our default Gemini text generation model.
> Changed - Update from `gpt-4o-mini` to `gpt-5.4-mini`, `gpt-4.1-mini` to `gpt-5.4-mini` and `gpt-image-1` to `gpt-image-2` as our default OpenAI text generation, vision generation and image generation models, respectively.
> Changed - Update from `grok-2` to `grok-4.3` as our default xAI text and vision generation model.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
