### PR TITLE
Update to Nano Banana 2 as our default image generation model when using Google

### DIFF
--- a/includes/Classifai/Providers/GoogleAI/Images.php
+++ b/includes/Classifai/Providers/GoogleAI/Images.php
@@ -301,7 +301,7 @@ class Images extends Provider {
 		$body = apply_filters(
 			'classifai_googleai_images_request_body',
 			array(
-				'contents'  => array(
+				'contents'         => array(
 					array(
 						'parts' => array(
 							array(

--- a/includes/Classifai/Providers/GoogleAI/Images.php
+++ b/includes/Classifai/Providers/GoogleAI/Images.php
@@ -36,7 +36,7 @@ class Images extends Provider {
 	 *
 	 * @var string
 	 */
-	protected $model = 'imagen-4.0-generate-preview-06-06';
+	protected $model = 'gemini-3.1-flash-image';
 
 	/**
 	 * Maximum number of characters a prompt can have.
@@ -100,7 +100,7 @@ class Images extends Provider {
 		 * Filter the model name.
 		 *
 		 * Useful if you want to use a different model, like
-		 * imagen-4.0-ultra.
+		 * gemini-3-pro-image.
 		 *
 		 * @since 3.5.0
 		 * @hook classifai_googleai_images_model
@@ -286,6 +286,8 @@ class Images extends Provider {
 
 		$request = new APIRequest( '', $this->feature_instance::ID, $this );
 
+		$num = absint( $args['num'] );
+
 		/**
 		 * Filter the request body before sending to Google AI.
 		 *
@@ -299,37 +301,69 @@ class Images extends Provider {
 		$body = apply_filters(
 			'classifai_googleai_images_request_body',
 			array(
-				'instances'  => array(
+				'contents'  => array(
 					array(
-						'prompt' => sanitize_text_field( $prompt ),
+						'parts' => array(
+							array(
+								'text' => sanitize_text_field( $prompt ),
+							),
+						),
 					),
 				),
-				'parameters' => array(
-					'sampleCount' => absint( $args['num'] ),
-					'aspectRatio' => sanitize_text_field( $args['aspect_ratio'] ),
+				'generationConfig' => array(
+					'responseModalities' => array( 'TEXT', 'IMAGE' ),
+					'imageConfig'        => array(
+						'aspectRatio' => sanitize_text_field( $args['aspect_ratio'] ),
+					),
 				),
-			),
-		);
-
-		// Make our API request.
-		$response = $request->post(
-			trailingslashit( $this->get_api_url() ) . 'models/' . $this->get_model() . ':predict',
-			array(
-				'body' => wp_json_encode( $body ),
 			)
 		);
 
+		$endpoint  = trailingslashit( $this->get_api_url() ) . 'models/' . $this->get_model() . ':generateContent';
+		$responses = array();
+
+		// Gemini image models do not support multiple candidates per request.
+		for ( $i = 0; $i < $num; $i++ ) {
+			$responses[] = $request->post(
+				$endpoint,
+				array(
+					'body' => wp_json_encode( $body ),
+				)
+			);
+		}
+
 		$cleaned_responses = array();
 
-		// Extract out the image responses, if they exist.
-		if ( ! is_wp_error( $response ) && ! empty( $response['predictions'] ) ) {
-			foreach ( $response['predictions'] as $candidate ) {
-				if ( isset( $candidate['bytesBase64Encoded'] ) ) {
-					$cleaned_responses[] = array( 'url' => sanitize_text_field( trim( $candidate['bytesBase64Encoded'] ) ) );
+		foreach ( $responses as $response ) {
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
+
+			// Extract image responses from generateContent candidates.
+			if ( ! empty( $response['candidates'] ) ) {
+				foreach ( $response['candidates'] as $candidate ) {
+					if ( empty( $candidate['content']['parts'] ) ) {
+						continue;
+					}
+
+					foreach ( $candidate['content']['parts'] as $part ) {
+						if ( ! empty( $part['inlineData']['data'] ) ) {
+							$cleaned_responses[] = array(
+								'url' => trim( $part['inlineData']['data'] ),
+							);
+						}
+					}
+				}
+			} elseif ( ! empty( $response['predictions'] ) ) {
+				// Legacy Imagen predict response format.
+				foreach ( $response['predictions'] as $candidate ) {
+					if ( ! empty( $candidate['bytesBase64Encoded'] ) ) {
+						$cleaned_responses[] = array(
+							'url' => trim( $candidate['bytesBase64Encoded'] ),
+						);
+					}
 				}
 			}
-		} elseif ( is_wp_error( $response ) ) {
-			return $response;
 		}
 
 		return $cleaned_responses;

--- a/tests/test-plugin/e2e-test-plugin.php
+++ b/tests/test-plugin/e2e-test-plugin.php
@@ -119,6 +119,11 @@ function classifai_test_mock_http_requests( $preempt, $parsed_args, $url ) {
 			'success'     => 1,
 			'body'        => '',
 		);
+	} elseif (
+		strpos( $url, 'https://generativelanguage.googleapis.com/v1beta/models/' ) !== false &&
+		strpos( $url, '-image:generateContent' ) !== false
+	) {
+		$response = file_get_contents( __DIR__ . '/gemini-image.json' );
 	} elseif ( strpos( $url, 'https://generativelanguage.googleapis.com/v1beta/models/imagen-4.0-generate-preview-06-06:predict' ) !== false ) {
 		$response = file_get_contents( __DIR__ . '/imagen.json' );
 	} elseif ( strpos( $url, 'https://generativelanguage.googleapis.com/v1beta' ) !== false ) {

--- a/tests/test-plugin/gemini-image.json
+++ b/tests/test-plugin/gemini-image.json
@@ -1,0 +1,19 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "inlineData": {
+              "mimeType": "image/png",
+              "data": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+            }
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Description of the Change

We currently use Imagen 4 as our default image generation model when Google is set as the provider. These models are being deprecated in August so this PR updates our default to use Nano Banana 2.

This update required a few other changes, notably:

- Update the API URL we use to match what this model requires
- Ensure the payload we send matches the format this API requires which is slightly different than before
- Multiple images aren't allowed to be generated at once so when a user requests multiple, make an individual request for each one

**NOTE**: The request body is passed through the `classifai_googleai_images_request_body` filter. That request body is changing as part of this PR so anyone that is using that filter to modify the request body will likely need to update their code to avoid issues. I would be surprised if anyone is using that filter but could argue is is breaking backwards compat, though not something I'm concerned with

Closes #1141

### How to test the Change

1. Checkout this PR
2. Turn on the Image Generation Feature
3. Select Google AI Imagen as the Provider and configure that properly
4. Go to `Media > Generate Images` and enter a prompt
5. Ensure an image is generated properly
6. Modify various Image Generation settings like Number of images and Aspect ratio and ensure those work when an image is generated

### Changelog Entry

> Changed - Use Nano Banana 2 as our default image generation model when using Google. Note: this changes the request body that is passed through the `classifai_googleai_images_request_body` filter. If using this filter, ensure you update your code accordingly. 

### Credits

Props @jeffpaul, @dkotter 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2F10up%2Fclassifai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1143-d146500333f4571691f4cb2ef766e929d3348747.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->