### PR TITLE
Ensure returned content matches our format by using `response_format`

### DIFF
--- a/includes/Classifai/Features/Prompts/ImageTagsGenerator/default.php
+++ b/includes/Classifai/Features/Prompts/ImageTagsGenerator/default.php
@@ -18,8 +18,6 @@ Generate 3-5 tags that:
 - Do not infer identities, emotions, age, gender, race, or ethnicity unless these are visually unambiguous and central to the image
 - Avoid generic photography meta-tags: "stock photo", "high resolution", "professional photography", "image", "picture", "photo"
 
-Format the output as a Markdown bulleted list, one tag per line, prefixed with "- ".
-
-Output only the list. Do not add a heading, preamble ("Here are the tags:"), trailing commentary, ellipsis, or numbering.
+Return only tags that satisfy these rules.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/ImageTagsGenerator/default.php
+++ b/includes/Classifai/Features/Prompts/ImageTagsGenerator/default.php
@@ -18,6 +18,6 @@ Generate 3-5 tags that:
 - Do not infer identities, emotions, age, gender, race, or ethnicity unless these are visually unambiguous and central to the image
 - Avoid generic photography meta-tags: "stock photo", "high resolution", "professional photography", "image", "picture", "photo"
 
-Return only tags that satisfy these rules.
+Return only tags that satisfy these rules. Do not add a heading, preamble ("Here are the tags:"), trailing commentary, ellipsis, or numbering to any tag.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/KeyTakeaways/default.php
+++ b/includes/Classifai/Features/Prompts/KeyTakeaways/default.php
@@ -23,6 +23,6 @@ Extract 2-4 key takeaways that:
 - Are written in the same language as the article
 - Avoid restating the title or article headings verbatim
 
-Output only the list. Do not add a heading ("Key takeaways:"), do not add a preamble ("Here are the…"), do not number the items, and do not add trailing commentary.
+Return only takeaways that satisfy these rules. Do not add a heading ("Key takeaways:"), do not add a preamble ("Here are the…"), do not number the items, and do not add trailing commentary.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Providers/Azure/OpenAI.php
+++ b/includes/Classifai/Providers/Azure/OpenAI.php
@@ -788,8 +788,10 @@ class OpenAI extends Provider {
 							'type'                 => 'object',
 							'properties'           => [
 								'takeaways' => [
-									'type'  => 'array',
-									'items' => [
+									'type'     => 'array',
+									'minItems' => 2,
+									'maxItems' => 4,
+									'items'    => [
 										'type' => 'string',
 									],
 								],

--- a/includes/Classifai/Providers/Localhost/Ollama.php
+++ b/includes/Classifai/Providers/Localhost/Ollama.php
@@ -621,14 +621,28 @@ class Ollama extends Provider {
 				'messages' => [
 					[
 						'role'    => 'system',
-						'content' => 'You will be provided with content delimited by triple quotes. Ensure the response you return is valid JSON, in the structure {"takeaways":["first","second"]}. ' . $prompt,
+						'content' => 'You will be provided with content delimited by triple quotes. ' . $prompt,
 					],
 					[
 						'role'    => 'user',
 						'content' => '"""' . $content . '"""',
 					],
 				],
-				'format'   => 'json',
+				'format'   => [
+					'type'                 => 'object',
+					'properties'           => [
+						'takeaways' => [
+							'type'     => 'array',
+							'minItems' => 2,
+							'maxItems' => 4,
+							'items'    => [
+								'type' => 'string',
+							],
+						],
+					],
+					'required'             => [ 'takeaways' ],
+					'additionalProperties' => false,
+				],
 				'stream'   => false,
 			],
 			$post_id

--- a/includes/Classifai/Providers/Localhost/OllamaMultimodal.php
+++ b/includes/Classifai/Providers/Localhost/OllamaMultimodal.php
@@ -37,13 +37,39 @@ class OllamaMultimodal extends Ollama {
 		$models = parent::get_models( $args );
 
 		$supported_models = [
-			'llava',
 			'bakllava',
+			'deepseek-ocr',
+			'devstral-small-2',
+			'gemini-3-flash-preview',
+			'gemma3',
+			'gemma4',
+			'glm-ocr',
+			'granite3.2-vision',
+			'kimi-k2.5',
+			'kimi-k2.6',
 			'llama3.2-vision',
+			'llama4',
+			'llava',
 			'llava-llama3',
-			'moondream',
-			'minicpm-v',
 			'llava-phi3',
+			'medgemma',
+			'medgemma1.5',
+			'minicpm-v',
+			'minicpm-v4.5',
+			'minicpm-v4.6',
+			'minimax-m3',
+			'ministral-3',
+			'moondream',
+			'mistral-large-3',
+			'mistral-medium-3.5',
+			'mistral-small3.1',
+			'mistral-small3.2',
+			'nemotron3',
+			'qwen2.5vl',
+			'qwen3-vl',
+			'qwen3.5',
+			'qwen3.6',
+			'translategemma',
 		];
 
 		// Ensure our model list only contains the ones we support.
@@ -316,6 +342,21 @@ class OllamaMultimodal extends Ollama {
 				'model'  => $settings['model'] ?? '',
 				'prompt' => $prompt,
 				'images' => [ base64_encode( $image_data ) ], // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				'format' => [
+					'type'                 => 'object',
+					'properties'           => [
+						'tags' => [
+							'type'     => 'array',
+							'minItems' => 3,
+							'maxItems' => 5,
+							'items'    => [
+								'type' => 'string',
+							],
+						],
+					],
+					'required'             => [ 'tags' ],
+					'additionalProperties' => false,
+				],
 				'stream' => false,
 			],
 			$attachment_id
@@ -326,8 +367,19 @@ class OllamaMultimodal extends Ollama {
 
 		// If we have a response, clean it up.
 		if ( ! is_wp_error( $response ) ) {
-			$response = array_filter( explode( '- ', $response ) );
-			$response = array_map( 'trim', $response );
+			// We expect the response to be valid JSON since we requested that schema.
+			$image_tags = json_decode( $response, true );
+
+			if ( isset( $image_tags['tags'] ) && is_array( $image_tags['tags'] ) ) {
+				$response = array_filter(
+					array_map(
+						function ( $tag ) {
+							return sanitize_text_field( trim( $tag, ' "\'' ) );
+						},
+						$image_tags['tags']
+					)
+				);
+			}
 		}
 
 		// Ensure we have a valid response after processing.

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -539,6 +539,28 @@ class ChatGPT extends Provider {
 						],
 					],
 				],
+				'response_format'       => [
+					'type'        => 'json_schema',
+					'json_schema' => [
+						'name'   => 'image_tags',
+						'schema' => [
+							'type'                 => 'object',
+							'properties'           => [
+								'tags' => [
+									'type'     => 'array',
+									'minItems' => 3,
+									'maxItems' => 5,
+									'items'    => [
+										'type' => 'string',
+									],
+								],
+							],
+							'required'             => [ 'tags' ],
+							'additionalProperties' => false,
+						],
+						'strict' => true,
+					],
+				],
 				'temperature'           => 0.2,
 				'max_completion_tokens' => 300,
 			],
@@ -561,8 +583,22 @@ class ChatGPT extends Provider {
 		if ( ! empty( $response['choices'] ) ) {
 			foreach ( $response['choices'] as $choice ) {
 				if ( isset( $choice['message'], $choice['message']['content'] ) ) {
-					$response = array_filter( explode( '- ', $choice['message']['content'] ) );
-					$response = array_map( 'trim', $response );
+					// We expect the response to be valid JSON since we requested that schema.
+					$image_tags = json_decode( $choice['message']['content'], true );
+
+					if ( empty( $image_tags['tags'] ) || ! is_array( $image_tags['tags'] ) ) {
+						$response = new WP_Error( 'invalid_response', esc_html__( 'No tags found.', 'classifai' ) );
+						break;
+					}
+
+					$response = array_filter(
+						array_map(
+							function ( $tag ) {
+								return sanitize_text_field( trim( $tag, ' "\'' ) );
+							},
+							$image_tags['tags']
+						)
+					);
 
 					// Save all the tags for later.
 					update_post_meta( $post_id, 'classifai_computer_vision_image_tags', $response );

--- a/includes/Classifai/Providers/OpenAI/ChatGPT.php
+++ b/includes/Classifai/Providers/OpenAI/ChatGPT.php
@@ -1053,8 +1053,10 @@ class ChatGPT extends Provider {
 							'type'                 => 'object',
 							'properties'           => [
 								'takeaways' => [
-									'type'  => 'array',
-									'items' => [
+									'type'     => 'array',
+									'minItems' => 2,
+									'maxItems' => 4,
+									'items'    => [
 										'type' => 'string',
 									],
 								],

--- a/tests/Integration/Providers/ImageTagsGeneratorStructuredOutputTest.php
+++ b/tests/Integration/Providers/ImageTagsGeneratorStructuredOutputTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Tests for structured image tag output from vision providers.
+ */
+
+namespace Classifai\Tests\Providers;
+
+use Classifai\Features\ImageTagsGenerator;
+use Classifai\Providers\Localhost\OllamaMultimodal;
+use Classifai\Providers\OpenAI\ChatGPT;
+use WP_UnitTestCase;
+
+/**
+ * Class ImageTagsGeneratorStructuredOutputTest
+ *
+ * @package Classifai\Tests\Providers;
+ */
+class ImageTagsGeneratorStructuredOutputTest extends WP_UnitTestCase {
+	/**
+	 * Tear down method.
+	 */
+	public function tear_down() {
+		$this->remove_added_uploads();
+		remove_all_filters( 'classifai_feature_image_tags_generator_is_feature_enabled' );
+		remove_all_filters( 'pre_option_classifai_feature_image_tags_generator' );
+		remove_all_filters( 'pre_http_request' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that OpenAI uses structured output for image tags.
+	 */
+	public function test_openai_generates_image_tags_from_structured_output() {
+		$attachment_id = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/33772.jpg' );
+		$request_body  = [];
+
+		add_filter( 'classifai_feature_image_tags_generator_is_feature_enabled', '__return_true' );
+		add_filter(
+			'pre_option_classifai_feature_image_tags_generator',
+			function () {
+				return [
+					'status'             => '1',
+					'provider'           => ChatGPT::ID,
+					'tag_taxonomy'       => 'post_tag',
+					ChatGPT::ID          => [
+						'authenticated' => true,
+					],
+					OllamaMultimodal::ID => [
+						'authenticated' => true,
+					],
+				];
+			}
+		);
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $parsed_args, $url ) use ( &$request_body ) {
+				if ( false === strpos( $url, 'api.openai.com/v1/chat/completions' ) ) {
+					return $preempt;
+				}
+
+				$request_body = json_decode( $parsed_args['body'], true );
+
+				return [
+					'headers'  => [
+						'content-type' => 'application/json',
+					],
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => wp_json_encode(
+						[
+							'choices' => [
+								[
+									'message' => [
+										'content' => wp_json_encode(
+											[
+												'tags' => [
+													'cat',
+													'window',
+													'sunlight',
+												],
+											]
+										),
+									],
+								],
+							],
+						]
+					),
+				];
+			},
+			10,
+			3
+		);
+
+		$provider = new ChatGPT( new ImageTagsGenerator() );
+		$result   = $provider->generate_image_tags( $attachment_id );
+		$schema   = $request_body['response_format']['json_schema'] ?? [];
+
+		$this->assertSame( [ 'cat', 'window', 'sunlight' ], $result );
+		$this->assertSame( 'json_schema', $request_body['response_format']['type'] ?? '' );
+		$this->assertSame( 'image_tags', $schema['name'] ?? '' );
+		$this->assertSame( [ 'tags' ], $schema['schema']['required'] ?? [] );
+		$this->assertTrue( $schema['strict'] ?? false );
+	}
+
+	/**
+	 * Test that Ollama uses structured output for image tags.
+	 */
+	public function test_ollama_generates_image_tags_from_structured_output() {
+		$attachment_id = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/33772.jpg' );
+		$image_path    = get_attached_file( $attachment_id );
+		$request_body  = [];
+
+		add_filter( 'classifai_feature_image_tags_generator_is_feature_enabled', '__return_true' );
+		add_filter(
+			'pre_option_classifai_feature_image_tags_generator',
+			function () {
+				return [
+					'status'             => '1',
+					'provider'           => OllamaMultimodal::ID,
+					'tag_taxonomy'       => 'post_tag',
+					ChatGPT::ID          => [
+						'authenticated' => true,
+					],
+					OllamaMultimodal::ID => [
+						'authenticated' => true,
+						'endpoint_url'   => 'http://localhost:11434',
+						'model'          => 'llava',
+					],
+				];
+			}
+		);
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $parsed_args, $url ) use ( &$request_body ) {
+				if ( false === strpos( $url, 'localhost:11434' ) ) {
+					return $preempt;
+				}
+
+				$request_body = json_decode( $parsed_args['body'], true );
+
+				return [
+					'headers'  => [
+						'content-type' => 'application/json',
+					],
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => wp_json_encode(
+						[
+							'response' => wp_json_encode(
+								[
+									'tags' => [
+										'cat',
+										'window',
+										'sunlight',
+									],
+								]
+							),
+						]
+					),
+				];
+			},
+			10,
+			3
+		);
+
+		$provider = new OllamaMultimodal( new ImageTagsGenerator() );
+		$result   = $provider->generate_image_tags( $image_path, $attachment_id );
+
+		$this->assertSame( [ 'cat', 'window', 'sunlight' ], $result );
+		$this->assertSame( [ 'tags' ], $request_body['format']['required'] ?? [] );
+		$this->assertSame( 'array', $request_body['format']['properties']['tags']['type'] ?? '' );
+		$this->assertSame( 3, $request_body['format']['properties']['tags']['minItems'] ?? 0 );
+		$this->assertSame( 5, $request_body['format']['properties']['tags']['maxItems'] ?? 0 );
+	}
+}

--- a/tests/Integration/Providers/KeyTakeawaysStructuredOutputTest.php
+++ b/tests/Integration/Providers/KeyTakeawaysStructuredOutputTest.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * Tests for structured key takeaways output from language providers.
+ */
+
+namespace Classifai\Tests\Providers;
+
+use Classifai\Features\KeyTakeaways;
+use Classifai\Providers\Azure\OpenAI as AzureOpenAI;
+use Classifai\Providers\Localhost\Ollama;
+use Classifai\Providers\OpenAI\ChatGPT;
+use WP_UnitTestCase;
+
+/**
+ * Class KeyTakeawaysStructuredOutputTest
+ *
+ * @package Classifai\Tests\Providers;
+ */
+class KeyTakeawaysStructuredOutputTest extends WP_UnitTestCase {
+	/**
+	 * Tear down method.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'classifai_feature_key_takeaways_is_feature_enabled' );
+		remove_all_filters( 'pre_option_classifai_feature_key_takeaways' );
+		remove_all_filters( 'pre_http_request' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that OpenAI uses bounded structured output for key takeaways.
+	 */
+	public function test_openai_generates_key_takeaways_from_structured_output() {
+		$post_id      = $this->factory->post->create();
+		$request_body = [];
+
+		$this->mock_key_takeaways_settings( ChatGPT::ID );
+		$this->mock_openai_response( $request_body );
+
+		$provider = new ChatGPT( new KeyTakeaways() );
+		$result   = $provider->generate_key_takeaways(
+			$post_id,
+			[
+				'content' => 'This article explains structured outputs and why they help parsing.',
+				'title'   => 'Structured Outputs',
+			]
+		);
+		$schema   = $request_body['response_format']['json_schema']['schema']['properties']['takeaways'] ?? [];
+
+		$this->assertSame(
+			[
+				'Structured outputs make provider responses easier to parse.',
+				'Schemas reduce formatting instructions in prompts.',
+			],
+			$result
+		);
+		$this->assertSame( 'json_schema', $request_body['response_format']['type'] ?? '' );
+		$this->assertSame( 2, $schema['minItems'] ?? 0 );
+		$this->assertSame( 4, $schema['maxItems'] ?? 0 );
+	}
+
+	/**
+	 * Test that Ollama uses bounded structured output for key takeaways.
+	 */
+	public function test_ollama_generates_key_takeaways_from_structured_output() {
+		$post_id      = $this->factory->post->create();
+		$request_body = [];
+
+		$this->mock_key_takeaways_settings( Ollama::ID );
+		$this->mock_ollama_response( $request_body );
+
+		$provider = new Ollama( new KeyTakeaways() );
+		$result   = $provider->generate_key_takeaways(
+			$post_id,
+			[
+				'content' => 'This article explains structured outputs and why they help parsing.',
+				'title'   => 'Structured Outputs',
+			]
+		);
+		$schema   = $request_body['format']['properties']['takeaways'] ?? [];
+
+		$this->assertSame(
+			[
+				'Structured outputs make provider responses easier to parse.',
+				'Schemas reduce formatting instructions in prompts.',
+			],
+			$result
+		);
+		$this->assertSame( [ 'takeaways' ], $request_body['format']['required'] ?? [] );
+		$this->assertSame( 2, $schema['minItems'] ?? 0 );
+		$this->assertSame( 4, $schema['maxItems'] ?? 0 );
+	}
+
+	/**
+	 * Test that Azure OpenAI uses bounded structured output for key takeaways.
+	 */
+	public function test_azure_openai_generates_key_takeaways_from_structured_output() {
+		$post_id      = $this->factory->post->create();
+		$request_body = [];
+
+		$this->mock_key_takeaways_settings( AzureOpenAI::ID );
+		$this->mock_azure_openai_response( $request_body );
+
+		$provider = new AzureOpenAI( new KeyTakeaways() );
+		$result   = $provider->generate_key_takeaways(
+			$post_id,
+			[
+				'content' => 'This article explains structured outputs and why they help parsing.',
+				'title'   => 'Structured Outputs',
+			]
+		);
+		$schema   = $request_body['response_format']['json_schema']['schema']['properties']['takeaways'] ?? [];
+
+		$this->assertSame(
+			[
+				'Structured outputs make provider responses easier to parse.',
+				'Schemas reduce formatting instructions in prompts.',
+			],
+			$result
+		);
+		$this->assertSame( 'json_schema', $request_body['response_format']['type'] ?? '' );
+		$this->assertSame( 2, $schema['minItems'] ?? 0 );
+		$this->assertSame( 4, $schema['maxItems'] ?? 0 );
+	}
+
+	/**
+	 * Mock Key Takeaways feature settings.
+	 *
+	 * @param string $provider_id Provider ID.
+	 */
+	private function mock_key_takeaways_settings( string $provider_id ): void {
+		add_filter( 'classifai_feature_key_takeaways_is_feature_enabled', '__return_true' );
+		add_filter(
+			'pre_option_classifai_feature_key_takeaways',
+			function () use ( $provider_id ) {
+				return [
+					'status'               => '1',
+					'provider'             => $provider_id,
+					'key_takeaways_prompt' => [],
+					ChatGPT::ID            => [
+						'authenticated' => true,
+					],
+					Ollama::ID             => [
+						'authenticated' => true,
+						'endpoint_url'   => 'http://localhost:11434',
+						'model'          => 'llama3',
+					],
+					AzureOpenAI::ID        => [
+						'authenticated' => true,
+						'endpoint_url'   => 'https://example.openai.azure.com',
+						'api_key'        => 'test-api-key',
+						'deployment'     => 'test-deployment',
+					],
+				];
+			}
+		);
+	}
+
+	/**
+	 * Mock OpenAI response.
+	 *
+	 * @param array $request_body Captured request body.
+	 */
+	private function mock_openai_response( array &$request_body ): void {
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $parsed_args, $url ) use ( &$request_body ) {
+				if ( false === strpos( $url, 'api.openai.com/v1/chat/completions' ) ) {
+					return $preempt;
+				}
+
+				$request_body = json_decode( $parsed_args['body'], true );
+
+				return $this->get_chat_completion_response();
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Mock Ollama response.
+	 *
+	 * @param array $request_body Captured request body.
+	 */
+	private function mock_ollama_response( array &$request_body ): void {
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $parsed_args, $url ) use ( &$request_body ) {
+				if ( false === strpos( $url, 'localhost:11434' ) ) {
+					return $preempt;
+				}
+
+				$request_body = json_decode( $parsed_args['body'], true );
+
+				return [
+					'headers'  => [
+						'content-type' => 'application/json',
+					],
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => wp_json_encode(
+						[
+							'message' => [
+								'content' => $this->get_takeaways_json(),
+							],
+						]
+					),
+				];
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Mock Azure OpenAI response.
+	 *
+	 * @param array $request_body Captured request body.
+	 */
+	private function mock_azure_openai_response( array &$request_body ): void {
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $parsed_args, $url ) use ( &$request_body ) {
+				if ( false === strpos( $url, 'example.openai.azure.com' ) ) {
+					return $preempt;
+				}
+
+				$request_body = json_decode( $parsed_args['body'], true );
+
+				return $this->get_chat_completion_response();
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Get a chat completion response.
+	 *
+	 * @return array
+	 */
+	private function get_chat_completion_response(): array {
+		return [
+			'headers'  => [
+				'content-type' => 'application/json',
+			],
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+			'body'     => wp_json_encode(
+				[
+					'choices' => [
+						[
+							'message' => [
+								'content' => $this->get_takeaways_json(),
+							],
+						],
+					],
+				]
+			),
+		];
+	}
+
+	/**
+	 * Get the structured takeaways JSON response.
+	 *
+	 * @return string
+	 */
+	private function get_takeaways_json(): string {
+		return wp_json_encode(
+			[
+				'takeaways' => [
+					'Structured outputs make provider responses easier to parse.',
+					'Schemas reduce formatting instructions in prompts.',
+				],
+			]
+		);
+	}
+}

--- a/tests/e2e/specs/image-processing/image-processing-openai-chatgpt.spec.ts
+++ b/tests/e2e/specs/image-processing/image-processing-openai-chatgpt.spec.ts
@@ -598,7 +598,7 @@ test.describe( 'OpenAI ChatGPT Image Tag and Text Generator Tests', () => {
 		).toContainText( 'Rescan for text' );
 
 		// Verify generated Data.
-		const tags = [ 'Hello there', 'how may I assist you today?' ];
+		const tags = [ 'cat', 'window', 'sunlight' ];
 		await expect( page.locator( '#attachment_content' ) ).toHaveValue(
 			'Hello there, how may I assist you today?'
 		);

--- a/tests/test-plugin/chatgpt-image-tags.json
+++ b/tests/test-plugin/chatgpt-image-tags.json
@@ -1,0 +1,36 @@
+{
+	"id": "chatcmpl-DDb2Mg8vWjBTZnIMZ0Un9BwCq0c0D",
+	"object": "chat.completion",
+	"created": 1772133006,
+	"model": "gpt-4o-mini-2024-07-18",
+	"choices": [
+		{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "{\"tags\":[\"cat\",\"window\",\"sunlight\"]}",
+				"refusal": null,
+				"annotations": []
+			},
+			"logprobs": null,
+			"finish_reason": "stop"
+		}
+	],
+	"usage": {
+		"prompt_tokens": 981,
+		"completion_tokens": 52,
+		"total_tokens": 1033,
+		"prompt_tokens_details": {
+			"cached_tokens": 0,
+			"audio_tokens": 0
+		},
+		"completion_tokens_details": {
+			"reasoning_tokens": 0,
+			"audio_tokens": 0,
+			"accepted_prediction_tokens": 0,
+			"rejected_prediction_tokens": 0
+		}
+	},
+	"service_tier": "default",
+	"system_fingerprint": "fp_373a14eb6f"
+}

--- a/tests/test-plugin/e2e-test-plugin.php
+++ b/tests/test-plugin/e2e-test-plugin.php
@@ -59,6 +59,8 @@ function classifai_test_mock_http_requests( $preempt, $parsed_args, $url ) {
 				$response = file_get_contents( __DIR__ . '/resize-content-custom-prompt.json' );
 			} else if ( str_contains( $prompt, 'extracting the key takeaways from an article' ) ) {
 				$response = file_get_contents( __DIR__ . '/chatgpt-key-takeaways.json' );
+			} else if ( str_contains( $prompt, 'generating tags for an image uploaded' ) ) {
+				$response = file_get_contents( __DIR__ . '/chatgpt-image-tags.json' );
 			}
 		}
 	} elseif ( strpos( $url, 'https://api.openai.com/v1/moderations' ) !== false ) {


### PR DESCRIPTION
### Description of the Change

OpenAI and most other LLMs now support a `response_format` field that allows you to request the format in a certain JSON schema. This is more reliable than asking for a certain response type in the prompt as some LLMs will follow that and some don't.

Image Tags Generator is the main Feature being updated here as the prompt asked the LLM to return 2-4 tags in a list. Now we instead pass in the JSON schema we want in our request which makes it way more reliable to parse out those tags.

The other Feature updated here is Key Takeaways, which was already passing the `response_format` for OpenAI and Azure OpenAI but not Ollama, so updated that.

In addition, our list of Ollama vision models was out of date so updated that as well.

### How to test the Change

1. Enable Key Takeaways and Image Tags Generator
2. Set these up with OpenAI or Ollama (if Ollama, ensure you have a proper model selected)
3. Test those Features out and ensure they still work

### Changelog Entry

> Changed - Use the `response_format` parameter to ensure the response we get matches what we expect

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2F10up%2Fclassifai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1109-90a38b8f65eaa63a2ee62115a8438e0ec2345b22.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->