### PR TITLE
Fix TTS cache bug

### DIFF
--- a/includes/Classifai/Features/TextToSpeech.php
+++ b/includes/Classifai/Features/TextToSpeech.php
@@ -398,7 +398,8 @@ class TextToSpeech extends Feature {
 			$results = $this->run( $request->get_param( 'id' ), 'synthesize' );
 
 			if ( $results && ! is_wp_error( $results ) ) {
-				$attachment_id = $this->save( $results, $request->get_param( 'id' ) );
+				// An integer result means the provider returned a cached attachment ID
+				$attachment_id = is_int( $results ) ? $results : $this->save( $results, $request->get_param( 'id' ) );
 
 				if ( ! is_wp_error( $attachment_id ) ) {
 					return rest_ensure_response(
@@ -676,7 +677,10 @@ class TextToSpeech extends Feature {
 		$results = $this->run( $post_id, 'synthesize' );
 
 		if ( $results && ! is_wp_error( $results ) ) {
-			$this->save( $results, $post_id );
+			// An integer result means the provider returned a cached attachment ID
+			if ( ! is_int( $results ) ) {
+				$this->save( $results, $post_id );
+			}
 			delete_post_meta( $post_id, '_classifai_text_to_speech_error' );
 		} elseif ( is_wp_error( $results ) ) {
 			update_post_meta(

--- a/tests/Integration/Features/TextToSpeechTest.php
+++ b/tests/Integration/Features/TextToSpeechTest.php
@@ -125,4 +125,32 @@ class TextToSpeechTest extends TestCase {
 		$this->assertSame( $second, (int) get_post_meta( $post_id, TextToSpeech::AUDIO_ID_KEY, true ) );
 		$this->assertNull( get_post( $first ), 'The old audio attachment is deleted.' );
 	}
+
+	/**
+	 * When the provider returns a cached attachment ID (content unchanged), the
+	 * existing audio must be left intact rather than overwritten with the
+	 * numeric ID coerced to a string.
+	 *
+	 * @covers ::generate_text_to_speech_audio
+	 */
+	public function test_cached_audio_is_not_overwritten() {
+		$feature = new TextToSpeech();
+		$post_id = self::factory()->post->create( [ 'post_content' => 'Some content to read.' ] );
+		$this->as_user_with_role( 'administrator' );
+		$this->enable_feature();
+
+		// Seed a previously generated audio attachment.
+		$attachment_id = $feature->save( 'real-audio-bytes', $post_id );
+		$audio_file    = get_attached_file( $attachment_id );
+
+		// Mark the saved content hash so the provider's cached branch is taken.
+		update_post_meta( $post_id, TextToSpeech::AUDIO_HASH_KEY, md5( $feature->normalize_post_content( $post_id ) ) );
+
+		$feature->generate_text_to_speech_audio( $post_id );
+
+		// The attachment must be untouched: same ID, same file, same bytes.
+		$this->assertSame( $attachment_id, (int) get_post_meta( $post_id, TextToSpeech::AUDIO_ID_KEY, true ) );
+		$this->assertNotNull( get_post( $attachment_id ), 'The cached audio attachment is preserved.' );
+		$this->assertSame( 'real-audio-bytes', file_get_contents( $audio_file ) );
+	}
 }


### PR DESCRIPTION
### Description of the Change

While reviewing code for something else, found a potential bug in our Text To Speech Feature. When that Feature is run, we check to see if we have cached results (to avoid re-generating speech if the content hasn't changed). In that case, we return the attachment ID of the existing audio.

But we weren't checking for this when our callback runs, we just assumed it would always give us the audio file, not an attachment ID. This could potentially result in the existing audio file being wiped and a corrupt one being added (noting this is theoretical, didn't seem to actually be this dramatic in my testing).

This PR fixes it by checking the result returned and if that's an ID instead of a the actual audio, we don't run our save method.

### How to test the Change

I couldn't actually reproduce but the steps would be something like this:

1. Turn on the Text to Speech Feature
2. Create a post and generate speech
3. Don't change any content and re-trigger speech generation
4. The original audio file should still be there and there shouldn't be a new, broken audio file

### Changelog Entry

> Fixed - Ensure we don't overwrite a valid audio file when data already exists and content hasn't changed.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2F10up%2Fclassifai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1123-3741b273ee1284f0fc41b453b7d7c0948bf3e8eb.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->