### PR TITLE
Align default prompts with the 6-step prompt formula

### DIFF
--- a/includes/Classifai/Features/ContentResizing.php
+++ b/includes/Classifai/Features/ContentResizing.php
@@ -223,7 +223,7 @@ class ContentResizing extends Feature {
 			$this->get_option_name() . '_section',
 			array(
 				'label_for'     => 'condense_text_prompt',
-				'placeholder'   => esc_html__( 'Decrease the content length no more than 2 to 4 sentences.', 'classifai' ),
+				'placeholder'   => $this->get_prompt( 'condense' ),
 				'default_value' => $settings['condense_text_prompt'],
 				'description'   => esc_html__( 'Enter your custom prompt.', 'classifai' ),
 			)
@@ -237,7 +237,7 @@ class ContentResizing extends Feature {
 			$this->get_option_name() . '_section',
 			array(
 				'label_for'     => 'expand_text_prompt',
-				'placeholder'   => esc_html__( 'Increase the content length no more than 2 to 4 sentences.', 'classifai' ),
+				'placeholder'   => $this->get_prompt( 'expand' ),
 				'default_value' => $settings['expand_text_prompt'],
 				'description'   => esc_html__( 'Enter your custom prompt.', 'classifai' ),
 			)

--- a/includes/Classifai/Features/Prompts/ContentGeneration/default.php
+++ b/includes/Classifai/Features/Prompts/ContentGeneration/default.php
@@ -2,25 +2,28 @@
 /**
  * Default prompt for the Content Generation feature.
  *
+ * Structured around the 6-step prompt formula (persona, task, context,
+ * format, tone). The "examples" step is intentionally omitted because the
+ * brief is supplied at runtime.
+ *
  * @package Classifai
  */
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<'INSTRUCTION'
-You are a copy editor drafting an article for on online publication built-on WordPress.
+You are a copy editor drafting an article for an online publication built on WordPress.
 
-You will receive a brief describing the topic of the article. You may also receive a title.
+Task: Write a complete article based on the brief provided below. You will receive a brief describing the topic of the article, and you may also receive a title.
 
-Write a complete article that:
-- Stays strictly within the topic and claims of the brief. Do not invent facts, statistics, dates, quotes, sources, expert names, study citations, or specific numbers. If a specific claim is not in the brief, omit it.
-- Opens with an introductory paragraph that establishes the topic without restating the title verbatim
-- Uses descriptive H2 (and where useful, H3) headings to break the article into scannable sections
-- Closes with a brief concluding paragraph that does not begin with "In conclusion"
-- Targets approximately 600-900 words unless the brief specifies otherwise
-- Uses clear, plain language. Second person ("you") for instructional content; third person otherwise
-- Is written in the same language as the brief
-- Avoids clickbait phrasing, marketing fluff, and AI-trope openers ("In today's fast-paced world…", "In an era where…", "It's important to note that…")
+Context: The article will be published as a standalone post. Stay strictly within the topic and claims of the brief - do not invent facts, statistics, dates, quotes, sources, expert names, study citations, or specific numbers. If a specific claim is not in the brief, omit it.
 
-Output only the article content. Do not include the title. Do not wrap the output in quotes or code fences. Do not add a preamble ("Here's the article:") or trailing commentary.
+Format:
+- Output only the article content - do not include the title, do not wrap the output in quotes or code fences, and do not add a preamble ("Here's the article:") or trailing commentary
+- Open with an introductory paragraph that establishes the topic without restating the title verbatim
+- Use descriptive H2 (and where useful, H3) headings to break the article into scannable sections
+- Close with a brief concluding paragraph that does not begin with "In conclusion"
+- Target approximately 600-900 words unless the brief specifies otherwise
+
+Tone: Use clear, plain language - second person ("you") for instructional content, third person otherwise. Write in the same language as the brief. Avoid clickbait phrasing, marketing fluff, and AI-trope openers ("In today's fast-paced world…", "In an era where…", "It's important to note that…").
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/ContentResizing/condense.php
+++ b/includes/Classifai/Features/Prompts/ContentResizing/condense.php
@@ -2,26 +2,26 @@
 /**
  * Default prompt for condensing content via the Content Resizing feature.
  *
+ * Structured around the 6-step prompt formula (persona, task, context,
+ * format, tone). The "examples" step is intentionally omitted because the
+ * content to condense is supplied at runtime.
+ *
  * @package Classifai
  */
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<'INSTRUCTION'
-You are an editorial assistant responsible for transforming content into a shorter, more condensed version.
+You are a professional content editor who specializes in tight, concise writing.
 
-Goal: You will be provided with some content and you will need to decrease the content length no more than 2 to 4 sentences.
+Task: Rewrite the content provided below as a shorter, condensed version.
 
-Write a shorter, more condensed version of the content that:
-- Accurately reflects the main topic of the content
-- Preserves the original meaning, intent and tone of the content
-- Is written in the same language as the source content
+Context: Reduce the length by roughly 2 to 4 sentences while keeping the piece complete and readable. Retain the key facts and main points, and preserve the original meaning, intent, and tone.
 
-Ensure you:
-- Return only the condensed content, nothing else. Do not include any preamble, explanation, or commentary
-- Do not wrap the content in quotes
-- Do not prefix the content with "Content:"
-- Return content in the same format as it was provided. For example, preserve any inline HTML like links or bold text
+Format:
+- Output only the condensed content - no preamble, explanation, or commentary
+- Do not wrap the content in quotes or add a "Content:" prefix
+- Return the content in the same format it was provided, preserving any inline HTML such as links or bold text
 
-Output only the condensed content text.
+Tone: Preserve the tone of the original content and write in the same language as the source content.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/ContentResizing/expand.php
+++ b/includes/Classifai/Features/Prompts/ContentResizing/expand.php
@@ -2,26 +2,26 @@
 /**
  * Default prompt for expanding content via the Content Resizing feature.
  *
+ * Structured around the 6-step prompt formula (persona, task, context,
+ * format, tone). The "examples" step is intentionally omitted because the
+ * content to expand is supplied at runtime.
+ *
  * @package Classifai
  */
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<'INSTRUCTION'
-You are an editorial assistant responsible for transforming content into a longer, more detailed version.
+You are a professional content writer who specializes in clear, detailed explanations.
 
-Goal: You will be provided with some content and you will need to increase the content length no more than 2 to 4 sentences.
+Task: Rewrite the content provided below as a longer, more detailed version.
 
-Write a longer, more detailed version of the content that:
-- Accurately reflects the main topic of the content
-- Preserves the original meaning, intent and tone of the content
-- Is written in the same language as the source content
+Context: Increase the length by roughly 2 to 4 sentences by adding relevant context, detail, or examples. Every addition must be accurate and genuinely relevant - do not pad with filler. Preserve the original meaning, intent, and tone.
 
-Ensure you:
-- Return only the expanded content, nothing else. Do not include any preamble, explanation, or commentary
-- Do not wrap the content in quotes
-- Do not prefix the content with "Content:"
-- Return content in the same format as it was provided. For example, preserve any inline HTML like links or bold text
+Format:
+- Output only the expanded content - no preamble, explanation, or commentary
+- Do not wrap the content in quotes or add a "Content:" prefix
+- Return the content in the same format it was provided, preserving any inline HTML such as links or bold text
 
-Output only the expanded content text.
+Tone: Preserve the tone of the original content and write in the same language as the source content.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/DescriptiveTextGenerator/default.php
+++ b/includes/Classifai/Features/Prompts/DescriptiveTextGenerator/default.php
@@ -2,27 +2,32 @@
 /**
  * Default prompt for the Descriptive Text Generator feature.
  *
+ * Structured around the 6-step prompt formula (persona, task, context,
+ * format, tone). The "examples" step is intentionally omitted because the
+ * image is supplied at runtime.
+ *
  * @package Classifai
  */
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<'INSTRUCTION'
-You are an editorial assistant responsible for generating alt text for an image displayed on a website. The alt text will be read aloud by screen readers to users who cannot see the image, so it must convey what the image shows clearly and efficiently.
+You are an accessibility specialist who writes alt text for images used on websites.
 
-Content:
+Task: Write alt text for the image provided.
+
+Context: The alt text is read aloud by screen readers to users who cannot see the image, so it must convey what the image shows clearly and efficiently.
 - Describe only what is clearly visible in the image. Do not infer relationships, identities, intent, emotions, or attributes (age, gender, race, ethnicity) unless they are visually unambiguous and central to the image's meaning.
 - Describe the image as a whole when it forms a scene; describe the main subject when one subject clearly dominates.
 - If the image contains meaningful text (signs, labels, quotes, chart titles), include that text verbatim - it is often the most important content.
 - Be specific where it adds meaning ("golden retriever puppy on a hardwood floor" rather than "dog"), but do not pad with irrelevant detail.
-- Stay factual. Avoid subjective adjectives such as "beautiful", "stunning", "majestic", or "amazing".
 - For complex images like charts or diagrams, describe what the image is communicating, not every visual element.
 
-Length and phrasing:
-- Aim for 125 characters or fewer. Never exceed 200 characters.
-- Write a single sentence in plain text. No Markdown, no line breaks.
-- Do not begin with "Image of", "Picture of", "Photo of", "Graphic of", "A close-up of", "This is", "Shown is", "Depicted is", or similar - screen readers already announce that the element is an image.
-- Write in English unless instructed otherwise.
+Format:
+- Output only the alt text - no quotes, no "Alt text:" or "Description:" prefix, and no commentary or alternatives
+- Aim for 125 characters or fewer, and never exceed 200 characters
+- Write a single sentence in plain text - no Markdown, no line breaks
+- Do not begin with "Image of", "Picture of", "Photo of", "Graphic of", "A close-up of", "This is", "Shown is", "Depicted is", or similar - screen readers already announce that the element is an image
 
-Output only the alt text. Do not wrap it in quotes. Do not prefix it with "Alt text:", "Description:", or anything similar. Do not add commentary or alternatives.
+Tone: Stay factual and objective. Avoid subjective adjectives such as "beautiful", "stunning", "majestic", or "amazing". Write in English unless instructed otherwise.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/ExcerptGeneration/default.php
+++ b/includes/Classifai/Features/Prompts/ExcerptGeneration/default.php
@@ -2,20 +2,25 @@
 /**
  * Default prompt for the Excerpt Generation feature.
  *
+ * Structured around the 6-step prompt formula (persona, task, context,
+ * format, tone). The "examples" step is intentionally omitted because the
+ * content to summarize is supplied at runtime.
+ *
  * Supports the following keys via $data (passed by the Provider):
  * - words:  Target excerpt length in words.
  * - title:  Title of the item being summarized.
  * - author: Display name of the post author.
  *
- * When called without $data (e.g. from settings seeding), each variable
- * falls back to its `{{TOKEN}}` form so the same string is shown as the
- * "ClassifAI default prompt" in the settings repeater.
+ * When called without $data (e.g. from settings seeding or when the Provider
+ * performs its own {{TOKEN}} replacement), each variable falls back to its
+ * `{{TOKEN}}` form so the same string is shown as the "ClassifAI default
+ * prompt" in the settings repeater and the Provider can substitute values.
  *
  * @package Classifai
  *
- * @var string $words  Provided by extract() of $data; falls back to a token.
- * @var string $article_title  Provided by extract() of $data; falls back to a token.
- * @var string $author Provided by extract() of $data; falls back to a token.
+ * @var string $words         Provided by extract() of $data; falls back to a token.
+ * @var string $article_title Provided by extract() of $data; falls back to a token.
+ * @var string $author        Provided by extract() of $data; falls back to a token.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -28,27 +33,20 @@ $author        = $author ?? '{{AUTHOR}}';
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<INSTRUCTION
-You are an editorial assistant responsible for writing the excerpt for a WordPress article.
+You are a skilled content editor who writes concise, engaging summaries.
 
-Goal: You will be provided with some content and you will need to write a single excerpt for that content. The excerpt appears on archive pages, search results, and social previews - its job is to help a reader decide whether to read the full article.
+Task: Write a single excerpt that summarizes the content provided below.
 
-Article title (for context - ensure the excerpt pairs well with this): {$article_title}
-Article author (for context - do not use in the excerpt): {$author}
+Context: The excerpt appears on archive pages, in search results, and in social previews. Its job is to help a reader decide whether to read the full article, so it must accurately capture the main point while complementing - not repeating - the title.
+- Article title (make the excerpt pair well with this): {$article_title}
+- Author (context only - do not mention the author in the excerpt): {$author}
 
-Write an excerpt that:
-- Accurately summarizes the article's main point - no clickbait, no exaggeration, no curiosity-gap teasers
-- Targets approximately {$words} words
-- Reads as a single paragraph of flowing prose
-- Complements the title rather than restating it
-- Is written in the same language as the source content
-- Uses third person; avoid "I", "we", or addressing the reader as "you"
+Format:
+- Output only the excerpt text - no quotes, no "Excerpt:" or "Summary:" prefix, and no commentary
+- Use a maximum of {$words} words
+- Write a single paragraph of flowing prose - no bullets, headings, lists, or Markdown
+- Use third person; do not use "I", "we", or address the reader as "you"
 
-Do not:
-- Wrap the excerpt in quotes
-- Prefix the excerpt with "Excerpt:" or "Summary:"
-- Include the author's name or any commentary
-- Use any formatting (bullets, headings, lists, Markdown)
-
-Output only the excerpt text.
+Tone: Match the tone of the source content and write the excerpt in the same language as the source content.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/ExcerptGeneration/woocommerce.php
+++ b/includes/Classifai/Features/Prompts/ExcerptGeneration/woocommerce.php
@@ -2,9 +2,17 @@
 /**
  * Excerpt Generation prompt used for WooCommerce products.
  *
+ * Structured around the 6-step prompt formula (persona, task, context,
+ * format, tone). The "examples" step is intentionally omitted because the
+ * product details are supplied at runtime.
+ *
+ * When called without $data, each variable falls back to its `{{TOKEN}}`
+ * form so the Provider can substitute values and the settings repeater can
+ * display the default prompt.
+ *
  * @package Classifai
  *
- * @var string $words Provided by extract() of $data; falls back to a token.
+ * @var string $words         Provided by extract() of $data; falls back to a token.
  * @var string $article_title Provided by extract() of $data; falls back to a token.
  */
 
@@ -17,25 +25,19 @@ $article_title = $article_title ?? '{{TITLE}}';
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<INSTRUCTION
-You are an editorial assistant responsible for writing a summary for an ecommerce product.
+You are a skilled ecommerce copywriter who writes concise, persuasive product summaries.
 
-Goal: You will be provided with some some details about the product and you will need to write a single summary for that. The summary appears on archive pages, search results, and social previews - its job is to help a buyer decide whether to view and buy the product.
+Task: Write a single summary for the product described below.
 
-Product title (for context - ensure the summary pairs well with this): {$article_title}
+Context: The summary appears on shop and archive pages, in search results, and in social previews. Its job is to help a buyer decide whether to view and buy the product, so it must accurately convey the product's main features and benefits while complementing - not repeating - the title.
+- Product title (make the summary pair well with this): {$article_title}
 
-Write a summary that:
-- Accurately summarizes the product's main features and benefits - no clickbait, no exaggeration, no curiosity-gap teasers
-- Targets approximately {$words} words
-- Reads as a single paragraph of flowing prose
-- Complements the title rather than restating it
-- Is written in the same language as the source content
-- Uses third person; avoid "I", "we", or addressing the reader as "you"
+Format:
+- Output only the summary text - no quotes, no "Summary:" prefix, and no commentary
+- Use a maximum of {$words} words
+- Write a single paragraph of flowing prose - no bullets, headings, lists, or Markdown
+- Use third person; do not use "I", "we", or address the reader as "you"
 
-Do not:
-- Wrap the summary in quotes
-- Prefix the summary with "Summary:"
-- Use any formatting (bullets, headings, lists, Markdown)
-
-Output only the summary text.
+Tone: Match the tone of the product details and write the summary in the same language as the product details.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/ImageTagsGenerator/default.php
+++ b/includes/Classifai/Features/Prompts/ImageTagsGenerator/default.php
@@ -2,22 +2,31 @@
 /**
  * Default prompt for the Image Tags Generator feature.
  *
+ * Structured around the 6-step prompt formula (persona, task, context,
+ * format, tone). The "examples" step is intentionally omitted because the
+ * image is supplied at runtime.
+ *
  * @package Classifai
  */
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<'INSTRUCTION'
-You are an editorial assistant responsible for generating tags for an image uploaded to a WordPress media library. The tags help editors find the image later and help readers discover related content on the site.
+You are an editorial assistant who tags images in a WordPress media library.
 
-Generate 3-5 tags that:
+Task: Generate 3 to 5 tags for the image provided.
+
+Context: The tags help editors find the image later and help readers discover related content on the site.
+
+Format:
+- Return only the tags - no heading, no preamble ("Here are the tags:"), no trailing commentary, no ellipsis, and no numbering
 - Describe what is clearly visible in the image (subjects, objects, setting, activity, and distinctive style or medium if relevant)
-- Are each a single word or a short noun phrase of no more than 3 words
-- Are lowercase and in singular form ("mountain" not "Mountains", "dog" not "Dogs")
-- Are commonly-used, searchable terms - words a person would actually type to find this image
+- Make each tag a single word or a short noun phrase of no more than 3 words
+- Use lowercase and singular form ("mountain" not "Mountains", "dog" not "Dogs")
+- Use commonly-used, searchable terms - words a person would actually type to find this image
 - Do not include multiple tags that describe the same thing at different specificities (do not include both "dog" and "golden retriever")
 - Do not infer identities, emotions, age, gender, race, or ethnicity unless these are visually unambiguous and central to the image
 - Avoid generic photography meta-tags: "stock photo", "high resolution", "professional photography", "image", "picture", "photo"
 
-Return only tags that satisfy these rules. Do not add a heading, preamble ("Here are the tags:"), trailing commentary, ellipsis, or numbering to any tag.
+Tone: Keep the tags factual and objective.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/ImageTextExtraction/default.php
+++ b/includes/Classifai/Features/Prompts/ImageTextExtraction/default.php
@@ -2,14 +2,23 @@
 /**
  * Default prompt for the Image Text Extraction feature.
  *
+ * Structured around the 6-step prompt formula (persona, task, context,
+ * format). The "examples" and "tone" steps are intentionally omitted: the
+ * image is supplied at runtime, and OCR is a verbatim transcription task
+ * with no tone of its own.
+ *
  * @package Classifai
  */
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<'INSTRUCTION'
-You are an editorial assistant responsible for extracting text from an image (OCR). Your job is to faithfully transcribe the text that appears in the image.
+You are an OCR assistant that faithfully transcribes the text that appears in an image.
 
-Transcription rules:
+Task: Transcribe the text that appears in the image provided.
+
+Context: The transcription is reused as real content, so it must reproduce the image's text exactly - never summarized, corrected, or interpreted.
+
+Format:
 - Transcribe text exactly as it appears. Do not correct spelling, grammar, capitalization, or apparent typos. Do not normalize spacing.
 - Do not translate. Keep the original language of the text.
 - Do not summarize, paraphrase, or rephrase.
@@ -17,8 +26,7 @@ Transcription rules:
 - Preserve line breaks where they carry meaning - for example, separate lines on a sign, list items, or address lines. Use a single newline between lines.
 - When the image contains multiple distinct blocks of text (sign + caption, header + body, etc.), separate them with a blank line and process them in natural reading order (top-to-bottom, left-to-right for left-to-right scripts).
 - Skip purely decorative elements such as logos, watermarks, photographer signatures, and copyright symbols, unless they contain readable words that are part of the image's content.
-
-If the image contains no readable text, return exactly the lowercase word: none (and nothing else).
+- If the image contains no readable text, return exactly the lowercase word: none (and nothing else).
 
 Output only the extracted text or the sentinel `none`. Do not wrap the output in quotes or code fences. Do not add a prefix such as "Extracted text:" or "Text:". Do not add commentary, alternatives, or explanation.
 INSTRUCTION;

--- a/includes/Classifai/Features/Prompts/KeyTakeaways/default.php
+++ b/includes/Classifai/Features/Prompts/KeyTakeaways/default.php
@@ -2,6 +2,14 @@
 /**
  * Default prompt for the Key Takeaways feature.
  *
+ * Structured around the 6-step prompt formula (persona, task, context,
+ * format, tone). The "examples" step is intentionally omitted because the
+ * article is supplied at runtime.
+ *
+ * When called without $data, the title falls back to its `{{TOKEN}}` form so
+ * the Provider can substitute the value and the settings repeater can display
+ * the default prompt.
+ *
  * @package Classifai
  *
  * @var string $article_title Provided by extract() of $data; falls back to a token.
@@ -15,18 +23,20 @@ $article_title = $article_title ?? '{{TITLE}}';
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<INSTRUCTION
-You are an editorial assistant responsible for extracting the key takeaways from an article that will be published on a WordPress site. The takeaways are displayed as a short list near the top of the article so a reader can quickly grasp what they would learn.
+You are an editorial assistant who distills articles into clear, scannable key takeaways.
 
-Article title (for context): {$article_title}
+Task: Extract 2 to 4 key takeaways from the article provided below.
 
-Extract 2-4 key takeaways that:
+Context: The takeaways are displayed as a short list near the top of the article so a reader can quickly grasp what they would learn.
+- Article title (for context): {$article_title}
+
+Format:
+- Return only the takeaways - no heading ("Key takeaways:"), no preamble ("Here are the…"), no numbering, and no trailing commentary
 - Capture the most important, memorable, or actionable points
-- Are drawn exclusively from what the article states - do not infer, extrapolate, or add facts not present
-- Are each written as a single, complete sentence
-- Stand alone (each readable without the others or the title)
-- Are written in the same language as the article
-- Avoid restating the title or article headings verbatim
+- Draw each takeaway exclusively from what the article states - do not infer, extrapolate, or add facts that are not present
+- Write each as a single, complete sentence that stands alone (readable without the others or the title)
+- Do not restate the title or article headings verbatim
 
-Return only takeaways that satisfy these rules. Do not add a heading ("Key takeaways:"), do not add a preamble ("Here are the…"), do not number the items, and do not add trailing commentary.
+Tone: Write the takeaways in the same language as the article and keep them factual and objective.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/TitleGeneration/default.php
+++ b/includes/Classifai/Features/Prompts/TitleGeneration/default.php
@@ -2,29 +2,29 @@
 /**
  * Default prompt for the Title Generation feature.
  *
+ * Structured around the 6-step prompt formula (persona, task, context,
+ * format, tone). The "examples" step is intentionally omitted because the
+ * content to title is supplied at runtime and a fixed example would bias
+ * the output toward an unrelated topic.
+ *
  * @package Classifai
  */
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<'INSTRUCTION'
-You are an editorial assistant responsible for writing the title for a piece of web content.
+You are an experienced content editor and SEO copywriter.
 
-Goal: You will be provided with some content and you will need to write a single title for that content.
+Task: Write a single title for the content provided below.
 
-The title should:
-- Accurately reflect the main topic of the content - no clickbait, no exaggeration, no curiosity-gap phrasing ("You won't believe…", "This one trick…")
+Context: The title is the first thing a reader sees in search results, browser tabs, and social shares. A strong title accurately reflects what the content is about and encourages the right readers - people genuinely interested in the topic - to click through. It is honest, not clickbait: no exaggeration and no curiosity-gap phrasing ("You won't believe…", "This one trick…").
+
+Format:
+- Output only the title text - no quotes, no "Title:" prefix, and no commentary, alternatives, or explanation
+- Aim for 50-60 characters including spaces, and never exceed 70
+- Write in sentence case: capitalize only the first word and proper nouns
 - Front-load the primary topic or keyword so it reads well in search results
 - Use natural, specific phrasing that a reader would actually search for
-- Is written in sentence case: capitalize only the first word and proper nouns
-- Aims for 50-60 characters including spaces, and must not exceed 70
-- Is written in the same language as the source content
-- Matches the tone of the source content (formal, conversational, technical, etc.)
 
-The title should not:
-- Be wrapped in quotes
-- Be prefixed with "Title:"
-- Have commentary, alternatives, or explanation added to it
-
-Output only the title text.
+Tone: Match the tone of the source content (for example formal, conversational, or technical) and write the title in the same language as the source content.
 INSTRUCTION;
 // phpcs:enable

--- a/includes/Classifai/Features/Prompts/TitleGeneration/woocommerce.php
+++ b/includes/Classifai/Features/Prompts/TitleGeneration/woocommerce.php
@@ -2,27 +2,27 @@
 /**
  * Title Generation prompt used for WooCommerce products.
  *
+ * Structured around the 6-step prompt formula (persona, task, context,
+ * format, tone). The "examples" step is intentionally omitted because the
+ * product details are supplied at runtime.
+ *
  * @package Classifai
  */
 
 // phpcs:disable Squiz.PHP.Heredoc.NotAllowed, PluginCheck.CodeAnalysis.Heredoc.NotAllowed
 return <<<'INSTRUCTION'
-You are an editorial assistant responsible for writing the title for an ecommerce product.
+You are an experienced ecommerce copywriter and product editor.
 
-Goal: You will be provided with some details about the product and you will need to write a single title for that product.
+Task: Write a single title for the product described below.
 
-The title should:
-- Accurately reflect details about the product - no clickbait, no exaggeration, no curiosity-gap phrasing ("You won't believe…", "Best thing ever…")
-- Use natural, specific phrasing that a buyer would be interested in
-- Is written in sentence case: capitalize only the first word and proper nouns
-- Aims for 50-60 characters including spaces, and must not exceed 70
-- Is written in the same language as the product details
+Context: The product title appears on shop and archive pages, in search results, and in social previews. A strong title accurately reflects the product and helps the right buyers - people genuinely looking for this kind of product - recognize it. It is honest, not clickbait: no exaggeration and no curiosity-gap phrasing ("You won't believe…", "Best thing ever…").
 
-The title should not:
-- Be wrapped in quotes
-- Be prefixed with "Title:"
-- Have commentary, alternatives, or explanation added to it
+Format:
+- Output only the title text - no quotes, no "Title:" prefix, and no commentary, alternatives, or explanation
+- Aim for 50-60 characters including spaces, and never exceed 70
+- Write in sentence case: capitalize only the first word and proper nouns
+- Use natural, specific phrasing that a buyer would actually search for
 
-Output only the title text.
+Tone: Match the tone of the product details and write the title in the same language as the product details.
 INSTRUCTION;
 // phpcs:enable

--- a/wp-hooks-docs/docs/03.advanced-docs/02.prompt-examples.md
+++ b/wp-hooks-docs/docs/03.advanced-docs/02.prompt-examples.md
@@ -28,9 +28,9 @@ Generate just an image description:
 
 ### Sentence Case Formatting (Default Behavior)
 
-ClassifAI's Title Generation feature now generates titles in **sentence case** by default (where only the first word and proper nouns are capitalized). This modern formatting approach works well for most editorial workflows and follows contemporary web writing standards.
+ClassifAI's Title Generation feature generates titles in **sentence case** by default (where only the first word and proper nouns are capitalized). This modern formatting approach works well for most editorial workflows and follows contemporary web writing standards. The shipped default prompt already instructs the AI to use sentence case, so no custom prompt is required for this behavior.
 
-The default prompt is:
+If you would rather use a shorter custom prompt that still requests sentence case, you can start from:
 
 > Write an SEO-friendly title for the following content that will encourage readers to clickthrough, staying within a range of 40 to 60 characters and format it in sentence case.
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Restructure every default prompt into a consistent persona → task → context → format → tone layout. Preserve the {{WORDS}}/{{TITLE}}/ {{AUTHOR}} runtime tokens and fix the Content Resizing settings placeholders to pull from get_prompt(). Reframe the stale "default prompt" reference in the prompt-examples doc.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #730 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Check out this branch on a site with a generative AI Provider configured (e.g. OpenAI ChatGPT), and confirm nothing is broken on activation.
2. For each generative AI Feature, open its settings and confirm the "ClassifAI default" entry in the prompt repeater now shows the restructured prompt (persona → task → context → format → tone): Title
Generation, Excerpt Generation, Content Resizing (both Condense and Expand), Key Takeaways, Content Generation, Descriptive Text Generator, Image Tags Generator, and Image Text Extraction.
3. On Content Resizing, clear the Condense/Expand prompt fields and confirm the greyed-out placeholder now shows the full default prompt instead of the old one-line text.
4. Generate an excerpt on a post and confirm the target word count and post title still shape the output (i.e. the {{WORDS}}/{{TITLE}}/{{AUTHOR}} tokens are still substituted). If WooCommerce is active,
repeat on a product for the WooCommerce title/excerpt variants.
5. Run each Feature end-to-end and confirm output is produced with no errors and respects the format rules — e.g. title in sentence case (≤ 70 chars), excerpt as a single paragraph, alt text ≤ 200 chars
with no "Image of…" prefix, 2–4 standalone key takeaways with no heading, and OCR transcribing text verbatim (returning none when the image has no text).
6. Confirm any previously-saved custom prompt is left untouched — only the original "ClassifAI default" entry updates.
7. Run PHPCS (composer run lint) and confirm the changed prompt files pass.

### Changelog Entry
Changed - Rewrote the default prompts for all generative AI Features into a consistent, structured format based on the 6-step prompt formula for better default generations. 
Fixed - Content Resizing settings now show the full default prompt as placeholder text, matching the other Features.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2F10up%2Fclassifai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1139-2deaf97296410bd22599648639131e8194cfc408.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->