### PR TITLE
Guard settings destructure so the settings page doesn't blank when classifAISettings is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ### Fixed
 
-- Settings page no longer crashes to a blank screen when `window.classifAISettings` is undefined (for example when a caching or optimization plugin changes script order); the settings data is now read defensively (props [@thisismyurl](https://github.com/thisismyurl) via [#XXXX](https://github.com/10up/classifai/pull/XXXX)).
+- Settings page no longer crashes to a blank screen when `window.classifAISettings` is undefined (for example when a caching or optimization plugin changes script order); the settings data is now read defensively (props [@thisismyurl](https://github.com/thisismyurl) via [#1135](https://github.com/10up/classifai/pull/1135)).
 
 ## [3.8.0] - 2026-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
+### Fixed
+
+- Settings page no longer crashes to a blank screen when `window.classifAISettings` is undefined (for example when a caching or optimization plugin changes script order); the settings data is now read defensively (props [@thisismyurl](https://github.com/thisismyurl) via [#XXXX](https://github.com/10up/classifai/pull/XXXX)).
+
 ## [3.8.0] - 2026-03-20
 
 ### Added

--- a/src/js/settings/components/classifai-settings/index.js
+++ b/src/js/settings/components/classifai-settings/index.js
@@ -43,6 +43,13 @@ const FeatureSettingsWrapper = () => {
 	const { service, feature } = useParams();
 	const serviceFeatures = Object.keys( features[ service ] || {} );
 
+	// When the settings data is unavailable (for example the global was
+	// missing) there is no feature to route to, so render nothing rather than
+	// navigating to an undefined path.
+	if ( ! serviceFeatures.length ) {
+		return null;
+	}
+
 	if ( ! serviceFeatures.includes( feature ) ) {
 		return <Navigate to={ serviceFeatures[ 0 ] } replace />;
 	}

--- a/src/js/settings/components/classifai-settings/index.js
+++ b/src/js/settings/components/classifai-settings/index.js
@@ -31,7 +31,7 @@ import { ClassifAIRegistration } from '../classifai-registration';
 import { ClassifAIWelcomeGuide } from './welcome-guide';
 import { Notices } from '../feature-settings/notices';
 
-const { services, features } = window.classifAISettings;
+const { services = {}, features = {} } = window.classifAISettings || {};
 
 /**
  * FeatureSettingsWrapper component to render the feature settings.


### PR DESCRIPTION
Hey folks,

If `window.classifAISettings` is ever undefined when the settings bundle loads, the whole settings screen goes blank with nothing but a console error to explain it. The cause is the module-scope destructure at the top of `classifai-settings/index.js` — `const { services, features } = window.classifAISettings;` runs the moment the module is imported, before React mounts, so there's no error boundary between it and the user. Anything that shifts script order or timing (a caching or optimization plugin deferring or reordering the enqueue, an asset that fails to localize) leaves the global undefined and that line throws a TypeError that takes the page down.

This PR guards just that destructure: default `services` and `features` to `{}` and fall back to `{}` when the global is missing. The downstream code already treats these defensively (`features[ service ] || {}`), so an empty object degrades into an empty settings shell instead of a white screen. The issue also floats a React error boundary and a NitroPack exclusion; I kept this change to the one-line guard that stops the crash, since those are larger design calls that deserve their own discussion. Glad to follow up on either if you want them.

One thing worth flagging plainly: an automated regression test here is awkward. There's no JS unit harness (only PHP unit and the Playwright e2e suite), and the e2e environment always localizes `window.classifAISettings`, so a test would have to force the failure synthetically — aborting or blanking the settings script via `page.route` before mount — to reproduce the undefined-global state. Your e2e suite already uses `page.route` for that kind of interception, so I'm glad to add that guard if you'd like it; I held off because it exercises a forced condition rather than a natural one, and the change itself is a defensive default with no behavior change when the global is present. Your call.

No rendered-UI change comes with this — the guard only affects the crash path when the global is absent, so there's no accessibility surface to review.

Closes #1073

(full disclosure: AI helped me identify the issue and verify my work)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2F10up%2Fclassifai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1135-0615f0de7834f8161dcbe9e45e4bb037584937d0.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->