### PR TITLE
Ensure our final release ships with a `composer.json` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,7 +21,7 @@
 /composer.lock export-ignore
 /CONTRIBUTING.md export-ignore
 /CREDITS.md export-ignore
-/eslint.config.js export-ignore
+/eslint.config.mjs export-ignore
 /LICENSE.md export-ignore
 /package-lock.json export-ignore
 /package.json export-ignore

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -40,6 +40,17 @@ jobs:
       run: |
         npm run archive
 
+    - name: Add release composer.json
+      run: |
+        DEV_PHP=$(jq -r '.require.php' composer.json)
+        REL_PHP=$(jq -r '.require.php' bin/composer-release.json)
+        if [ "$DEV_PHP" != "$REL_PHP" ]; then
+          echo "::error::PHP constraint drift: composer.json requires '$DEV_PHP' but bin/composer-release.json requires '$REL_PHP'"
+          exit 1
+        fi
+        cp bin/composer-release.json release/composer.json
+        composer validate --no-check-lock release/composer.json
+
     - name: Release to Stable
       uses: s0/git-publish-subdir-action@ac113f6bfe8896e85a373534242c949a7ea74c98 # develop
       env:

--- a/bin/composer-release.json
+++ b/bin/composer-release.json
@@ -1,0 +1,22 @@
+{
+  "name": "10up/classifai",
+  "description": "Enhance your WordPress content with Artificial Intelligence and Machine Learning services.",
+  "type": "wordpress-plugin",
+  "license": "GPL-2.0-or-later",
+  "homepage": "https://classifaiplugin.com/",
+  "authors": [
+    {
+      "name": "10up",
+      "email": "info@10up.com",
+      "homepage": "https://10up.com"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/10up/classifai/issues",
+    "source": "https://github.com/10up/classifai"
+  },
+  "require": {
+    "php": ">=7.4",
+    "composer/installers": "^1.0 || ^2.0"
+  }
+}

--- a/wp-hooks-docs/docs/01.get-started/01.installation.md
+++ b/wp-hooks-docs/docs/01.get-started/01.installation.md
@@ -20,7 +20,7 @@ ClassifAI releases can be installed via Composer.
 
 #### 1. Update composer.json
 
-Instruct Composer to install ClassifAI into the plugins directory by adding or modifying the "extra" section of your project's composer.json file to match the following:
+If your project isn't already set up to install WordPress plugins into the plugins directory, add or modify the "extra" section of your project's composer.json file to match the following:
 
 ```json
 "extra": {
@@ -32,33 +32,28 @@ Instruct Composer to install ClassifAI into the plugins directory by adding or m
 }
 ```
 
-Add this repository to composer.json, specifying a release version, as shown below:
+You will also need to allow the `composer/installers` plugin, if you don't already:
 
 ```json
-"repositories": [
-    {
-        "type": "package",
-        "package": {
-            "name": "10up/classifai",
-            "version": "3.7.0",
-            "type": "wordpress-plugin",
-            "dist": {
-                "url": "https://github.com/10up/classifai/archive/refs/tags/3.7.0.zip",
-                "type": "zip"
-            }
-        }
+"config": {
+    "allow-plugins": {
+        "composer/installers": true
     }
-]
-```
-
-Finally, require the plugin, using the version number you specified in the previous step:
-
-```json
-"require": {
-    "10up/classifai": "3.7.0"
 }
 ```
 
-After you run `composer update`, ClassifAI will be installed in the plugins directory with no build steps needed.
+#### 2. Require the plugin
 
-#### 2. Activate Plugin
+```bash
+composer require 10up/classifai
+```
+
+To install a specific version, pass a constraint, for example:
+
+```bash
+composer require 10up/classifai:^4.0
+```
+
+Release builds bundle all of their dependencies, so ClassifAI is installed into the plugins directory with no build steps needed.
+
+#### 3. Activate Plugin


### PR DESCRIPTION
### Description of the Change

We currently exclude the `composer.json` file from our final release asset. As described in #1181, this causes some issues with sites that are managing their dependencies via composer, as the newest versions of ClassifAI will never show.

Instead of just allowing our `composer.json` file to be in the final release, this PR adds a step during our release process where a smaller, simpler `composer.json` file is added. This allows composer installs to work as expected while avoiding shipping any unneeded things, like dependency includes.

Closes #1181

### How to test the Change

Run the following commands:

```bash
npm install
npm run build
npm run makepot
composer install --no-dev -o
npm run archive
cp bin/composer-release.json release/composer.json
composer validate --no-check-lock release/composer.json
```

You should now have a `release` directory that includes a `composer.json` file. This `release` directory is what we end up releasing as part of our `Release to Stable` GitHub Workflow

### Changelog Entry

> Added - Ensure our final release includes a `composer.json` file

### Credits

Props @tyrann0us, @dkotter 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2F10up%2Fclassifai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1182-3c4918a59a6b3a5cff63d6c9d6b243f67e9cdea7.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->