### PR TITLE
Add allowed post statuses setting for Text to Speech feature

### DIFF
--- a/includes/Classifai/Features/TextToSpeech.php
+++ b/includes/Classifai/Features/TextToSpeech.php
@@ -940,20 +940,6 @@ class TextToSpeech extends Feature {
 				'description'    => __( 'Choose which post types support this feature.', 'classifai' ),
 			)
 		);
-
-		add_settings_field(
-			'post_statuses',
-			esc_html__( 'Allowed post statuses', 'classifai' ),
-			array( $this, 'render_checkbox_group' ),
-			$this->get_option_name(),
-			$this->get_option_name() . '_section',
-			array(
-				'label_for'      => 'post_statuses',
-				'options'        => \Classifai\get_post_statuses_for_language_settings(),
-				'default_values' => $settings['post_statuses'],
-				'description'    => __( 'Choose which post statuses are allowed to generate audio, e.g. disable this for Draft to avoid generating audio for content that is still being edited.', 'classifai' ),
-			)
-		);
 	}
 
 	/**

--- a/includes/Classifai/Features/TextToSpeech.php
+++ b/includes/Classifai/Features/TextToSpeech.php
@@ -255,7 +255,10 @@ class TextToSpeech extends Feature {
 	public function rest_handle_audio( \WP_Post $post, WP_REST_Request $request ) {
 		$post_id = (int) $request->get_param( 'id' );
 
-		if ( ! $this->is_feature_enabled() ) {
+		if (
+			! in_array( $post->post_status, $this->get_supported_post_statuses(), true ) ||
+			! $this->is_feature_enabled()
+		) {
 			return;
 		}
 
@@ -614,6 +617,7 @@ class TextToSpeech extends Feature {
 	public function save_post_metadata( int $post_id ) {
 		if (
 			! in_array( get_post_type( $post_id ), $this->get_supported_post_types(), true ) ||
+			! in_array( get_post_status( $post_id ), $this->get_supported_post_statuses(), true ) ||
 			! $this->is_feature_enabled()
 		) {
 			return;
@@ -936,6 +940,20 @@ class TextToSpeech extends Feature {
 				'description'    => __( 'Choose which post types support this feature.', 'classifai' ),
 			)
 		);
+
+		add_settings_field(
+			'post_statuses',
+			esc_html__( 'Allowed post statuses', 'classifai' ),
+			array( $this, 'render_checkbox_group' ),
+			$this->get_option_name(),
+			$this->get_option_name() . '_section',
+			array(
+				'label_for'      => 'post_statuses',
+				'options'        => \Classifai\get_post_statuses_for_language_settings(),
+				'default_values' => $settings['post_statuses'],
+				'description'    => __( 'Choose which post statuses are allowed to generate audio, e.g. disable this for Draft to avoid generating audio for content that is still being edited.', 'classifai' ),
+			)
+		);
 	}
 
 	/**
@@ -961,10 +979,13 @@ class TextToSpeech extends Feature {
 	 */
 	public function get_feature_default_settings(): array {
 		return array(
-			'post_types' => array(
+			'post_types'    => array(
 				'post' => 'post',
 			),
-			'provider'   => Speech::ID,
+			'post_statuses' => array(
+				'publish' => 'publish',
+			),
+			'provider'      => Speech::ID,
 		);
 	}
 
@@ -982,6 +1003,16 @@ class TextToSpeech extends Feature {
 				$new_settings['post_types'][ $post_type->name ] = '';
 			} else {
 				$new_settings['post_types'][ $post_type->name ] = sanitize_text_field( $new_settings['post_types'][ $post_type->name ] );
+			}
+		}
+
+		$post_statuses = \Classifai\get_post_statuses_for_language_settings();
+
+		foreach ( array_keys( $post_statuses ) as $post_status ) {
+			if ( ! isset( $new_settings['post_statuses'][ $post_status ] ) ) {
+				$new_settings['post_statuses'][ $post_status ] = '';
+			} else {
+				$new_settings['post_statuses'][ $post_status ] = sanitize_text_field( $new_settings['post_statuses'][ $post_status ] );
 			}
 		}
 

--- a/src/js/settings/components/feature-additional-settings/text-to-speech.js
+++ b/src/js/settings/components/feature-additional-settings/text-to-speech.js
@@ -4,6 +4,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { CheckboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -23,36 +24,70 @@ export const TextToSpeechSettings = () => {
 		select( STORE_NAME ).getFeatureSettings()
 	);
 	const { setFeatureSettings } = useDispatch( STORE_NAME );
-	const { postTypes } = window.classifAISettings;
+	const { postTypes, postStatuses } = window.classifAISettings;
 
 	return (
-		<SettingsRow
-			label={ __( 'Allowed post types', 'classifai' ) }
-			description={ __(
-				'Choose which post types support this feature.',
-				'classifai'
-			) }
-			className="settings-allowed-post-types"
-		>
-			{ Object.keys( postTypes || {} ).map( ( key ) => {
-				return (
-					<CheckboxControl
-						id={ key }
-						key={ key }
-						checked={ featureSettings.post_types?.[ key ] === key }
-						label={ postTypes?.[ key ] }
-						onChange={ ( value ) => {
-							setFeatureSettings( {
-								post_types: {
-									...featureSettings.post_types,
-									[ key ]: value ? key : '0',
-								},
-							} );
-						} }
-						__nextHasNoMarginBottom
-					/>
-				);
-			} ) }
-		</SettingsRow>
+		<>
+			<SettingsRow
+				label={ __( 'Allowed post statuses', 'classifai' ) }
+				description={ __(
+					'Choose which post statuses are allowed to generate audio, e.g. disable this for Draft to avoid generating audio for content that is still being edited.',
+					'classifai'
+				) }
+				className="settings-allowed-post-statuses"
+			>
+				{ Object.keys( postStatuses || {} ).map( ( key ) => {
+					return (
+						<CheckboxControl
+							id={ `post_status_${ key }` }
+							key={ key }
+							checked={
+								featureSettings.post_statuses?.[ key ] === key
+							}
+							label={ decodeEntities( postStatuses?.[ key ] ) }
+							onChange={ ( value ) => {
+								setFeatureSettings( {
+									post_statuses: {
+										...featureSettings.post_statuses,
+										[ key ]: value ? key : '0',
+									},
+								} );
+							} }
+							__nextHasNoMarginBottom
+						/>
+					);
+				} ) }
+			</SettingsRow>
+			<SettingsRow
+				label={ __( 'Allowed post types', 'classifai' ) }
+				description={ __(
+					'Choose which post types support this feature.',
+					'classifai'
+				) }
+				className="settings-allowed-post-types"
+			>
+				{ Object.keys( postTypes || {} ).map( ( key ) => {
+					return (
+						<CheckboxControl
+							id={ key }
+							key={ key }
+							checked={
+								featureSettings.post_types?.[ key ] === key
+							}
+							label={ postTypes?.[ key ] }
+							onChange={ ( value ) => {
+								setFeatureSettings( {
+									post_types: {
+										...featureSettings.post_types,
+										[ key ]: value ? key : '0',
+									},
+								} );
+							} }
+							__nextHasNoMarginBottom
+						/>
+					);
+				} ) }
+			</SettingsRow>
+		</>
 	);
 };


### PR DESCRIPTION
## Description

Fixes #1000. As described in the issue, a client's "Sponsored Posts" workflow makes numerous text changes on Drafts, and Public Post Preview was showing the wrong/stale audio because Text to Speech currently generates audio for **any** post status, including Draft and Pending.

@dkotter noted:

> We do have a few Features that have settings in place to allow you to choose the post statuses that the Feature will run under so I could see the case of adding that for the Text to Speech Feature.

This adds exactly that:
- `Feature::get_supported_post_statuses()` already exists as a shared base-class method (reads `$this->get_settings()['post_statuses']`) — `Classification` already uses it, `TextToSpeech` just wasn't populating or checking that setting yet.
- Default is Publish only (matching `Classification`'s own default), so out of the box audio will no longer regenerate on every Draft save — which is the behavior the issue asks for. Anyone who wants the old behavior back can just check "Draft" in the new setting.

@dkotter flagged in review that my first pass added the setting via the legacy PHP settings screen (`add_custom_settings_fields()`), which isn't the default UI since v3.2.0 and is being phased out. Moved the actual settings control to React instead, matching how `Classification`'s own React settings already handle `post_statuses` (`src/js/settings/components/feature-additional-settings/classification.js`) — same `window.classifAISettings.postStatuses` data source, already localized in `Admin/Settings.php`, so no new PHP localization was needed.

## Changes

In `includes/Classifai/Features/TextToSpeech.php`:
- `get_feature_default_settings()` — add `post_statuses` default (`publish` only).
- `sanitize_default_feature_settings()` — sanitize the new setting the same way `post_types` already is.
- `save_post_metadata()` — gate audio generation (classic editor / meta box save path) on `get_supported_post_statuses()`, same pattern as the existing `post_types` check right next to it.
- `rest_handle_audio()` — same gate for the block editor / REST save path, since that's the path Gutenberg actually uses and is likely what the reporter's workflow hits.

In `src/js/settings/components/feature-additional-settings/text-to-speech.js`:
- Added the "Allowed post statuses" checkbox group, mirroring `Classification`'s existing React settings component for the same setting.

## Testing/Review Recommendations

I don't have a full WordPress + PHP environment set up locally, so I wasn't able to run PHPCS/PHPUnit myself for the PHP side — verified that by careful manual review instead (matched the existing `post_types` pattern exactly, confirmed the helper functions are already generic/shared, re-read the diff for syntax correctness).

For the JS side, I do have a working toolchain: ran `wp-scripts lint-js` and `tsc --noEmit` on the changed file, both clean.

Happy to adjust the default (e.g. include Pending too) or extend the meta-box visibility logic if you'd like the box itself hidden for disallowed statuses — I kept this PR to the functional gate to start.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2F10up%2Fclassifai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1160-683e07ba31bf74812c5ef8e4f0ce5244f5cab9c0.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->