### PR TITLE
Fix some style issues

### DIFF
--- a/includes/Classifai/Blocks/key-takeaways/edit.js
+++ b/includes/Classifai/Blocks/key-takeaways/edit.js
@@ -136,6 +136,8 @@ const BlockEdit = ( props ) => {
 						variant={ 'secondary' }
 						onClick={ () => setRun( true ) }
 						isBusy={ isLoading }
+						disabled={ isLoading }
+						accessibleWhenDisabled
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/src/js/features/text-to-speech/index.js
+++ b/src/js/features/text-to-speech/index.js
@@ -232,7 +232,10 @@ const TextToSpeechPlugin = () => {
 				<>
 					<div style={ { marginTop: '12px' } }>
 						<ToggleControl
-							label={ __( 'Display audio controls', 'classifai' ) }
+							label={ __(
+								'Display audio controls',
+								'classifai'
+							) }
 							help={ __(
 								'Controls the display of the audio player on the front-end.',
 								'classifai'

--- a/src/js/features/text-to-speech/index.js
+++ b/src/js/features/text-to-speech/index.js
@@ -230,46 +230,52 @@ const TextToSpeechPlugin = () => {
 			/>
 			{ sourceUrl && (
 				<>
-					<ToggleControl
-						label={ __( 'Display audio controls', 'classifai' ) }
-						help={ __(
-							'Controls the display of the audio player on the front-end.',
-							'classifai'
-						) }
-						checked={ displayGeneratedAudio }
-						onChange={ ( value ) => {
-							wp.data.dispatch( 'core/editor' ).editPost( {
-								classifai_display_generated_audio: value,
-							} );
-						} }
-						disabled={ isProcessingAudio }
-						isBusy={ isProcessingAudio }
-					/>
-					<BaseControl
-						id="classifai-audio-preview-controls"
-						help={
-							isProcessingAudio
-								? ''
-								: __(
-										'Preview the generated audio.',
-										'classifai'
-								  )
-						}
-						__nextHasNoMarginBottom
-					>
-						<Button
-							id="classifai-audio-controls__preview-btn"
-							icon={ <Icon icon={ audioIcon } /> }
-							variant="secondary"
-							onClick={ () => setIsPreviewing( ! isPreviewing ) }
+					<div style={ { marginTop: '12px' } }>
+						<ToggleControl
+							label={ __( 'Display audio controls', 'classifai' ) }
+							help={ __(
+								'Controls the display of the audio player on the front-end.',
+								'classifai'
+							) }
+							checked={ displayGeneratedAudio }
+							onChange={ ( value ) => {
+								wp.data.dispatch( 'core/editor' ).editPost( {
+									classifai_display_generated_audio: value,
+								} );
+							} }
 							disabled={ isProcessingAudio }
 							isBusy={ isProcessingAudio }
+						/>
+					</div>
+					<div style={ { marginTop: '12px' } }>
+						<BaseControl
+							id="classifai-audio-preview-controls"
+							help={
+								isProcessingAudio
+									? ''
+									: __(
+											'Preview the generated audio.',
+											'classifai'
+									  )
+							}
+							__nextHasNoMarginBottom
 						>
-							{ isProcessingAudio
-								? __( 'Generating audio..', 'classifai' )
-								: __( 'Preview', 'classifai' ) }
-						</Button>
-					</BaseControl>
+							<Button
+								id="classifai-audio-controls__preview-btn"
+								icon={ <Icon icon={ audioIcon } /> }
+								variant="secondary"
+								onClick={ () =>
+									setIsPreviewing( ! isPreviewing )
+								}
+								disabled={ isProcessingAudio }
+								isBusy={ isProcessingAudio }
+							>
+								{ isProcessingAudio
+									? __( 'Generating audio..', 'classifai' )
+									: __( 'Preview', 'classifai' ) }
+							</Button>
+						</BaseControl>
+					</div>
 				</>
 			) }
 			{ sourceUrl && (


### PR DESCRIPTION
### Description of the Change

After working on #1100 figured I'd quickly check the other features to see if there were any problems that could quickly be addressed. Found two:

1. If regenerating Key Takeaways, the button wasn't being disabled
2. After text-to-speech is run, the elements we render in the sidebar didn't have proper spacing

| Before | After |
| ---- | ---- |
| <img width="299" height="330" alt="Key Takeaways regenerate button not disabled" src="https://github.com/user-attachments/assets/90fdb7ca-abf7-4b98-b762-904bf5c53018" /> | <img width="316" height="349" alt="Key Takeaways regenerate button disabled" src="https://github.com/user-attachments/assets/7e8f90f5-0ca0-4636-a8ad-b8ebbe803bfe" /> |
| <img width="289" height="282" alt="Text to speech controls with no spacing" src="https://github.com/user-attachments/assets/fbf1567d-5a7b-4c86-99a4-e067284aead3" /> | <img width="291" height="305" alt="Text to speech controls with spacing" src="https://github.com/user-attachments/assets/fde453c5-1cf0-4915-a748-e55ac49c9bd2" /> |

### How to test the Change

1. Turn on Key Takeaways, run that on a post and then click the refresh button in the sidebar. Ensure this works
2. Turn on TTS, run that on a post and then find the controls in the sidebar. Ensure they render properly

### Changelog Entry

> Fixed - Admin style issues for Key Takeaways and Text to Speech 

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2F10up%2Fclassifai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1101-8a69551912729cfc82db20edf4cd1ca41df6e6cf.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->