### PR TITLE
Move prompts to their own files for easier management

### DIFF
--- a/includes/Classifai/Features/ContentGeneration.php
+++ b/includes/Classifai/Features/ContentGeneration.php
@@ -30,59 +30,6 @@ class ContentGeneration extends Feature {
 	const ID = 'feature_content_generation';
 
 	/**
-	 * Prompt for creating content.
-	 *
-	 * @var string
-	 */
-	public $prompt = 'Act as an experienced SEO copywriter tasked with writing an article based off of a given summary and an optionally provided title. Your goal is to craft a compelling, informative piece that adheres to SEO best practices, is well-researched, engaging to the target audience, and structured in a way that enhances readability. Incorporate relevant keywords naturally throughout the text, without compromising the flow or quality of the content. Ensure that the article provides value to the reader. Only return the contents of the article, not the title or other commentary.';
-
-	// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
-	/**
-	 * The format of how we'd like content to be returned.
-	 *
-	 * @var string
-	 */
-	public $return_format = <<<'INSTRUCTION'
-The content returned should be valid WordPress block markup as described below, using elements like paragraphs and headings where appropriate. Be selective on the elements you use, defaulting to paragraphs. Please check the content before returning to ensure each element has proper opening and closing block markup and HTML tags and any required block attributes. Ensure elements don't nest inside each other, i.e. don't put a paragraph inside another paragraph or a list within a paragraph. Don't start the content with a heading, start with a paragraph.
-
-Markup available to use; don't use any other blocks, even if requested:
-<!-- wp:paragraph -->
-<p>CONTENT</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:heading -->
-<h2 class="wp-block-heading">CONTENT</h2>
-<!-- /wp:heading -->
-
-<!-- wp:table -->
-<figure class="wp-block-table"><table class="has-fixed-layout"><tbody><tr><td>CONTENT</td></tr><tr><td>CONTENT</td></tr></tbody></table></figure>
-<!-- /wp:table -->
-
-<!-- wp:quote -->
-<blockquote class="wp-block-quote">
-<p>CONTENT</p>
-</blockquote>
-<!-- /wp:quote -->
-
-<!-- wp:pullquote -->
-<figure class="wp-block-pullquote"><blockquote><p>QUOTE</p><cite>AUTHOR</cite></blockquote></figure>
-<!-- /wp:pullquote -->
-
-<!-- wp:list -->
-<ul class="wp-block-list">
-<li>CONTENT</li>
-</ul>
-<!-- /wp:list -->
-
-<!-- wp:list {"ordered":true} -->
-<ol class="wp-block-list">
-<li>CONTENT</li>
-</ol>
-<!-- /wp:list -->
-INSTRUCTION;
-	// phpcs:enable
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -267,7 +214,7 @@ INSTRUCTION;
 			'prompt'             => [
 				[
 					'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
-					'prompt'   => $this->prompt,
+					'prompt'   => $this->get_prompt( 'default' ),
 					'original' => 1,
 				],
 			],
@@ -292,7 +239,7 @@ INSTRUCTION;
 		if ( $settings && ! empty( $settings['prompt'] ) ) {
 			foreach ( $settings['prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings['prompt'][ $key ]['prompt'] = $this->prompt;
+					$settings['prompt'][ $key ]['prompt'] = $this->get_prompt( 'default' );
 					break;
 				}
 			}

--- a/includes/Classifai/Features/ContentResizing.php
+++ b/includes/Classifai/Features/ContentResizing.php
@@ -32,20 +32,6 @@ class ContentResizing extends Feature {
 	const ID = 'feature_content_resizing';
 
 	/**
-	 * Prompt for shrinking content.
-	 *
-	 * @var string
-	 */
-	public $condense_prompt = 'Decrease the content length no more than 2 to 4 sentences.';
-
-	/**
-	 * Prompt for growing content.
-	 *
-	 * @var string
-	 */
-	public $expand_prompt = 'Increase the content length no more than 2 to 4 sentences.';
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -268,14 +254,14 @@ class ContentResizing extends Feature {
 			'condense_text_prompt' => [
 				[
 					'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
-					'prompt'   => $this->condense_prompt,
+					'prompt'   => $this->get_prompt( 'condense' ),
 					'original' => 1,
 				],
 			],
 			'expand_text_prompt'   => [
 				[
 					'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
-					'prompt'   => $this->expand_prompt,
+					'prompt'   => $this->get_prompt( 'expand' ),
 					'original' => 1,
 				],
 			],
@@ -296,7 +282,7 @@ class ContentResizing extends Feature {
 		if ( $settings && ! empty( $settings['condense_text_prompt'] ) ) {
 			foreach ( $settings['condense_text_prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings['condense_text_prompt'][ $key ]['prompt'] = $this->condense_prompt;
+					$settings['condense_text_prompt'][ $key ]['prompt'] = $this->get_prompt( 'condense' );
 					break;
 				}
 			}
@@ -305,7 +291,7 @@ class ContentResizing extends Feature {
 		if ( $settings && ! empty( $settings['expand_text_prompt'] ) ) {
 			foreach ( $settings['expand_text_prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings['expand_text_prompt'][ $key ]['prompt'] = $this->expand_prompt;
+					$settings['expand_text_prompt'][ $key ]['prompt'] = $this->get_prompt( 'expand' );
 					break;
 				}
 			}

--- a/includes/Classifai/Features/DescriptiveTextGenerator.php
+++ b/includes/Classifai/Features/DescriptiveTextGenerator.php
@@ -29,13 +29,6 @@ class DescriptiveTextGenerator extends Feature {
 	const ID = 'feature_descriptive_text_generator';
 
 	/**
-	 * Prompt for generating descriptive text.
-	 *
-	 * @var string
-	 */
-	public $prompt = 'You are an assistant that generates descriptions of images that are used on a website. You will be provided with an image and will describe the main item you see in the image, giving details but staying concise. There is no need to say "the image contains" or similar, just describe what is actually in the image. This text will be important for screen readers, so make sure it is descriptive and accurate but not overly verbose. Before returning the text, re-evaluate your response and ensure you are following the above points, in particular ensuring the text is concise.';
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -428,7 +421,7 @@ class DescriptiveTextGenerator extends Feature {
 		if ( $settings && ! empty( $settings[ ChatGPT::ID ]['prompt'] ) ) {
 			foreach ( $settings[ ChatGPT::ID ]['prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings[ ChatGPT::ID ]['prompt'][ $key ]['prompt'] = $this->prompt;
+					$settings[ ChatGPT::ID ]['prompt'][ $key ]['prompt'] = $this->get_prompt( 'default' );
 					break;
 				}
 			}
@@ -437,7 +430,7 @@ class DescriptiveTextGenerator extends Feature {
 		if ( $settings && ! empty( $settings[ Grok::ID ]['prompt'] ) ) {
 			foreach ( $settings[ Grok::ID ]['prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings[ Grok::ID ]['prompt'][ $key ]['prompt'] = $this->prompt;
+					$settings[ Grok::ID ]['prompt'][ $key ]['prompt'] = $this->get_prompt( 'default' );
 					break;
 				}
 			}
@@ -446,7 +439,7 @@ class DescriptiveTextGenerator extends Feature {
 		if ( $settings && ! empty( $settings[ OllamaMM::ID ]['prompt'] ) ) {
 			foreach ( $settings[ OllamaMM::ID ]['prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings[ OllamaMM::ID ]['prompt'][ $key ]['prompt'] = $this->prompt;
+					$settings[ OllamaMM::ID ]['prompt'][ $key ]['prompt'] = $this->get_prompt( 'default' );
 					break;
 				}
 			}

--- a/includes/Classifai/Features/ExcerptGeneration.php
+++ b/includes/Classifai/Features/ExcerptGeneration.php
@@ -32,20 +32,6 @@ class ExcerptGeneration extends Feature {
 	const ID = 'feature_excerpt_generation';
 
 	/**
-	 * Prompt for generating excerpts.
-	 *
-	 * @var string
-	 */
-	public $prompt = 'Summarize the following message using a maximum of {{WORDS}} words. The original message was written by {{AUTHOR}}. Ensure this summary pairs well with the following text: {{TITLE}}.';
-
-	/**
-	 * Prompt for generating excerpts for WooCommerce Products.
-	 *
-	 * @var string
-	 */
-	public $woo_prompt = 'Create a concise, compelling summary for an ecommerce product that highlights key features, benefits, and unique selling points. Keep it within {{WORDS}} words and ensure it pairs well with the product title: {{TITLE}}.';
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -334,7 +320,7 @@ class ExcerptGeneration extends Feature {
 			$this->get_option_name() . '_section',
 			[
 				'label_for'     => 'generate_excerpt_prompt',
-				'placeholder'   => $this->prompt,
+				'placeholder'   => $this->get_prompt( 'default' ),
 				'default_value' => $settings['generate_excerpt_prompt'],
 				'description'   => esc_html__( "Add a custom prompt. Note the following variables that can be used in the prompt and will be replaced with content: {{WORDS}} will be replaced with the desired excerpt length setting. {{TITLE}} will be replaced with the item's title. {{AUTHOR}} will be replaced with the post author's display name.", 'classifai' ),
 			]
@@ -381,7 +367,7 @@ class ExcerptGeneration extends Feature {
 			'generate_excerpt_prompt' => [
 				[
 					'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
-					'prompt'   => $this->prompt,
+					'prompt'   => $this->get_prompt( 'default' ),
 					'original' => 1,
 				],
 			],
@@ -406,7 +392,7 @@ class ExcerptGeneration extends Feature {
 		if ( $settings && ! empty( $settings['generate_excerpt_prompt'] ) ) {
 			foreach ( $settings['generate_excerpt_prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings['generate_excerpt_prompt'][ $key ]['prompt'] = $this->prompt;
+					$settings['generate_excerpt_prompt'][ $key ]['prompt'] = $this->get_prompt( 'default' );
 					break;
 				}
 			}

--- a/includes/Classifai/Features/Feature.php
+++ b/includes/Classifai/Features/Feature.php
@@ -642,6 +642,62 @@ abstract class Feature {
 	}
 
 	/**
+	 * Load a prompt from a file in the Feature's Prompts/ subdirectory.
+	 *
+	 * Prompt files live alongside the Feature class at
+	 * `Features/Prompts/{ShortClassName}/{name}.php` and must `return` a string.
+	 * Any keys in `$data` are extracted into the file's variable scope so prompts
+	 * can interpolate runtime values, e.g. `"Summarize in {$words} words."`.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $name The prompt file name without extension. Default 'default'.
+	 * @param array  $data Optional. Variables exposed to the prompt file.
+	 * @return string The prompt text, or an empty string if the file is missing.
+	 */
+	public function get_prompt( string $name = 'default', array $data = array() ): string {
+		$reflection = new \ReflectionClass( $this );
+		$file_name  = $reflection->getFileName();
+
+		if ( ! $file_name ) {
+			return '';
+		}
+
+		$file_path = trailingslashit( dirname( $file_name ) )
+			. 'Prompts/'
+			. $reflection->getShortName()
+			. '/'
+			. $name
+			. '.php';
+
+		if ( ! file_exists( $file_path ) || ! is_readable( $file_path ) ) {
+			return '';
+		}
+
+		if ( ! empty( $data ) ) {
+			extract( $data, EXTR_SKIP ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
+		}
+
+		$content = require $file_path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
+		$prompt  = is_string( $content ) ? $content : '';
+
+		/**
+		 * Filter a Feature's default prompt loaded from file.
+		 *
+		 * @since x.x.x
+		 * @hook classifai_feature_prompt
+		 *
+		 * @param string  $prompt  The prompt text.
+		 * @param string  $name    The prompt name (e.g. 'default', 'woocommerce').
+		 * @param array   $data    Data passed to the prompt file.
+		 * @param Feature $feature The feature instance.
+		 *
+		 * @return string The filtered prompt text.
+		 */
+		return apply_filters( 'classifai_feature_prompt', $prompt, $name, $data, $this );
+	}
+
+	/**
 	 * Generic prompt repeater field callback
 	 *
 	 * @since 2.4.0

--- a/includes/Classifai/Features/ImageTagsGenerator.php
+++ b/includes/Classifai/Features/ImageTagsGenerator.php
@@ -28,20 +28,6 @@ class ImageTagsGenerator extends Feature {
 	 */
 	const ID = 'feature_image_tags_generator';
 
-	// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
-	/**
-	 * Prompt for generating tags.
-	 *
-	 * @var string
-	 */
-	public $prompt = <<<'INSTRUCTION'
-You are an assistant that generates image tags. You will be provided with an image and will generate a list of tags that best represent the image. Ensure the tags are short. Return at most the best 5 tags and return these in the following format:
-- Tag
-- Another tag
-- ...
-INSTRUCTION;
-	// phpcs:enable
-
 	/**
 	 * Constructor.
 	 */
@@ -82,7 +68,7 @@ INSTRUCTION;
 		if ( $settings && ! empty( $settings[ ChatGPT::ID ]['prompt'] ) ) {
 			foreach ( $settings[ ChatGPT::ID ]['prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings[ ChatGPT::ID ]['prompt'][ $key ]['prompt'] = $this->prompt;
+					$settings[ ChatGPT::ID ]['prompt'][ $key ]['prompt'] = $this->get_prompt( 'default' );
 					break;
 				}
 			}
@@ -91,7 +77,7 @@ INSTRUCTION;
 		if ( $settings && ! empty( $settings[ OllamaMM::ID ]['prompt'] ) ) {
 			foreach ( $settings[ OllamaMM::ID ]['prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings[ OllamaMM::ID ]['prompt'][ $key ]['prompt'] = $this->prompt;
+					$settings[ OllamaMM::ID ]['prompt'][ $key ]['prompt'] = $this->get_prompt( 'default' );
 					break;
 				}
 			}

--- a/includes/Classifai/Features/ImageTextExtraction.php
+++ b/includes/Classifai/Features/ImageTextExtraction.php
@@ -30,13 +30,6 @@ class ImageTextExtraction extends Feature {
 	const ID = 'feature_image_to_text_generator';
 
 	/**
-	 * Prompt for extracting text.
-	 *
-	 * @var string
-	 */
-	public $prompt = 'You are an assistant that extracts text from images. You will be provided with an image and will return whatever text is in the image. Return only the text, nothing else. If there is no text present, return the word none.';
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -76,7 +69,7 @@ class ImageTextExtraction extends Feature {
 		if ( $settings && ! empty( $settings[ ChatGPT::ID ]['prompt'] ) ) {
 			foreach ( $settings[ ChatGPT::ID ]['prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings[ ChatGPT::ID ]['prompt'][ $key ]['prompt'] = $this->prompt;
+					$settings[ ChatGPT::ID ]['prompt'][ $key ]['prompt'] = $this->get_prompt( 'default' );
 					break;
 				}
 			}
@@ -85,7 +78,7 @@ class ImageTextExtraction extends Feature {
 		if ( $settings && ! empty( $settings[ OllamaMM::ID ]['prompt'] ) ) {
 			foreach ( $settings[ OllamaMM::ID ]['prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings[ OllamaMM::ID ]['prompt'][ $key ]['prompt'] = $this->prompt;
+					$settings[ OllamaMM::ID ]['prompt'][ $key ]['prompt'] = $this->get_prompt( 'default' );
 					break;
 				}
 			}

--- a/includes/Classifai/Features/KeyTakeaways.php
+++ b/includes/Classifai/Features/KeyTakeaways.php
@@ -30,13 +30,6 @@ class KeyTakeaways extends Feature {
 	const ID = 'feature_key_takeaways';
 
 	/**
-	 * Prompt for generating the key takeaways.
-	 *
-	 * @var string
-	 */
-	public $prompt = 'The content you will be provided with is from an already written article. This article has the title of: {{TITLE}}. Your task is to carefully read through this article and provide a summary that captures all the important points. This summary should be concise and limited to about 2-4 points but should also be detailed enough to allow someone to quickly grasp the full article. Read the article a few times before providing the summary and trim each point down to be as concise as possible.';
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -273,7 +266,7 @@ class KeyTakeaways extends Feature {
 			'key_takeaways_prompt' => [
 				[
 					'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
-					'prompt'   => $this->prompt,
+					'prompt'   => $this->get_prompt( 'default' ),
 					'original' => 1,
 				],
 			],
@@ -294,7 +287,7 @@ class KeyTakeaways extends Feature {
 		if ( $settings && ! empty( $settings['key_takeaways_prompt'] ) ) {
 			foreach ( $settings['key_takeaways_prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings['key_takeaways_prompt'][ $key ]['prompt'] = $this->prompt;
+					$settings['key_takeaways_prompt'][ $key ]['prompt'] = $this->get_prompt( 'default' );
 					break;
 				}
 			}

--- a/includes/Classifai/Features/Prompts/ContentGeneration/default.php
+++ b/includes/Classifai/Features/Prompts/ContentGeneration/default.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Default prompt for the Content Generation feature.
+ *
+ * @package Classifai
+ */
+
+return 'Act as an experienced SEO copywriter tasked with writing an article based off of a given summary and an optionally provided title. Your goal is to craft a compelling, informative piece that adheres to SEO best practices, is well-researched, engaging to the target audience, and structured in a way that enhances readability. Incorporate relevant keywords naturally throughout the text, without compromising the flow or quality of the content. Ensure that the article provides value to the reader. Only return the contents of the article, not the title or other commentary.';

--- a/includes/Classifai/Features/Prompts/ContentGeneration/return-format.php
+++ b/includes/Classifai/Features/Prompts/ContentGeneration/return-format.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Return-format instruction appended to the system message for the Content Generation feature.
+ *
+ * Describes the WordPress block markup that the model should emit.
+ *
+ * @package Classifai
+ */
+
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<'INSTRUCTION'
+The content returned should be valid WordPress block markup as described below, using elements like paragraphs and headings where appropriate. Be selective on the elements you use, defaulting to paragraphs. Please check the content before returning to ensure each element has proper opening and closing block markup and HTML tags and any required block attributes. Ensure elements don't nest inside each other, i.e. don't put a paragraph inside another paragraph or a list within a paragraph. Don't start the content with a heading, start with a paragraph.
+
+Markup available to use; don't use any other blocks, even if requested:
+<!-- wp:paragraph -->
+<p>CONTENT</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">CONTENT</h2>
+<!-- /wp:heading -->
+
+<!-- wp:table -->
+<figure class="wp-block-table"><table class="has-fixed-layout"><tbody><tr><td>CONTENT</td></tr><tr><td>CONTENT</td></tr></tbody></table></figure>
+<!-- /wp:table -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+<p>CONTENT</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>QUOTE</p><cite>AUTHOR</cite></blockquote></figure>
+<!-- /wp:pullquote -->
+
+<!-- wp:list -->
+<ul class="wp-block-list">
+<li>CONTENT</li>
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:list {"ordered":true} -->
+<ol class="wp-block-list">
+<li>CONTENT</li>
+</ol>
+<!-- /wp:list -->
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Features/Prompts/ContentResizing/condense.php
+++ b/includes/Classifai/Features/Prompts/ContentResizing/condense.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Default prompt for condensing content via the Content Resizing feature.
+ *
+ * @package Classifai
+ */
+
+return 'Decrease the content length no more than 2 to 4 sentences.';

--- a/includes/Classifai/Features/Prompts/ContentResizing/expand.php
+++ b/includes/Classifai/Features/Prompts/ContentResizing/expand.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Default prompt for expanding content via the Content Resizing feature.
+ *
+ * @package Classifai
+ */
+
+return 'Increase the content length no more than 2 to 4 sentences.';

--- a/includes/Classifai/Features/Prompts/DescriptiveTextGenerator/default.php
+++ b/includes/Classifai/Features/Prompts/DescriptiveTextGenerator/default.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Default prompt for the Descriptive Text Generator feature.
+ *
+ * @package Classifai
+ */
+
+return 'You are an assistant that generates descriptions of images that are used on a website. You will be provided with an image and will describe the main item you see in the image, giving details but staying concise. There is no need to say "the image contains" or similar, just describe what is actually in the image. This text will be important for screen readers, so make sure it is descriptive and accurate but not overly verbose. Before returning the text, re-evaluate your response and ensure you are following the above points, in particular ensuring the text is concise.';

--- a/includes/Classifai/Features/Prompts/ExcerptGeneration/default.php
+++ b/includes/Classifai/Features/Prompts/ExcerptGeneration/default.php
@@ -14,12 +14,12 @@
  * @package Classifai
  *
  * @var string $words  Provided by extract() of $data; falls back to a token.
- * @var string $title  Provided by extract() of $data; falls back to a token.
+ * @var string $article_title  Provided by extract() of $data; falls back to a token.
  * @var string $author Provided by extract() of $data; falls back to a token.
  */
 
-$words  = $words ?? '{{WORDS}}';
-$title  = $title ?? '{{TITLE}}';
-$author = $author ?? '{{AUTHOR}}';
+$words         = $words ?? '{{WORDS}}';
+$article_title = $article_title ?? '{{TITLE}}';
+$author        = $author ?? '{{AUTHOR}}';
 
-return "Summarize the following message using a maximum of {$words} words. The original message was written by {$author}. Ensure this summary pairs well with the following text: {$title}.";
+return "Summarize the following message using a maximum of {$words} words. The original message was written by {$author}. Ensure this summary pairs well with the following text: {$article_title}.";

--- a/includes/Classifai/Features/Prompts/ExcerptGeneration/default.php
+++ b/includes/Classifai/Features/Prompts/ExcerptGeneration/default.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Default prompt for the Excerpt Generation feature.
+ *
+ * Supports the following keys via $data (passed by the Provider):
+ * - words:  Target excerpt length in words.
+ * - title:  Title of the item being summarized.
+ * - author: Display name of the post author.
+ *
+ * When called without $data (e.g. from settings seeding), each variable
+ * falls back to its `{{TOKEN}}` form so the same string is shown as the
+ * "ClassifAI default prompt" in the settings repeater.
+ *
+ * @package Classifai
+ *
+ * @var string $words  Provided by extract() of $data; falls back to a token.
+ * @var string $title  Provided by extract() of $data; falls back to a token.
+ * @var string $author Provided by extract() of $data; falls back to a token.
+ */
+
+$words  = $words ?? '{{WORDS}}';
+$title  = $title ?? '{{TITLE}}';
+$author = $author ?? '{{AUTHOR}}';
+
+return "Summarize the following message using a maximum of {$words} words. The original message was written by {$author}. Ensure this summary pairs well with the following text: {$title}.";

--- a/includes/Classifai/Features/Prompts/ExcerptGeneration/woocommerce.php
+++ b/includes/Classifai/Features/Prompts/ExcerptGeneration/woocommerce.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Excerpt Generation prompt used for WooCommerce products.
+ *
+ * @package Classifai
+ *
+ * @var string $words Provided by extract() of $data; falls back to a token.
+ * @var string $title Provided by extract() of $data; falls back to a token.
+ */
+
+$words = $words ?? '{{WORDS}}';
+$title = $title ?? '{{TITLE}}';
+
+return "Create a concise, compelling summary for an ecommerce product that highlights key features, benefits, and unique selling points. Keep it within {$words} words and ensure it pairs well with the product title: {$title}.";

--- a/includes/Classifai/Features/Prompts/ExcerptGeneration/woocommerce.php
+++ b/includes/Classifai/Features/Prompts/ExcerptGeneration/woocommerce.php
@@ -5,10 +5,10 @@
  * @package Classifai
  *
  * @var string $words Provided by extract() of $data; falls back to a token.
- * @var string $title Provided by extract() of $data; falls back to a token.
+ * @var string $article_title Provided by extract() of $data; falls back to a token.
  */
 
-$words = $words ?? '{{WORDS}}';
-$title = $title ?? '{{TITLE}}';
+$words         = $words ?? '{{WORDS}}';
+$article_title = $article_title ?? '{{TITLE}}';
 
-return "Create a concise, compelling summary for an ecommerce product that highlights key features, benefits, and unique selling points. Keep it within {$words} words and ensure it pairs well with the product title: {$title}.";
+return "Create a concise, compelling summary for an ecommerce product that highlights key features, benefits, and unique selling points. Keep it within {$words} words and ensure it pairs well with the product title: {$article_title}.";

--- a/includes/Classifai/Features/Prompts/ImageTagsGenerator/default.php
+++ b/includes/Classifai/Features/Prompts/ImageTagsGenerator/default.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Default prompt for the Image Tags Generator feature.
+ *
+ * @package Classifai
+ */
+
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<'INSTRUCTION'
+You are an assistant that generates image tags. You will be provided with an image and will generate a list of tags that best represent the image. Ensure the tags are short. Return at most the best 5 tags and return these in the following format:
+- Tag
+- Another tag
+- ...
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Features/Prompts/ImageTextExtraction/default.php
+++ b/includes/Classifai/Features/Prompts/ImageTextExtraction/default.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Default prompt for the Image Text Extraction feature.
+ *
+ * @package Classifai
+ */
+
+return 'You are an assistant that extracts text from images. You will be provided with an image and will return whatever text is in the image. Return only the text, nothing else. If there is no text present, return the word none.';

--- a/includes/Classifai/Features/Prompts/KeyTakeaways/default.php
+++ b/includes/Classifai/Features/Prompts/KeyTakeaways/default.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Default prompt for the Key Takeaways feature.
+ *
+ * @package Classifai
+ *
+ * @var string $title Provided by extract() of $data; falls back to a token.
+ */
+
+$title = $title ?? '{{TITLE}}';
+
+return "The content you will be provided with is from an already written article. This article has the title of: {$title}. Your task is to carefully read through this article and provide a summary that captures all the important points. This summary should be concise and limited to about 2-4 points but should also be detailed enough to allow someone to quickly grasp the full article. Read the article a few times before providing the summary and trim each point down to be as concise as possible.";

--- a/includes/Classifai/Features/Prompts/KeyTakeaways/default.php
+++ b/includes/Classifai/Features/Prompts/KeyTakeaways/default.php
@@ -4,9 +4,9 @@
  *
  * @package Classifai
  *
- * @var string $title Provided by extract() of $data; falls back to a token.
+ * @var string $article_title Provided by extract() of $data; falls back to a token.
  */
 
-$title = $title ?? '{{TITLE}}';
+$article_title = $article_title ?? '{{TITLE}}';
 
-return "The content you will be provided with is from an already written article. This article has the title of: {$title}. Your task is to carefully read through this article and provide a summary that captures all the important points. This summary should be concise and limited to about 2-4 points but should also be detailed enough to allow someone to quickly grasp the full article. Read the article a few times before providing the summary and trim each point down to be as concise as possible.";
+return "The content you will be provided with is from an already written article. This article has the title of: {$article_title}. Your task is to carefully read through this article and provide a summary that captures all the important points. This summary should be concise and limited to about 2-4 points but should also be detailed enough to allow someone to quickly grasp the full article. Read the article a few times before providing the summary and trim each point down to be as concise as possible.";

--- a/includes/Classifai/Features/Prompts/TitleGeneration/default.php
+++ b/includes/Classifai/Features/Prompts/TitleGeneration/default.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Default prompt for the Title Generation feature.
+ *
+ * @package Classifai
+ */
+
+return 'Write an SEO-friendly title for the following content that will encourage readers to clickthrough, staying within a range of 40 to 60 characters and format it in sentence case.';

--- a/includes/Classifai/Features/Prompts/TitleGeneration/woocommerce.php
+++ b/includes/Classifai/Features/Prompts/TitleGeneration/woocommerce.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Title Generation prompt used for WooCommerce products.
+ *
+ * @package Classifai
+ */
+
+return 'Write an SEO-friendly, engaging product title that encourages clicks and purchases. Use key details like product type, attributes, and categories while keeping it within 40 to 60 characters and format it in sentence case.';

--- a/includes/Classifai/Features/TitleGeneration.php
+++ b/includes/Classifai/Features/TitleGeneration.php
@@ -32,20 +32,6 @@ class TitleGeneration extends Feature {
 	const ID = 'feature_title_generation';
 
 	/**
-	 * Prompt for generating titles.
-	 *
-	 * @var string
-	 */
-	public $prompt = 'Write an SEO-friendly title for the following content that will encourage readers to clickthrough, staying within a range of 40 to 60 characters and format it in sentence case.';
-
-	/**
-	 * Prompt for generating titles for WooCommerce Products.
-	 *
-	 * @var string
-	 */
-	public $woo_prompt = 'Write an SEO-friendly, engaging product title that encourages clicks and purchases. Use key details like product type, attributes, and categories while keeping it within 40 to 60 characters and format it in sentence case.';
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -346,7 +332,7 @@ class TitleGeneration extends Feature {
 			$this->get_option_name() . '_section',
 			[
 				'label_for'     => 'generate_title_prompt',
-				'placeholder'   => $this->prompt,
+				'placeholder'   => $this->get_prompt( 'default' ),
 				'default_value' => $settings['generate_title_prompt'],
 				'description'   => esc_html__( 'Add a custom prompt, if desired.', 'classifai' ),
 			]
@@ -363,7 +349,7 @@ class TitleGeneration extends Feature {
 			'generate_title_prompt' => [
 				[
 					'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
-					'prompt'   => $this->prompt,
+					'prompt'   => $this->get_prompt( 'default' ),
 					'original' => 1,
 				],
 			],
@@ -384,7 +370,7 @@ class TitleGeneration extends Feature {
 		if ( $settings && ! empty( $settings['generate_title_prompt'] ) ) {
 			foreach ( $settings['generate_title_prompt'] as $key => $prompt ) {
 				if ( 1 === intval( $prompt['original'] ) ) {
-					$settings['generate_title_prompt'][ $key ]['prompt'] = $this->prompt;
+					$settings['generate_title_prompt'][ $key ]['prompt'] = $this->get_prompt( 'default' );
 					break;
 				}
 			}

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -378,9 +378,9 @@ class OpenAI extends Provider {
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
-			$excerpt_prompt = $feature->woo_prompt;
+			$excerpt_prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->prompt );
+			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		// Replace our variables in the prompt.
@@ -489,9 +489,9 @@ class OpenAI extends Provider {
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
-			$prompt = $feature->woo_prompt;
+			$prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		/**
@@ -595,9 +595,9 @@ class OpenAI extends Provider {
 		);
 
 		if ( 'shrink' === $args['resize_type'] ) {
-			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->get_prompt( 'condense' ) );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->expand_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->get_prompt( 'expand' ) );
 		}
 
 		/**
@@ -736,7 +736,7 @@ class OpenAI extends Provider {
 			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Generate results" button.', 'classifai' ) );
 		}
 
-		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->prompt );
+		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 
 		// Replace our variables in the prompt.
 		$prompt_search  = array( '{{TITLE}}' );
@@ -891,7 +891,7 @@ class OpenAI extends Provider {
 		 *
 		 * @return string Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_azure_openai_content_prompt', esc_textarea( get_default_prompt( $settings['prompt'] ) ?? $feature->prompt ), $post_id, $args );
+		$prompt = apply_filters( 'classifai_azure_openai_content_prompt', esc_textarea( get_default_prompt( $settings['prompt'] ) ?? $feature->get_prompt( 'default' ) ), $post_id, $args );
 
 		// Set up the content we are sending to the LLM.
 		if ( ! empty( $args['conversation'] ) ) {
@@ -908,7 +908,7 @@ class OpenAI extends Provider {
 		$messages = [
 			[
 				'role'    => 'system',
-				'content' => $prompt . "\n" . $feature->return_format,
+				'content' => $prompt . "\n" . $feature->get_prompt( 'return-format' ),
 			],
 			[
 				'role'    => 'user',

--- a/includes/Classifai/Providers/Browser/ChromeAI.php
+++ b/includes/Classifai/Providers/Browser/ChromeAI.php
@@ -136,9 +136,9 @@ class ChromeAI extends Provider {
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
-			$excerpt_prompt = $feature->woo_prompt;
+			$excerpt_prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->prompt );
+			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		// Replace our variables in the prompt.
@@ -221,9 +221,9 @@ class ChromeAI extends Provider {
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
-			$prompt = $feature->woo_prompt;
+			$prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		/**
@@ -287,9 +287,9 @@ class ChromeAI extends Provider {
 		$settings = $feature->get_settings();
 
 		if ( 'shrink' === $args['resize_type'] ) {
-			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->get_prompt( 'condense' ) );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->expand_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->get_prompt( 'expand' ) );
 		}
 
 		/**

--- a/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
+++ b/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
@@ -216,9 +216,9 @@ class GeminiAPI extends Provider {
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
-			$excerpt_prompt = $feature->woo_prompt;
+			$excerpt_prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->prompt );
+			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		// Replace our variables in the prompt.
@@ -337,9 +337,9 @@ class GeminiAPI extends Provider {
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
-			$prompt = $feature->woo_prompt;
+			$prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		/**
@@ -452,9 +452,9 @@ class GeminiAPI extends Provider {
 		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		if ( 'shrink' === $args['resize_type'] ) {
-			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->get_prompt( 'condense' ) );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->expand_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->get_prompt( 'expand' ) );
 		}
 
 		/**

--- a/includes/Classifai/Providers/Localhost/Ollama.php
+++ b/includes/Classifai/Providers/Localhost/Ollama.php
@@ -213,9 +213,9 @@ class Ollama extends Provider {
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
-			$excerpt_prompt = $feature->woo_prompt;
+			$excerpt_prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->prompt );
+			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		// Replace our variables in the prompt.
@@ -319,9 +319,9 @@ class Ollama extends Provider {
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
-			$prompt = $feature->woo_prompt;
+			$prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		/**
@@ -434,9 +434,9 @@ class Ollama extends Provider {
 		);
 
 		if ( 'shrink' === $args['resize_type'] ) {
-			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->get_prompt( 'condense' ) );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->expand_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->get_prompt( 'expand' ) );
 		}
 
 		/**
@@ -583,7 +583,7 @@ class Ollama extends Provider {
 			return new WP_Error( 'no_content', esc_html__( 'No content found. Please add content then click the "Generate results" button.', 'classifai' ) );
 		}
 
-		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->prompt );
+		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 
 		// Replace our variables in the prompt.
 		$prompt_search  = array( '{{TITLE}}' );
@@ -709,7 +709,7 @@ class Ollama extends Provider {
 		 *
 		 * @return string Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_ollama_content_prompt', esc_textarea( get_default_prompt( $settings['prompt'] ) ?? $feature->prompt ), $post_id, $args );
+		$prompt = apply_filters( 'classifai_ollama_content_prompt', esc_textarea( get_default_prompt( $settings['prompt'] ) ?? $feature->get_prompt( 'default' ) ), $post_id, $args );
 
 		// Set up the content we are sending to the LLM.
 		if ( ! empty( $args['conversation'] ) ) {
@@ -726,7 +726,7 @@ class Ollama extends Provider {
 		$messages = [
 			[
 				'role'    => 'system',
-				'content' => $prompt . "\n" . $feature->return_format,
+				'content' => $prompt . "\n" . $feature->get_prompt( 'return-format' ),
 			],
 			[
 				'role'    => 'user',

--- a/includes/Classifai/Providers/Localhost/OllamaMultimodal.php
+++ b/includes/Classifai/Providers/Localhost/OllamaMultimodal.php
@@ -76,7 +76,7 @@ class OllamaMultimodal extends Ollama {
 				$common_settings['prompt'] = [
 					[
 						'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
-						'prompt'   => $this->feature_instance->prompt,
+						'prompt'   => $this->feature_instance->get_prompt( 'default' ),
 						'original' => 1,
 						'default'  => 1,
 					],
@@ -156,7 +156,7 @@ class OllamaMultimodal extends Ollama {
 		 *
 		 * @return string Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_ollama_descriptive_text_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->prompt, $attachment_id );
+		$prompt = apply_filters( 'classifai_ollama_descriptive_text_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->get_prompt( 'default' ), $attachment_id );
 
 		/**
 		 * Filter the request body before sending to Ollama.
@@ -224,7 +224,7 @@ class OllamaMultimodal extends Ollama {
 		 *
 		 * @return string Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_ollama_ocr_processing_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->prompt, $attachment_id );
+		$prompt = apply_filters( 'classifai_ollama_ocr_processing_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->get_prompt( 'default' ), $attachment_id );
 
 		/**
 		 * Filter the request body before sending to Ollama.
@@ -297,7 +297,7 @@ class OllamaMultimodal extends Ollama {
 		 *
 		 * @return string Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_ollama_image_tag_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->prompt, $attachment_id );
+		$prompt = apply_filters( 'classifai_ollama_image_tag_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->get_prompt( 'default' ), $attachment_id );
 
 		/**
 		 * Filter the request body before sending to Ollama.

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -166,7 +166,7 @@ class ChatGPT extends Provider {
 				$common_settings['prompt'] = [
 					[
 						'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
-						'prompt'   => $this->feature_instance->prompt,
+						'prompt'   => $this->feature_instance->get_prompt( 'default' ),
 						'original' => 1,
 						'default'  => 1,
 					],
@@ -292,7 +292,7 @@ class ChatGPT extends Provider {
 		 *
 		 * @return string Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_chatgpt_descriptive_text_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->prompt, $post_id );
+		$prompt = apply_filters( 'classifai_chatgpt_descriptive_text_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->get_prompt( 'default' ), $post_id );
 
 		/**
 		 * Filter the request body before sending to ChatGPT.
@@ -393,7 +393,7 @@ class ChatGPT extends Provider {
 		 *
 		 * @return string Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_chatgpt_ocr_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->prompt, $post_id );
+		$prompt = apply_filters( 'classifai_chatgpt_ocr_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->get_prompt( 'default' ), $post_id );
 
 		/**
 		 * Filter the request body before sending to ChatGPT.
@@ -504,7 +504,7 @@ class ChatGPT extends Provider {
 		 *
 		 * @return string Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_chatgpt_image_tag_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->prompt, $post_id );
+		$prompt = apply_filters( 'classifai_chatgpt_image_tag_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->get_prompt( 'default' ), $post_id );
 
 		/**
 		 * Filter the request body before sending to ChatGPT.
@@ -611,9 +611,9 @@ class ChatGPT extends Provider {
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
-			$excerpt_prompt = $feature->woo_prompt;
+			$excerpt_prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->prompt );
+			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		// Replace our variables in the prompt.
@@ -720,9 +720,9 @@ class ChatGPT extends Provider {
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
-			$prompt = $feature->woo_prompt;
+			$prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		/**
@@ -824,9 +824,9 @@ class ChatGPT extends Provider {
 		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		if ( 'shrink' === $args['resize_type'] ) {
-			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->get_prompt( 'condense' ) );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->expand_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->get_prompt( 'expand' ) );
 		}
 
 		/**
@@ -964,7 +964,7 @@ class ChatGPT extends Provider {
 
 		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
-		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->prompt );
+		$prompt = esc_textarea( get_default_prompt( $settings['key_takeaways_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 
 		// Replace our variables in the prompt.
 		$prompt_search  = array( '{{TITLE}}' );
@@ -1117,7 +1117,7 @@ class ChatGPT extends Provider {
 		 *
 		 * @return string Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_chatgpt_content_prompt', esc_textarea( get_default_prompt( $settings['prompt'] ) ?? $feature->prompt ), $post_id, $args );
+		$prompt = apply_filters( 'classifai_chatgpt_content_prompt', esc_textarea( get_default_prompt( $settings['prompt'] ) ?? $feature->get_prompt( 'default' ) ), $post_id, $args );
 
 		// Set up the content we are sending to the LLM.
 		if ( ! empty( $args['conversation'] ) ) {
@@ -1134,7 +1134,7 @@ class ChatGPT extends Provider {
 		$messages = [
 			[
 				'role'    => 'system',
-				'content' => $prompt . "\n" . $feature->return_format,
+				'content' => $prompt . "\n" . $feature->get_prompt( 'return-format' ),
 			],
 			[
 				'role'    => 'user',

--- a/includes/Classifai/Providers/XAI/Grok.php
+++ b/includes/Classifai/Providers/XAI/Grok.php
@@ -149,7 +149,7 @@ class Grok extends Provider {
 				$common_settings['prompt'] = [
 					[
 						'title'    => esc_html__( 'ClassifAI default', 'classifai' ),
-						'prompt'   => $this->feature_instance->prompt,
+						'prompt'   => $this->feature_instance->get_prompt( 'default' ),
 						'original' => 1,
 						'default'  => 1,
 					],
@@ -375,7 +375,7 @@ class Grok extends Provider {
 		 *
 		 * @return string Prompt.
 		 */
-		$prompt = apply_filters( 'classifai_xai_grok_descriptive_text_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->prompt, $post_id );
+		$prompt = apply_filters( 'classifai_xai_grok_descriptive_text_prompt', get_default_prompt( $settings[ static::ID ]['prompt'] ?? [] ) ?? $feature->get_prompt( 'default' ), $post_id );
 
 		/**
 		 * Filter the request body before sending to xAI Grok.
@@ -472,9 +472,9 @@ class Grok extends Provider {
 
 		// Overwrite the prompt if we are generating an excerpt for a product.
 		if ( 'product' === $post_type ) {
-			$excerpt_prompt = $feature->woo_prompt;
+			$excerpt_prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->prompt );
+			$excerpt_prompt = esc_textarea( get_default_prompt( $settings['generate_excerpt_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		// Replace our variables in the prompt.
@@ -581,9 +581,9 @@ class Grok extends Provider {
 
 		// Overwrite the prompt if we are generating titles for a product.
 		if ( 'product' === $post_type ) {
-			$prompt = $feature->woo_prompt;
+			$prompt = $feature->get_prompt( 'woocommerce' );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['generate_title_prompt'] ) ?? $feature->get_prompt( 'default' ) );
 		}
 
 		/**
@@ -685,9 +685,9 @@ class Grok extends Provider {
 		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
 		if ( 'shrink' === $args['resize_type'] ) {
-			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->condense_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['condense_text_prompt'] ) ?? $feature->get_prompt( 'condense' ) );
 		} else {
-			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->expand_prompt );
+			$prompt = esc_textarea( get_default_prompt( $settings['expand_text_prompt'] ) ?? $feature->get_prompt( 'expand' ) );
 		}
 
 		/**

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,5 +20,11 @@ parameters:
 		# These constants are defined but we'd need to stub them for PHPStan to know.
 		- '#Constant CLASSIFAI_.+ not found#'
 		- '#Constant WATSON_.+ not found#'
+		# Prompt files receive runtime variables via extract() in Feature::get_prompt();
+		# the `$var ?? 'fallback'` pattern is intentional so seed-time calls without $data
+		# still produce a usable string.
+		-
+			message: '#Variable \$\w+ on left side of \?\? always exists and is not nullable\.#'
+			path: includes/Classifai/Features/Prompts/*
 	WPCompat:
 		requiresAtLeast: '6.9'


### PR DESCRIPTION
### Description of the Change

At the moment any Features that use prompts have those set within their individual Feature classes. This works but is harder to maintain especially as we start to make our prompts a bit more robust/complex (which will be a follow up PR here).

This PR moves all these prompts into their own files and introduces a new `get_prompt` method that will retrieve the prompt. This allows getting a prompt by name and optionally passing in additional data that should be used in the prompt (like a length variable).

None of the prompts have been changed yet, this is just updating the underlying structure to make this more maintainable going forward.

### How to test the Change

Go to a the settings page for a Feature that uses prompts (like Title Generation). Ensure the default prompt shows up there as expected.

Test out a Feature that uses prompts (like Title Generation). Ensure this still works as expected.

### Changelog Entry

> Added - New `get_prompt` method that is used to get prompts for any Feature that needs it.
> Changed - Move all prompts to their own files so they can be pulled in via the new `get_prompt` method

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
