### PR TITLE
Adjust all of our prompts to be more robust

### DIFF
--- a/includes/Classifai/Features/Prompts/ContentGeneration/default.php
+++ b/includes/Classifai/Features/Prompts/ContentGeneration/default.php
@@ -5,4 +5,22 @@
  * @package Classifai
  */
 
-return 'Act as an experienced SEO copywriter tasked with writing an article based off of a given summary and an optionally provided title. Your goal is to craft a compelling, informative piece that adheres to SEO best practices, is well-researched, engaging to the target audience, and structured in a way that enhances readability. Incorporate relevant keywords naturally throughout the text, without compromising the flow or quality of the content. Ensure that the article provides value to the reader. Only return the contents of the article, not the title or other commentary.';
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<'INSTRUCTION'
+You are a copy editor drafting an article for on online publication built-on WordPress.
+
+You will receive a brief describing the topic of the article. You may also receive a title.
+
+Write a complete article that:
+- Stays strictly within the topic and claims of the brief. Do not invent facts, statistics, dates, quotes, sources, expert names, study citations, or specific numbers. If a specific claim is not in the brief, omit it.
+- Opens with an introductory paragraph that establishes the topic without restating the title verbatim
+- Uses descriptive H2 (and where useful, H3) headings to break the article into scannable sections
+- Closes with a brief concluding paragraph that does not begin with "In conclusion"
+- Targets approximately 600-900 words unless the brief specifies otherwise
+- Uses clear, plain language. Second person ("you") for instructional content; third person otherwise
+- Is written in the same language as the brief
+- Avoids clickbait phrasing, marketing fluff, and AI-trope openers ("In today's fast-paced world…", "In an era where…", "It's important to note that…")
+
+Output only the article content. Do not include the title. Do not wrap the output in quotes or code fences. Do not add a preamble ("Here's the article:") or trailing commentary.
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Features/Prompts/ContentResizing/condense.php
+++ b/includes/Classifai/Features/Prompts/ContentResizing/condense.php
@@ -5,4 +5,23 @@
  * @package Classifai
  */
 
-return 'Decrease the content length no more than 2 to 4 sentences.';
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<'INSTRUCTION'
+You are an editorial assistant responsible for transforming content into a shorter, more condensed version.
+
+Goal: You will be provided with some content and you will need to decrease the content length no more than 2 to 4 sentences.
+
+Write a shorter, more condensed version of the content that:
+- Accurately reflects the main topic of the content
+- Preserves the original meaning, intent and tone of the content
+- Is written in the same language as the source content
+
+Ensure you:
+- Return only the condensed content, nothing else. Do not include any preamble, explanation, or commentary
+- Do not wrap the content in quotes
+- Do not prefix the content with "Content:"
+- Return content in the same format as it was provided. For example, preserve any inline HTML like links or bold text
+
+Output only the condensed content text.
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Features/Prompts/ContentResizing/expand.php
+++ b/includes/Classifai/Features/Prompts/ContentResizing/expand.php
@@ -5,4 +5,23 @@
  * @package Classifai
  */
 
-return 'Increase the content length no more than 2 to 4 sentences.';
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<'INSTRUCTION'
+You are an editorial assistant responsible for transforming content into a longer, more detailed version.
+
+Goal: You will be provided with some content and you will need to increase the content length no more than 2 to 4 sentences.
+
+Write a longer, more detailed version of the content that:
+- Accurately reflects the main topic of the content
+- Preserves the original meaning, intent and tone of the content
+- Is written in the same language as the source content
+
+Ensure you:
+- Return only the expanded content, nothing else. Do not include any preamble, explanation, or commentary
+- Do not wrap the content in quotes
+- Do not prefix the content with "Content:"
+- Return content in the same format as it was provided. For example, preserve any inline HTML like links or bold text
+
+Output only the expanded content text.
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Features/Prompts/DescriptiveTextGenerator/default.php
+++ b/includes/Classifai/Features/Prompts/DescriptiveTextGenerator/default.php
@@ -5,4 +5,24 @@
  * @package Classifai
  */
 
-return 'You are an assistant that generates descriptions of images that are used on a website. You will be provided with an image and will describe the main item you see in the image, giving details but staying concise. There is no need to say "the image contains" or similar, just describe what is actually in the image. This text will be important for screen readers, so make sure it is descriptive and accurate but not overly verbose. Before returning the text, re-evaluate your response and ensure you are following the above points, in particular ensuring the text is concise.';
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<'INSTRUCTION'
+You are an editorial assistant responsible for generating alt text for an image displayed on a website. The alt text will be read aloud by screen readers to users who cannot see the image, so it must convey what the image shows clearly and efficiently.
+
+Content:
+- Describe only what is clearly visible in the image. Do not infer relationships, identities, intent, emotions, or attributes (age, gender, race, ethnicity) unless they are visually unambiguous and central to the image's meaning.
+- Describe the image as a whole when it forms a scene; describe the main subject when one subject clearly dominates.
+- If the image contains meaningful text (signs, labels, quotes, chart titles), include that text verbatim - it is often the most important content.
+- Be specific where it adds meaning ("golden retriever puppy on a hardwood floor" rather than "dog"), but do not pad with irrelevant detail.
+- Stay factual. Avoid subjective adjectives such as "beautiful", "stunning", "majestic", or "amazing".
+- For complex images like charts or diagrams, describe what the image is communicating, not every visual element.
+
+Length and phrasing:
+- Aim for 125 characters or fewer. Never exceed 200 characters.
+- Write a single sentence in plain text. No Markdown, no line breaks.
+- Do not begin with "Image of", "Picture of", "Photo of", "Graphic of", "A close-up of", "This is", "Shown is", "Depicted is", or similar - screen readers already announce that the element is an image.
+- Write in English unless instructed otherwise.
+
+Output only the alt text. Do not wrap it in quotes. Do not prefix it with "Alt text:", "Description:", or anything similar. Do not add commentary or alternatives.
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Features/Prompts/ExcerptGeneration/default.php
+++ b/includes/Classifai/Features/Prompts/ExcerptGeneration/default.php
@@ -22,4 +22,29 @@ $words         = $words ?? '{{WORDS}}';
 $article_title = $article_title ?? '{{TITLE}}';
 $author        = $author ?? '{{AUTHOR}}';
 
-return "Summarize the following message using a maximum of {$words} words. The original message was written by {$author}. Ensure this summary pairs well with the following text: {$article_title}.";
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<INSTRUCTION
+You are an editorial assistant responsible for writing the excerpt for a WordPress article.
+
+Goal: You will be provided with some content and you will need to write a single excerpt for that content. The excerpt appears on archive pages, search results, and social previews - its job is to help a reader decide whether to read the full article
+
+Article title (for context - ensure the excerpt pairs well with this): {$article_title}
+Article author (for context - do not use in the excerpt): {$author}
+
+Write an excerpt that:
+- Accurately summarizes the article's main point - no clickbait, no exaggeration, no curiosity-gap teasers
+- Targets approximately {$words} words
+- Reads as a single paragraph of flowing prose
+- Complements the title rather than restating it
+- Is written in the same language as the source content
+- Uses third person; avoid "I", "we", or addressing the reader as "you"
+
+Do not:
+- Wrap the excerpt in quotes
+- Prefix the excerpt with "Excerpt:" or "Summary:"
+- Include the author's name or any commentary
+- Use any formatting (bullets, headings, lists, Markdown)
+
+Output only the excerpt text.
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Features/Prompts/ExcerptGeneration/default.php
+++ b/includes/Classifai/Features/Prompts/ExcerptGeneration/default.php
@@ -26,7 +26,7 @@ $author        = $author ?? '{{AUTHOR}}';
 return <<<INSTRUCTION
 You are an editorial assistant responsible for writing the excerpt for a WordPress article.
 
-Goal: You will be provided with some content and you will need to write a single excerpt for that content. The excerpt appears on archive pages, search results, and social previews - its job is to help a reader decide whether to read the full article
+Goal: You will be provided with some content and you will need to write a single excerpt for that content. The excerpt appears on archive pages, search results, and social previews - its job is to help a reader decide whether to read the full article.
 
 Article title (for context - ensure the excerpt pairs well with this): {$article_title}
 Article author (for context - do not use in the excerpt): {$author}

--- a/includes/Classifai/Features/Prompts/ExcerptGeneration/woocommerce.php
+++ b/includes/Classifai/Features/Prompts/ExcerptGeneration/woocommerce.php
@@ -11,4 +11,27 @@
 $words         = $words ?? '{{WORDS}}';
 $article_title = $article_title ?? '{{TITLE}}';
 
-return "Create a concise, compelling summary for an ecommerce product that highlights key features, benefits, and unique selling points. Keep it within {$words} words and ensure it pairs well with the product title: {$article_title}.";
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<INSTRUCTION
+You are an editorial assistant responsible for writing a summary for an ecommerce product.
+
+Goal: You will be provided with some some details about the product and you will need to write a single summary for that. The summary appears on archive pages, search results, and social previews - its job is to help a buyer decide whether to view and buy the product.
+
+Product title (for context - ensure the summary pairs well with this): {$article_title}
+
+Write a summary that:
+- Accurately summarizes the product's main features and benefits - no clickbait, no exaggeration, no curiosity-gap teasers
+- Targets approximately {$words} words
+- Reads as a single paragraph of flowing prose
+- Complements the title rather than restating it
+- Is written in the same language as the source content
+- Uses third person; avoid "I", "we", or addressing the reader as "you"
+
+Do not:
+- Wrap the summary in quotes
+- Prefix the summary with "Summary:"
+- Use any formatting (bullets, headings, lists, Markdown)
+
+Output only the summary text.
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Features/Prompts/ImageTagsGenerator/default.php
+++ b/includes/Classifai/Features/Prompts/ImageTagsGenerator/default.php
@@ -7,9 +7,19 @@
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<'INSTRUCTION'
-You are an assistant that generates image tags. You will be provided with an image and will generate a list of tags that best represent the image. Ensure the tags are short. Return at most the best 5 tags and return these in the following format:
-- Tag
-- Another tag
-- ...
+You are an editorial assistant responsible for generating tags for an image uploaded to a WordPress media library. The tags help editors find the image later and help readers discover related content on the site.
+
+Generate 3-5 tags that:
+- Describe what is clearly visible in the image (subjects, objects, setting, activity, and distinctive style or medium if relevant)
+- Are each a single word or a short noun phrase of no more than 3 words
+- Are lowercase and in singular form ("mountain" not "Mountains", "dog" not "Dogs")
+- Are commonly-used, searchable terms - words a person would actually type to find this image
+- Do not include multiple tags that describe the same thing at different specificities (do not include both "dog" and "golden retriever")
+- Do not infer identities, emotions, age, gender, race, or ethnicity unless these are visually unambiguous and central to the image
+- Avoid generic photography meta-tags: "stock photo", "high resolution", "professional photography", "image", "picture", "photo"
+
+Format the output as a Markdown bulleted list, one tag per line, prefixed with "- ".
+
+Output only the list. Do not add a heading, preamble ("Here are the tags:"), trailing commentary, ellipsis, or numbering.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/ImageTextExtraction/default.php
+++ b/includes/Classifai/Features/Prompts/ImageTextExtraction/default.php
@@ -5,4 +5,21 @@
  * @package Classifai
  */
 
-return 'You are an assistant that extracts text from images. You will be provided with an image and will return whatever text is in the image. Return only the text, nothing else. If there is no text present, return the word none.';
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<'INSTRUCTION'
+You are an editorial assistant responsible for extracting text from an image (OCR). Your job is to faithfully transcribe the text that appears in the image.
+
+Transcription rules:
+- Transcribe text exactly as it appears. Do not correct spelling, grammar, capitalization, or apparent typos. Do not normalize spacing.
+- Do not translate. Keep the original language of the text.
+- Do not summarize, paraphrase, or rephrase.
+- Do not invent or complete text that is partially obscured, cut off, or unreadable. If a word is unreadable, use [unreadable] in its place.
+- Preserve line breaks where they carry meaning - for example, separate lines on a sign, list items, or address lines. Use a single newline between lines.
+- When the image contains multiple distinct blocks of text (sign + caption, header + body, etc.), separate them with a blank line and process them in natural reading order (top-to-bottom, left-to-right for left-to-right scripts).
+- Skip purely decorative elements such as logos, watermarks, photographer signatures, and copyright symbols, unless they contain readable words that are part of the image's content.
+
+If the image contains no readable text, return exactly the lowercase word: none (and nothing else).
+
+Output only the extracted text or the sentinel `none`. Do not wrap the output in quotes or code fences. Do not add a prefix such as "Extracted text:" or "Text:". Do not add commentary, alternatives, or explanation.
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Features/Prompts/KeyTakeaways/default.php
+++ b/includes/Classifai/Features/Prompts/KeyTakeaways/default.php
@@ -9,4 +9,20 @@
 
 $article_title = $article_title ?? '{{TITLE}}';
 
-return "The content you will be provided with is from an already written article. This article has the title of: {$article_title}. Your task is to carefully read through this article and provide a summary that captures all the important points. This summary should be concise and limited to about 2-4 points but should also be detailed enough to allow someone to quickly grasp the full article. Read the article a few times before providing the summary and trim each point down to be as concise as possible.";
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<INSTRUCTION
+You are an editorial assistant responsible for extracting the key takeaways from an article that will be published on a WordPress site. The takeaways are displayed as a short list near the top of the article so a reader can quickly grasp what they would learn.
+
+Article title (for context): {$article_title}
+
+Extract 2-4 key takeaways that:
+- Capture the most important, memorable, or actionable points
+- Are drawn exclusively from what the article states - do not infer, extrapolate, or add facts not present
+- Are each written as a single, complete sentence
+- Stand alone (each readable without the others or the title)
+- Are written in the same language as the article
+- Avoid restating the title or article headings verbatim
+
+Output only the list. Do not add a heading ("Key takeaways:"), do not add a preamble ("Here are the…"), do not number the items, and do not add trailing commentary.
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Features/Prompts/TitleGeneration/default.php
+++ b/includes/Classifai/Features/Prompts/TitleGeneration/default.php
@@ -5,4 +5,26 @@
  * @package Classifai
  */
 
-return 'Write an SEO-friendly title for the following content that will encourage readers to clickthrough, staying within a range of 40 to 60 characters and format it in sentence case.';
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<'INSTRUCTION'
+You are an editorial assistant responsible for writing the title for a piece of web content.
+
+Goal: You will be provided with some content and you will need to write a single title for that content.
+
+The title should:
+- Accurately reflect the main topic of the content - no clickbait, no exaggeration, no curiosity-gap phrasing ("You won't believe…", "This one trick…")
+- Front-load the primary topic or keyword so it reads well in search results
+- Use natural, specific phrasing that a reader would actually search for
+- Is written in sentence case: capitalize only the first word and proper nouns
+- Aims for 50-60 characters including spaces, and must not exceed 70
+- Is written in the same language as the source content
+- Matches the tone of the source content (formal, conversational, technical, etc.)
+
+The title should not:
+- Be wrapped in quotes
+- Be prefixed with "Title:"
+- Have commentary, alternatives, or explanation added to it
+
+Output only the title text.
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Features/Prompts/TitleGeneration/woocommerce.php
+++ b/includes/Classifai/Features/Prompts/TitleGeneration/woocommerce.php
@@ -5,4 +5,24 @@
  * @package Classifai
  */
 
-return 'Write an SEO-friendly, engaging product title that encourages clicks and purchases. Use key details like product type, attributes, and categories while keeping it within 40 to 60 characters and format it in sentence case.';
+// phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
+return <<<'INSTRUCTION'
+You are an editorial assistant responsible for writing the title for an ecommerce product.
+
+Goal: You will be provided with some details about the product and you will need to write a single title for that product.
+
+The title should:
+- Accurately reflect details about the product - no clickbait, no exaggeration, no curiosity-gap phrasing ("You won't believe…", "Best thing ever…")
+- Use natural, specific phrasing that a buyer would be interested in
+- Is written in sentence case: capitalize only the first word and proper nouns
+- Aims for 50-60 characters including spaces, and must not exceed 70
+- Is written in the same language as the product details
+
+The title should not:
+- Be wrapped in quotes
+- Be prefixed with "Title:"
+- Have commentary, alternatives, or explanation added to it
+
+Output only the title text.
+INSTRUCTION;
+// phpcs:enable

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -284,8 +284,8 @@ class OpenAI extends Provider {
 				],
 				'body'    => wp_json_encode(
 					[
-						'prompt'     => 'Once upon a time',
-						'max_tokens' => 5,
+						'prompt'                => 'Once upon a time',
+						'max_completion_tokens' => 5,
 					]
 				),
 				'use_vip' => true,

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -631,7 +631,7 @@ class OpenAI extends Provider {
 				'messages'    => [
 					[
 						'role'    => 'system',
-						'content' => 'You will be provided with content delimited by triple quotes. ' . $prompt,
+						'content' => $prompt . ' You will be provided with content delimited by triple quotes',
 					],
 					[
 						'role'    => 'user',

--- a/includes/Classifai/Providers/Browser/ChromeAI.php
+++ b/includes/Classifai/Providers/Browser/ChromeAI.php
@@ -320,7 +320,7 @@ class ChromeAI extends Provider {
 		$body = apply_filters(
 			'classifai_chrome_ai_resize_content_request_body',
 			[
-				'prompt'  => 'You will be provided with content delimited by triple quotes. ' . $prompt,
+				'prompt'  => $prompt . ' You will be provided with content delimited by triple quotes',
 				'content' => esc_html( $args['content'] ),
 				'func'    => static::ID,
 			],

--- a/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
+++ b/includes/Classifai/Providers/GoogleAI/GeminiAPI.php
@@ -488,7 +488,7 @@ class GeminiAPI extends Provider {
 				'contents'         => [
 					[
 						'parts' => [
-							'text' => 'You will be provided with content delimited by triple quotes. ' . $prompt . '\n"""' . esc_html( $args['content'] ) . '"""',
+							'text' => $prompt . ' You will be provided with content delimited by triple quotes.\n"""' . esc_html( $args['content'] ) . '"""',
 						],
 					],
 				],

--- a/includes/Classifai/Providers/Localhost/Ollama.php
+++ b/includes/Classifai/Providers/Localhost/Ollama.php
@@ -471,7 +471,7 @@ class Ollama extends Provider {
 				'messages' => [
 					[
 						'role'    => 'system',
-						'content' => 'You will be provided with content delimited by triple quotes. ' . $prompt,
+						'content' => $prompt . ' You will be provided with content delimited by triple quotes',
 					],
 					[
 						'role'    => 'user',

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -308,8 +308,8 @@ class ChatGPT extends Provider {
 		$body = apply_filters(
 			'classifai_chatgpt_descriptive_text_request_body',
 			[
-				'model'       => $this->vision_model,
-				'messages'    => [
+				'model'                 => $this->vision_model,
+				'messages'              => [
 					[
 						'role'    => 'system',
 						'content' => $prompt,
@@ -327,8 +327,8 @@ class ChatGPT extends Provider {
 						],
 					],
 				],
-				'temperature' => 0.2,
-				'max_tokens'  => 300,
+				'temperature'           => 0.2,
+				'max_completion_tokens' => 300,
 			],
 			$post_id
 		);
@@ -409,8 +409,8 @@ class ChatGPT extends Provider {
 		$body = apply_filters(
 			'classifai_chatgpt_ocr_request_body',
 			[
-				'model'       => $this->vision_model,
-				'messages'    => [
+				'model'                 => $this->vision_model,
+				'messages'              => [
 					[
 						'role'    => 'system',
 						'content' => $prompt,
@@ -428,8 +428,8 @@ class ChatGPT extends Provider {
 						],
 					],
 				],
-				'temperature' => 0.2,
-				'max_tokens'  => 300,
+				'temperature'           => 0.2,
+				'max_completion_tokens' => 300,
 			],
 			$post_id
 		);
@@ -520,8 +520,8 @@ class ChatGPT extends Provider {
 		$body = apply_filters(
 			'classifai_chatgpt_image_tag_request_body',
 			[
-				'model'       => $this->vision_model,
-				'messages'    => [
+				'model'                 => $this->vision_model,
+				'messages'              => [
 					[
 						'role'    => 'system',
 						'content' => $prompt,
@@ -539,8 +539,8 @@ class ChatGPT extends Provider {
 						],
 					],
 				],
-				'temperature' => 0.2,
-				'max_tokens'  => 300,
+				'temperature'           => 0.2,
+				'max_completion_tokens' => 300,
 			],
 			$post_id
 		);

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -861,7 +861,7 @@ class ChatGPT extends Provider {
 				'messages'    => [
 					[
 						'role'    => 'system',
-						'content' => 'You will be provided with content delimited by triple quotes. ' . $prompt,
+						'content' => $prompt . ' You will be provided with content delimited by triple quotes.',
 					],
 					[
 						'role'    => 'user',

--- a/includes/Classifai/Providers/Provider.php
+++ b/includes/Classifai/Providers/Provider.php
@@ -132,7 +132,7 @@ abstract class Provider {
 			$messages = [
 				[
 					'role'    => 'system',
-					'content' => $this->system_prompt . ' ' . $prompt,
+					'content' => $prompt . ' ' . $this->system_prompt,
 				],
 				[
 					'role'    => 'user',

--- a/includes/Classifai/Providers/XAI/Grok.php
+++ b/includes/Classifai/Providers/XAI/Grok.php
@@ -722,7 +722,7 @@ class Grok extends Provider {
 				'messages'    => [
 					[
 						'role'    => 'system',
-						'content' => 'You will be provided with content delimited by triple quotes. ' . $prompt,
+						'content' => $prompt . ' You will be provided with content delimited by triple quotes',
 					],
 					[
 						'role'    => 'user',

--- a/src/js/settings/components/feature-additional-settings/prompt-repeater.js
+++ b/src/js/settings/components/feature-additional-settings/prompt-repeater.js
@@ -86,7 +86,9 @@ export const PromptRepeater = ( props ) => {
 										'classifai'
 									) }
 								</strong>{ ' ' }
-								{ prompt.prompt }
+								<span style={ { whiteSpace: 'pre-line' } }>
+									{ prompt.prompt }
+								</span>
 							</p>
 						</>
 					) }

--- a/tests/test-plugin/e2e-test-plugin.php
+++ b/tests/test-plugin/e2e-test-plugin.php
@@ -146,7 +146,7 @@ function classifai_test_mock_http_requests( $preempt, $parsed_args, $url ) {
 
 			if ( str_contains( $prompt, 'increase the content length' ) || str_contains( $prompt, 'decrease the content length' ) ) {
 				$response = file_get_contents( __DIR__ . '/ollama-chat-resize.json' );
-			} else if ( str_contains( $prompt, 'Write an SEO-friendly title' ) ) {
+			} else if ( str_contains( $prompt, 'write a single title for that content' ) ) {
 				$response = file_get_contents( __DIR__ . '/ollama-structured-title.json' );
 			}
 		}

--- a/tests/test-plugin/e2e-test-plugin.php
+++ b/tests/test-plugin/e2e-test-plugin.php
@@ -49,7 +49,7 @@ function classifai_test_mock_http_requests( $preempt, $parsed_args, $url ) {
 			$messages = isset( $body['messages'] ) ? $body['messages'] : [];
 			$prompt   = count( $messages ) > 0 ? $messages[0]['content'] : '';
 
-			if ( str_contains( $prompt, 'Increase the content' ) || str_contains( $prompt, 'Decrease the content' ) ) {
+			if ( str_contains( $prompt, 'increase the content length' ) || str_contains( $prompt, 'decrease the content length' ) ) {
 				$response = file_get_contents( __DIR__ . '/resize-content.json' );
 			} else if ( str_contains( $prompt, 'This is a custom excerpt prompt' ) ) {
 				$response = file_get_contents( __DIR__ . '/chatgpt-custom-excerpt-prompt.json' );
@@ -57,7 +57,7 @@ function classifai_test_mock_http_requests( $preempt, $parsed_args, $url ) {
 				$response = file_get_contents( __DIR__ . '/chatgpt-custom-title-prompt.json' );
 			} else if ( str_contains( $prompt, 'This is a custom shrink prompt' ) || str_contains( $prompt, 'This is a custom grow prompt' ) ) {
 				$response = file_get_contents( __DIR__ . '/resize-content-custom-prompt.json' );
-			} else if ( str_contains( $prompt, 'provide a summary that captures all the important points' ) ) {
+			} else if ( str_contains( $prompt, 'extracting the key takeaways from an article' ) ) {
 				$response = file_get_contents( __DIR__ . '/chatgpt-key-takeaways.json' );
 			}
 		}
@@ -129,7 +129,7 @@ function classifai_test_mock_http_requests( $preempt, $parsed_args, $url ) {
 			$parts    = isset( $contents[0]['parts'] ) ? $contents[0]['parts'] : [];
 			$prompt   = $parts['text'] ?? '';
 
-			if ( str_contains( $prompt, 'Increase the content' ) || str_contains( $prompt, 'Decrease the content' ) ) {
+			if ( str_contains( $prompt, 'increase the content length' ) || str_contains( $prompt, 'decrease the content length' ) ) {
 				$response = file_get_contents( __DIR__ . '/geminiapi-resize-content.json' );
 			}
 		}
@@ -144,7 +144,7 @@ function classifai_test_mock_http_requests( $preempt, $parsed_args, $url ) {
 			$messages = isset( $body['messages'] ) ? $body['messages'] : [];
 			$prompt   = count( $messages ) > 0 ? $messages[0]['content'] : '';
 
-			if ( str_contains( $prompt, 'Increase the content' ) || str_contains( $prompt, 'Decrease the content' ) ) {
+			if ( str_contains( $prompt, 'increase the content length' ) || str_contains( $prompt, 'decrease the content length' ) ) {
 				$response = file_get_contents( __DIR__ . '/ollama-chat-resize.json' );
 			} else if ( str_contains( $prompt, 'Write an SEO-friendly title' ) ) {
 				$response = file_get_contents( __DIR__ . '/ollama-structured-title.json' );

--- a/wp-hooks-docs/docs/03.advanced-docs/09.extending-classifai.md
+++ b/wp-hooks-docs/docs/03.advanced-docs/09.extending-classifai.md
@@ -328,8 +328,8 @@ private function call_chatgpt( array $settings, string $prompt, string $content 
     );
 
     $body = [
-        'model'       => 'gpt-4o-mini',
-        'messages'    => [
+        'model'                 => 'gpt-4o-mini',
+        'messages'              => [
             [
                 'role'    => 'system',
                 'content' => $prompt,
@@ -339,8 +339,8 @@ private function call_chatgpt( array $settings, string $prompt, string $content 
                 'content' => $content,
             ],
         ],
-        'temperature' => 0.3,
-        'max_tokens'  => 2000,
+        'temperature'           => 0.3,
+        'max_completion_tokens' => 2000,
     ];
 
     // Make the API request.


### PR DESCRIPTION
### Description of the Change

The prompts we use in ClassifAI stem back to when we were trying to support `gpt-3.5-turbo` which had a context window of something like 4000 tokens. We wanted to keep our prompts as simple as possible to avoid using too much of that context.

While we don't want to use context for the sake of using context, the default models in ClassifAI now support multiple hundreds of thousands of tokens and as such, it was time to re-evaluate our prompts.

This PR updates all of our prompts to be more robust while trying to preserve the original intent. This could be a good time to discuss if we want to make any fundamental changes to these prompts (for instance, making our Descriptive Text Generator be better at producing accessible alt text) but for now, I've tried to avoid any major changes.

### How to test the Change

The following Features all have modified prompts and will need tested:

- Content Generation
- Content Resizing
- Descriptive Text Generator
- Excerpt Generation
- Image Tags Generator
- Image Text Extraction
- Key Takeaways
- Title Generation

Let me know if any specific test instructions are needed for those.

Also worth noting these new default prompts should show in the settings for each of these, so that is another area you can use to verify the changes.

### Changelog Entry

> Changed - Update all of our default prompts to be more robust
> Fixed - Ensure our default prompts render with line breaks in the settings screen
> Fixed - Switch from the deprecated `max_tokens` param to `max_completion_tokens`

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
