### PR TITLE
Fix the styles of the title generation modal

### DIFF
--- a/src/js/features/title-generation/index.js
+++ b/src/js/features/title-generation/index.js
@@ -97,13 +97,13 @@ const TitleGenerationPlugin = () => {
 		}
 
 		return (
-			<Flex gap="5" wrap>
+			<Flex gap="5" wrap align="flex-start">
 				{ dataToRender.map( ( item, i ) => {
 					return (
 						<FlexItem
 							className="classifai-title"
 							key={ i }
-							style={ { flexGrow: 1 } }
+							style={ { flexBasis: 'calc(50% - 10px)' } }
 						>
 							<TextareaControl
 								rows="5"
@@ -117,6 +117,7 @@ const TitleGenerationPlugin = () => {
 							/>
 							<Button
 								variant="secondary"
+								style={ { marginTop: '8px' } }
 								onClick={ async () => {
 									const isDirty =
 										select(
@@ -174,6 +175,7 @@ const TitleGenerationPlugin = () => {
 						<Button
 							className={ feature?.feature }
 							variant="secondary"
+							disabled={ isOpen }
 							onClick={ () => buttonClick( path ) }
 						>
 							{ feature?.buttonText }


### PR DESCRIPTION
### Description of the Change

Currently the title generation modal has some styling issues, namely the select button doesn't have any top margin and if you have it set to generate an odd number of titles (3, 5, 7, etc), the last item expands the full width though the other items only take up half width. This PR addresses both.

| Before | After |
| ---- | ---- |
| <img width="571" height="527" alt="Title generation modal before changes" src="https://github.com/user-attachments/assets/e76ee82d-aba8-439e-ade2-7c731f3f558e" /> | <img width="565" height="510" alt="Title generation modal after changes" src="https://github.com/user-attachments/assets/30e626bb-82a1-41eb-bc63-2c39e76aaf60" /> |

### How to test the Change

1. Enable Title Generation
2. Set `Number of suggestions` to 3
3. Go to a post and click the `Generate titles` button in the sidebar
4. Ensure a modal opens and title results are rendered properly

### Changelog Entry

> Fixed - Update the Title Generation modal styling

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2F10up%2Fclassifai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1100-3694a345cc57bbd7381739b1baa3cc3b4f561272.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->